### PR TITLE
Fix issue #26

### DIFF
--- a/src/lib/DataLoader.svelte
+++ b/src/lib/DataLoader.svelte
@@ -99,10 +99,10 @@
       );
 
       // Setup the comments
-      $comments = $comments.map((c) => ({
-        ...c,
-        username: $users.find((u) => u.id == c.author).username,
-      }));
+      $comments = $comments.flatMap((c) => {
+        const author = $users.find((u) => u.id == c.author);
+        return author ? [{...c, username: author.username}] : [];
+      });
       $comments = $comments
         .map((c) => ({
           ...c,


### PR DESCRIPTION
After locally setting up the project and debugging it, I came to the conclusion that the exception described in the aforementioned issue was caused by a referential integrity constraint violation; namely, that there was at least one comment that referred to an unexisting author.

I didn't find any reason why this issue would only affect Firefox, so I think that the best fix would be to locate such troublesome comments in the database and either edit their author information or delete them. However, to prevent these problems from bringing down the site in the future, let's ignore comments with unknown authors in the frontend, which I think works fine.