### PR TITLE
fix(build): read PUBLIC_SUPABASE_* at runtime ($env/dynamic/public)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,10 +1,10 @@
 import { createServerClient } from '@supabase/ssr';
 import { type Handle, redirect } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
-import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 
 const supabase: Handle = async ({ event, resolve }) => {
-  event.locals.supabase = createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+  event.locals.supabase = createServerClient(env.PUBLIC_SUPABASE_URL!, env.PUBLIC_SUPABASE_ANON_KEY!, {
     cookies: {
       getAll: () => event.cookies.getAll(),
       setAll: (toSet) =>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,12 +1,12 @@
 import { createBrowserClient, createServerClient, isBrowser } from '@supabase/ssr';
-import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 import type { LayoutLoad } from './$types';
 
 export const load: LayoutLoad = async ({ data, depends, fetch }) => {
   depends('supabase:auth');
   const supabase = isBrowser()
-    ? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, { global: { fetch } })
-    : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+    ? createBrowserClient(env.PUBLIC_SUPABASE_URL!, env.PUBLIC_SUPABASE_ANON_KEY!, { global: { fetch } })
+    : createServerClient(env.PUBLIC_SUPABASE_URL!, env.PUBLIC_SUPABASE_ANON_KEY!, {
         global: { fetch },
         cookies: { getAll: () => data.cookies }
       });


### PR DESCRIPTION
## Problem

The plan-3 preview deploy failed:

```
[MISSING_EXPORT] "PUBLIC_SUPABASE_URL" is not exported by "\0virtual:env/static/public"
  src/routes/+layout.ts / src/hooks.server.ts
```

`$env/static/public` **inlines** the vars at build time and hard-fails the build if they're absent. The Supabase public vars are set in Vercel's **Production** scope but not **Preview**, so every preview build (plan-3, and future Plan 4/5 previews) fails. This is the 3rd Vercel-env papercut.

## Fix

Switch both files to **`$env/dynamic/public`**, which reads at runtime instead of inlining at build. The build no longer depends on the vars being present at build time.

- **Verified env-independent:** `npm run build` succeeds with `.env.local` removed (previously a `MISSING_EXPORT` failure).
- **Runtime unchanged when vars are present:** Playwright 7/7, vitest 8/8, `svelte-check` 0 errors, build clean.
- Values are still `PUBLIC_`-prefixed (browser-exposed by design); `createServerClient`/`createBrowserClient` receive them at runtime. `!` asserts non-null since they're required at runtime.

## Action still needed for previews to *function* (not just build)

This makes the build pass everywhere. For **preview** deploys to actually reach Supabase at runtime, `PUBLIC_SUPABASE_URL` + `PUBLIC_SUPABASE_ANON_KEY` must also exist in Vercel's **Preview** environment scope (or set them to **All Environments**). Production already has them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)