### PR TITLE
Plan 5: Comments, Interest, Experts roster & Markdown sanitizer

### DIFF
--- a/docs/superpowers/plans/2026-06-05-phase1-plan5-comments-interest-sanitizer.md
+++ b/docs/superpowers/plans/2026-06-05-phase1-plan5-comments-interest-sanitizer.md
@@ -1,0 +1,806 @@
+# AI Safety Ideas — Phase 1 · Plan 5: Comments, Interest, Experts roster & Markdown sanitizer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Finish the Phase-1 **data model** — `comments` + `interest` (the last spec §6 tables) — add a public **experts roster** (`/experts`), and introduce a **server-side Markdown sanitizer** so user content renders as real, safe HTML instead of the temporary `whitespace-pre-wrap` plain text. This completes the schema so the later ETL can losslessly restore the old 83 comments + 133 interests, and closes the "no `@html` of unsanitized user content" requirement from `CLAUDE.md` properly.
+
+**Architecture:** Builds on Plans 1–4. `comments`/`interest` follow the established posture: plain RLS INSERT pinned to `auth.uid()`, `legacy_id`/`legacy` pinned (service-role-only), and **visibility-gated SELECT** (a comment/interest is readable only when its idea is — mirroring `idea_funding`). Markdown is rendered + sanitized **server-side** in `$lib/server/markdown.ts` (so `marked` + DOMPurify never ship to the client); loaders produce `*_html` fields and components `{@html}` the pre-sanitized output. Comments are flat (top-level) in the v1 UI; the `reply_to` column exists for the ETL + future threading.
+
+**Tech Stack:** Plans 1–4 stack + two new server-only deps: **`marked`** (Markdown→HTML) and **`isomorphic-dompurify`** (sanitize, works under SSR/Node + the jsdom test env).
+
+**Cloud note (controller-handled, NOT a subagent task):** subagents develop + test against the **local** stack only. After the migration is finalized and reviewed, the controller applies it to cloud `gjomchhbsbtauzkpyjwa` via the Supabase MCP and re-runs `get_advisors`. Subagents must NOT touch the cloud, `CLAUDE.md`, `docs/`, `.claude/`, or `src_legacy_v0/`.
+
+---
+
+## Key design decisions
+
+- **Comments/interest read = idea visibility** (mirrors `idea_funding`): `using (exists (select 1 from public.ideas i where i.id = idea_id))` — the `ideas` RLS hides drafts, so comments/interest on a non-public idea aren't leaked, and the same gate keeps them off un-published ideas.
+- **Plain RLS INSERT, pinned:** `author_id`/`profile_id = auth.uid()`, `legacy_id IS NULL AND legacy = '{}'` (service-role-only ETL anchors). No money, no RPC.
+- **Comments: insert + delete, no edit.** `SELECT` (idea-visible) · `INSERT` (own, on a visible idea) · `DELETE` (own **or** admin, for moderation). **No UPDATE policy** — editing is delete-and-repost in v1 (keeps the surface minimal; matches the deny-by-default ethos). `reply_to uuid → comments(id) on delete cascade` is stored for ETL/future threading but the v1 UI posts only top-level comments.
+- **Interest is a toggle:** `unique (idea_id, profile_id)` so one interest per member per idea; `INSERT` (own) / `DELETE` (own). `note_md` optional (the old `how` column maps here). Withdraw is a fail-loud delete (`.select()` + 409), like the Plan-4 pledge withdraw.
+- **`author_id`/`profile_id` are `on delete set null`** (a comment/interest outlives a deleted account; original anchored in `legacy`), mirroring every other table.
+- **Markdown is sanitized server-side.** `$lib/server/markdown.ts#renderMarkdown(md)` = `marked` → `isomorphic-dompurify`; it lives under `$lib/server` so the deps stay out of the client bundle. Loaders compute `*_html` (e.g. `summary_html`, `explanation_html`, `body_html`, `bio_html`) for the `*_md` columns and the components render `{@html ...}` of that **already-sanitized** string — never `{@html}` of raw user input. Beyond DOMPurify's default (strips `<script>`/`on*`/`javascript:`/`data:`), the config **forbids interactive form controls** (`FORBID_TAGS`, anti-phishing) and the **`style` attribute** (`FORBID_ATTR`, anti-clickjacking), and an `afterSanitizeAttributes` hook adds `rel="noopener noreferrer"` to any `target` link. The plain-text hypothesis **`claim`** (a yes/no statement, not `*_md`) is rendered as escaped plain text, **not** through markdown. Comment/interest bodies are length-capped in the action as a cheap pre-limit.
+- **Experts roster `/experts`** is a public list of `experts.status='approved'` (featured first), linking to the existing `/u/[handle]` profile. No separate `/experts/[handle]` (the profile already lives at `/u/[handle]`).
+- **ETL mapping:** old `comments` (`text`→`body_md`, `reply_to` self-ref, `anon_author`/`anon_author_url`/`upvotes`→`legacy`) and `idea_user_interest_relation` (`how`→`note_md`, `contact_if_started`→`legacy`) land via `legacy_id` + `legacy jsonb`, imported by the service-role ETL.
+- **Rate-limiting (spec §9)** for the new comment/interest endpoints remains part of the deferred single app-wide pass; not built here.
+
+---
+
+## File structure (Plan 5)
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/<ts>_comments_interest.sql` | `comments` + `interest` tables + RLS + indexes |
+| `supabase/tests/database/comments_interest_test.sql` | pgTAP RLS tests |
+| `package.json` / `package-lock.json` | add `marked` + `isomorphic-dompurify` |
+| `src/lib/server/markdown.ts` | `renderMarkdown()` — server-only MD→sanitized HTML |
+| `src/lib/markdown.test.ts` | Vitest unit (renders + sanitizes) |
+| `src/lib/types/database.ts` | Regenerated (comments + interest) |
+| `src/lib/components/AnswerCard.svelte`, `Markdown.svelte` | `Markdown.svelte` renders pre-sanitized HTML; AnswerCard uses it |
+| `src/routes/u/[handle]/+page.server.ts` / `+page.svelte` | **Modify**: sanitize `bio_md` → `bio_html` |
+| `src/routes/console/+page.server.ts` / `+page.svelte` | **Modify**: sanitize queue `explanation_md` → `explanation_html` |
+| `src/routes/ideas/[id]/+page.server.ts` / `+page.svelte` | **Modify**: sanitize idea/answers; add comments + interest (load + actions + UI) |
+| `src/routes/experts/+page.server.ts` / `+page.svelte` | New public experts roster |
+| `e2e/social.spec.ts` | E2E |
+
+---
+
+## Task 1: Migration — comments + interest
+
+**Files:** `supabase/migrations/<ts>_comments_interest.sql`
+
+- [ ] **Step 1: Create the migration**
+
+`supabase migration new comments_interest`, contents:
+
+```sql
+-- ============ comments (flat in v1 UI; reply_to stored for ETL + future threading) ============
+create table public.comments (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  author_id  uuid references public.profiles(id) on delete set null,
+  body_md    text not null,
+  reply_to   uuid references public.comments(id) on delete cascade,
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+alter table public.comments enable row level security;
+create index comments_idea_id_idx on public.comments (idea_id);
+create index comments_reply_to_idx on public.comments (reply_to);
+create index comments_author_id_idx on public.comments (author_id);
+
+-- SELECT: readable when its idea is visible (ideas RLS hides drafts) OR the caller is the author
+-- (mirrors idea_funding's "own row always visible" branch, so an author keeps their comment if the idea reverts to draft)
+create policy "comments readable when idea visible or own" on public.comments for select
+  using (
+    (select auth.uid()) = author_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: any member comments as themselves on a visible idea; author + legacy pinned
+create policy "members comment on visible ideas" on public.comments for insert to authenticated
+  with check (
+    (select auth.uid()) = author_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: the author, or an admin (moderation)
+create policy "author or admin deletes comment" on public.comments for delete to authenticated
+  using ((select auth.uid()) = author_id or public.is_admin());
+-- NOTE: no UPDATE policy — editing is delete-and-repost in v1.
+
+-- ============ interest (one per member per idea; a toggle) ============
+create table public.interest (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  profile_id uuid references public.profiles(id) on delete set null,
+  note_md    text,
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (idea_id, profile_id)
+);
+alter table public.interest enable row level security;
+create index interest_idea_id_idx on public.interest (idea_id);
+create index interest_profile_id_idx on public.interest (profile_id);  -- covers the profile_id FK (set-null cascade) + advisor
+
+-- SELECT: readable when the idea is visible OR the caller is the interested member
+create policy "interest readable when idea visible or own" on public.interest for select
+  using (
+    (select auth.uid()) = profile_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: a member expresses their OWN interest on a visible idea; profile + legacy pinned
+create policy "members express interest on visible ideas" on public.interest for insert to authenticated
+  with check (
+    (select auth.uid()) = profile_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: a member withdraws their own interest
+create policy "member withdraws own interest" on public.interest for delete to authenticated
+  using ((select auth.uid()) = profile_id);
+-- NOTE: no UPDATE policy — toggle is insert/delete; note set at insert.
+```
+
+- [ ] **Step 2: Apply locally**
+
+Run: `supabase db reset` (full rebuild — not `migration up`).
+Expected: all migrations (Plans 1–5) apply with no errors.
+
+- [ ] **Step 3: Smoke-check**
+
+Run: `docker exec supabase_db_aisafetyideas psql -U postgres -d postgres -c "select tablename, cmd, roles from pg_policies where schemaname='public' and tablename in ('comments','interest') order by 1,2;"`
+Expected: each table has exactly 3 policies — `SELECT` with `roles={public}` (anon-readable), `INSERT` and `DELETE` with `roles={authenticated}`. (No `UPDATE` policy on either.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations
+git commit -m "feat(db): comments + interest tables + RLS (Plan 5)"
+```
+
+---
+
+## Task 2: pgTAP — comments + interest RLS
+
+**Files:** `supabase/tests/database/comments_interest_test.sql`
+
+- [ ] **Step 1: Write the test**
+
+```sql
+begin;
+select plan(18);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),  -- author/expert
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now()),    -- member
+  ('00000000-0000-0000-0000-000000000000','33333333-3333-3333-3333-333333333333','authenticated','authenticated','carol@example.com','x', now(), now(), now()),  -- admin
+  ('00000000-0000-0000-0000-000000000000','44444444-4444-4444-4444-444444444444','authenticated','authenticated','dave@example.com','x', now(), now(), now());
+
+update public.profiles set is_admin = true where id = '33333333-3333-3333-3333-333333333333';
+insert into public.experts (id, status) values ('11111111-1111-1111-1111-111111111111','approved');
+insert into public.ideas (id, author_id, type, title, status) values
+  ('a0000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','open_ended','Open idea','open'),
+  ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','open_ended','Draft idea','draft');
+
+set local role authenticated;
+
+-- ===== bob comments + expresses interest (insert pinning) =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','Nice idea');
+select ok((select count(*) from public.comments) = 1, '1: member comments on a visible idea');                                              -- 1
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md)
+  values ('a0000000-0000-0000-0000-000000000001','33333333-3333-3333-3333-333333333333','spoof') $$,
+  '42501', null, '2: cannot comment as another author');                                                                                    -- 2
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md)
+  values ('a0000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222','on draft') $$,
+  '42501', null, '3: cannot comment on a draft idea');                                                                                      -- 3
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md, legacy_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','squat',7) $$,
+  '42501', null, '4: cannot set legacy_id on a live comment');                                                                              -- 4
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','squat','{"a":1}'::jsonb) $$,
+  '42501', null, '5: cannot set a non-empty legacy on a live comment');                                                                     -- 5
+insert into public.interest (id, idea_id, profile_id, note_md)
+  values ('d0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','keen');
+select ok((select count(*) from public.interest) = 1, '6: member expresses interest');                                                     -- 6
+select throws_ok($$ insert into public.interest (idea_id, profile_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222') $$,
+  '23505', null, '7: one interest per member per idea (unique)');                                                                           -- 7
+select throws_ok($$ insert into public.interest (idea_id, profile_id)
+  values ('a0000000-0000-0000-0000-000000000001','33333333-3333-3333-3333-333333333333') $$,
+  '42501', null, '8: cannot express interest on behalf of another');                                                                        -- 8
+select throws_ok($$ insert into public.interest (idea_id, profile_id, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','{"a":1}'::jsonb) $$,
+  '42501', null, '9: cannot set a non-empty legacy on a live interest');                                                                    -- 9
+
+-- ===== anon can read comments/interest on a visible idea =====
+set local role anon;
+select ok((select count(*) from public.comments) = 1, '10: comments are publicly readable on a visible idea');                             -- 10
+select ok((select count(*) from public.interest) = 1, '11: interest is publicly readable on a visible idea');                              -- 11
+
+-- ===== draft-idea comment AND interest are not leaked (seed both as owner, bypass RLS) =====
+reset role;
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','draft comment');
+insert into public.interest (id, idea_id, profile_id)
+  values ('d0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111');
+set local role anon;
+select is((select count(*) from public.comments where idea_id='a0000000-0000-0000-0000-000000000002'),
+  0::bigint, '12: comments on a draft idea are not leaked to the public');                                                                  -- 12
+select is((select count(*) from public.interest where idea_id='a0000000-0000-0000-0000-000000000002'),
+  0::bigint, '13: interest on a draft idea is not leaked to the public');                                                                   -- 13
+
+-- ===== delete: non-author can't; admin can (moderation); author can delete own =====
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';  -- dave
+delete from public.comments where id='c0000000-0000-0000-0000-000000000001';
+select is((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000001'),
+  1::bigint, '14: a non-author/non-admin cannot delete a comment');                                                                        -- 14
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","role":"authenticated"}';  -- admin carol
+delete from public.comments where id='c0000000-0000-0000-0000-000000000001';
+select ok((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000001') = 0,
+  '15: an admin can delete a comment (moderation)');                                                                                       -- 15
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';  -- bob
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','my own');
+delete from public.comments where id='c0000000-0000-0000-0000-000000000002';
+select ok((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000002') = 0,
+  '16: an author can delete their own comment');                                                                                           -- 16
+
+-- ===== interest: cannot withdraw another's; can withdraw own =====
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';  -- dave
+delete from public.interest where id='d0000000-0000-0000-0000-000000000001';
+select is((select count(*) from public.interest where id='d0000000-0000-0000-0000-000000000001'),
+  1::bigint, '17: a member cannot withdraw another member''s interest');                                                                   -- 17
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';  -- bob
+delete from public.interest where id='d0000000-0000-0000-0000-000000000001';
+select ok((select count(*) from public.interest where id='d0000000-0000-0000-0000-000000000001') = 0,
+  '18: a member withdraws their own interest');                                                                                            -- 18
+
+select * from finish();
+rollback;
+```
+
+- [ ] **Step 2: Run**
+
+Run: `supabase test db`
+Expected: **18/18** pass (this file) + Plans 1–4 suites all pass. Do NOT weaken RLS to pass. If you change the assertion count, set `plan(N)` to match (`grep -cE 'select (ok|is|throws_ok|lives_ok)\(' comments_interest_test.sql` must equal N).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/tests/database/comments_interest_test.sql
+git commit -m "test(db): pgTAP RLS tests for comments + interest"
+```
+
+---
+
+## Task 3: Markdown sanitizer (deps + server util + types + unit test)
+
+**Files:** `package.json`/`package-lock.json`, `src/lib/server/markdown.ts`, `src/lib/markdown.test.ts`, `src/lib/types/database.ts`, `src/lib/components/Markdown.svelte`
+
+- [ ] **Step 1: Add the deps**
+
+Run: `npm install marked isomorphic-dompurify`
+This pins both into `dependencies` and updates `package-lock.json`. Commit the lockfile with the code (Step 6).
+
+- [ ] **Step 2: `src/lib/server/markdown.ts`** (server-only — keeps `marked`/DOMPurify out of the client bundle)
+
+```ts
+import { marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+
+marked.setOptions({ gfm: true, breaks: true });
+
+// Defense-in-depth: any link that opens a new tab must not reach window.opener (reverse-tabnabbing).
+// Registered once at module load (DOMPurify is a singleton in isomorphic-dompurify).
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target')) {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+/**
+ * Render user-authored Markdown to SANITIZED HTML, server-side.
+ * Lives under $lib/server so the heavy deps never ship to the browser.
+ * DOMPurify's default HTML profile strips <script>, on* handlers, and javascript:/data: URLs; on top of that we
+ * forbid interactive form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing).
+ */
+export function renderMarkdown(md: string | null | undefined): string {
+  if (!md) return '';
+  const html = marked.parse(md, { async: false }) as string;
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ['form', 'input', 'button', 'select', 'option', 'textarea', 'label', 'fieldset', 'style'],
+    FORBID_ATTR: ['style']
+  });
+}
+```
+
+- [ ] **Step 3: `src/lib/markdown.test.ts`** (Vitest)
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './server/markdown';
+
+describe('renderMarkdown', () => {
+  it('renders basic markdown', () => {
+    const html = renderMarkdown('**bold** and [link](https://example.com)');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('href="https://example.com"');
+  });
+  it('strips <script>', () => {
+    const html = renderMarkdown('hi <script>alert(1)</script>');
+    expect(html).not.toContain('<script>');
+  });
+  it('strips event handlers and javascript: urls', () => {
+    const html = renderMarkdown('<a href="javascript:alert(1)" onclick="x()">x</a>');
+    expect(html).not.toContain('onclick');
+    expect(html.toLowerCase()).not.toContain('javascript:');
+  });
+  it('strips onerror on a SURVIVING <img> (the real boundary case)', () => {
+    const html = renderMarkdown('<img src=x onerror=alert(1)>');
+    expect(html).toContain('<img');                 // the element survives DOMPurify's html profile…
+    expect(html.toLowerCase()).not.toContain('onerror'); // …but the handler attribute is stripped
+  });
+  it('strips form controls (phishing) and the style attribute (clickjacking)', () => {
+    const f = renderMarkdown('<form action="https://evil"><input name="x"></form>');
+    expect(f.toLowerCase()).not.toContain('<form');
+    expect(f.toLowerCase()).not.toContain('<input');
+    const s = renderMarkdown('<a href="https://x" style="position:fixed;inset:0">x</a>');
+    expect(s).not.toContain('style=');
+  });
+  it('neutralizes data:text/html links', () => {
+    const html = renderMarkdown('[x](data:text/html,<script>alert(1)</script>)');
+    expect(html.toLowerCase()).not.toContain('data:text/html');
+  });
+  it('empty/nullish → empty string', () => {
+    expect(renderMarkdown('')).toBe('');
+    expect(renderMarkdown(null)).toBe('');
+    expect(renderMarkdown(undefined)).toBe('');
+  });
+});
+```
+
+- [ ] **Step 4: Regenerate types** (the new tables): `supabase gen types typescript --local 2>/dev/null > src/lib/types/database.ts`. Confirm `comments` + `interest` appear under `Tables`.
+
+- [ ] **Step 5: `src/lib/components/Markdown.svelte`** (renders ALREADY-sanitized HTML; the only sanctioned `@html`)
+
+```svelte
+<script lang="ts">
+  // `html` MUST be the output of $lib/server/markdown#renderMarkdown (already sanitized server-side).
+  let { html, class: klass = '' }: { html: string; class?: string } = $props();
+</script>
+{#if html}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags — server-sanitized via renderMarkdown -->
+  <div class="prose-sm {klass}" style="color:var(--body)">{@html html}</div>
+{/if}
+```
+
+- [ ] **Step 6: Verify + commit** `npm run check` (0 errors), `npx vitest run` (renderMarkdown passes), `npm run build` (clean). Then:
+
+```bash
+git add package.json package-lock.json src/lib/server/markdown.ts src/lib/markdown.test.ts src/lib/components/Markdown.svelte src/lib/types/database.ts
+git commit -m "feat: server-side Markdown sanitizer (marked + DOMPurify) + Markdown component"
+```
+
+---
+
+## Task 4: Apply the sanitizer to existing surfaces (profile bio + console queue)
+
+**Files:** `src/routes/u/[handle]/+page.server.ts` / `+page.svelte`, `src/routes/console/+page.server.ts` / `+page.svelte`
+
+> Idea-detail + AnswerCard get the sanitizer in Task 5 (where that surface is rewritten anyway). This task covers the two standalone spots.
+
+- [ ] **Step 1: Profile — sanitize `bio_md`.** In `src/routes/u/[handle]/+page.server.ts`, import the sanitizer and add `bio_html` to the returned profile data.
+
+Add at the top: `import { renderMarkdown } from '$lib/server/markdown';`
+Where the loader returns the profile, add a sibling field, e.g.:
+```ts
+  return { profile, bio_html: renderMarkdown(profile.bio_md), /* ...existing fields... */ };
+```
+(Keep all existing returned fields; only ADD `bio_html`.)
+
+- [ ] **Step 2: Profile svelte** — replace ONLY the read-only bio render `<p class="mt-3" ...>{data.profile.bio_md ?? ''}</p>` with the sanitized component (leave the edit `<textarea name="bio_md">` intact — it must keep the RAW `bio_md` for editing):
+```svelte
+  <Markdown html={data.bio_html} class="mt-3" />
+```
+Add `import Markdown from '$lib/components/Markdown.svelte';` to the `<script>`.
+
+- [ ] **Step 3: Console queue — sanitize `explanation_md`.** In `src/routes/console/+page.server.ts`, import `renderMarkdown` and, when building the `queue`, add `explanation_html: renderMarkdown(q.explanation_md)` to each normalized row (alongside the existing `submitter`/`ideas` normalization).
+
+- [ ] **Step 4: Console svelte** — replace the queue's WHOLE `{#if a.explanation_md}<p class="... whitespace-pre-wrap ...">{a.explanation_md}</p>{/if}` block with `<Markdown html={a.explanation_html} class="mb-2" />` (Markdown self-guards on empty `html`) and import `Markdown from '$lib/components/Markdown.svelte'`.
+
+- [ ] **Step 5: Verify** `npm run check` (0 errors) + `npm run build` (clean).
+
+- [ ] **Step 6: Commit** `git add src/routes/u src/routes/console && git commit -m "feat: render profile bio + review-queue explanations as sanitized markdown"`
+
+---
+
+## Task 5: Idea detail — sanitized content + comments + interest
+
+**Files:** `src/routes/ideas/[id]/+page.server.ts` / `+page.svelte` (modify), `src/lib/components/AnswerCard.svelte` (modify)
+
+- [ ] **Step 1: AnswerCard — render sanitized explanation.** Replace the `{#if answer.explanation_md}<p ... whitespace-pre-wrap ...>{answer.explanation_md}</p>{/if}` block with:
+```svelte
+  {#if answer.explanation_html}<Markdown html={answer.explanation_html} class="mt-2" />{/if}
+```
+Add `import Markdown from './Markdown.svelte';` and change the prop type field `explanation_md: string | null` → `explanation_html?: string | null` (the loader now supplies sanitized HTML).
+
+- [ ] **Step 2: REPLACE `src/routes/ideas/[id]/+page.server.ts`** (extends the Plan-4 loader: sanitizes idea + answers; adds comments + interest; adds `comment`/`delete_comment`/`interest`/`uninterest` actions alongside the existing `pledge`)
+
+```ts
+import { error, fail } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import { renderMarkdown } from '$lib/server/markdown';
+
+export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  const { data: idea } = await supabase
+    .from('ideas')
+    .select('id, title, summary_md, claim, type, status, resolution, estimated_hours, importance, source_url, author_id, currency')
+    .eq('id', params.id)
+    .single();
+  if (!idea) error(404, 'Idea not found');
+
+  const { data: author } = idea.author_id
+    ? await supabase.from('profiles').select('handle, display_name').eq('id', idea.author_id).single()
+    : { data: null };
+
+  const { data: cats } = await supabase
+    .from('idea_categories').select('categories(slug, title)').eq('idea_id', idea.id);
+
+  const { data: rawAnswers } = await supabase
+    .from('answers')
+    .select(
+      'id, title, explanation_md, status, payout_amount_cents, submitter_id,' +
+        ' answer_artifacts(id, kind, url, label),' +
+        ' submitter:profiles!answers_submitter_id_fkey(handle, display_name)'
+    )
+    .eq('idea_id', idea.id)
+    .order('created_at', { ascending: true });
+  const answers = (rawAnswers ?? []).map((a: any) => ({
+    id: a.id, title: a.title, status: a.status, payout_amount_cents: a.payout_amount_cents,
+    answer_artifacts: a.answer_artifacts,
+    explanation_html: renderMarkdown(a.explanation_md),   // field-picked: don't ship raw explanation_md to the client
+    submitter: Array.isArray(a.submitter) ? (a.submitter[0] ?? null) : a.submitter
+  }));
+
+  const { data: pot } = await supabase
+    .from('bounty_pot').select('pot_cents, funder_count').eq('idea_id', idea.id).maybeSingle();
+  const { data: rawFunders } = await supabase
+    .from('idea_funding')
+    .select('amount_cents, currency, funder_id, funder:profiles(handle, display_name)')
+    .eq('idea_id', idea.id).in('status', ['committed', 'escrowed'])
+    .order('created_at', { ascending: false });
+  const funderMap = new Map<string, { key: string; name: string; amount_cents: number; currency: string }>();
+  for (const f of (rawFunders ?? []) as any[]) {
+    const prof = Array.isArray(f.funder) ? (f.funder[0] ?? null) : f.funder;
+    const key = f.funder_id ?? 'anon';
+    const cur = funderMap.get(key) ?? {
+      key, name: prof?.display_name ?? prof?.handle ?? 'Anonymous', amount_cents: 0, currency: f.currency ?? 'USD'
+    };
+    cur.amount_cents += f.amount_cents;
+    funderMap.set(key, cur);
+  }
+  const funders = [...funderMap.values()];
+
+  // comments (flat, oldest first) with sanitized bodies
+  const { data: rawComments } = await supabase
+    .from('comments')
+    .select('id, body_md, author_id, created_at, author:profiles(handle, display_name)')
+    .eq('idea_id', idea.id)
+    .order('created_at', { ascending: true });
+  const comments = (rawComments ?? []).map((c: any) => ({
+    id: c.id,
+    author_id: c.author_id,
+    author: Array.isArray(c.author) ? (c.author[0] ?? null) : c.author,
+    body_html: renderMarkdown(c.body_md)
+  }));
+
+  // interest: total + whether the current user is interested
+  const { count: interestCount } = await supabase
+    .from('interest').select('id', { count: 'exact', head: true }).eq('idea_id', idea.id);
+  let myInterestId: string | null = null;
+  let isAdmin = false;
+  if (user) {
+    const { data: mine } = await supabase
+      .from('interest').select('id').eq('idea_id', idea.id).eq('profile_id', user.id).maybeSingle();
+    myInterestId = mine?.id ?? null;
+    // real admin status (from the DB, never user_metadata) so an admin sees the moderation delete control
+    const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+    isAdmin = me?.is_admin === true;
+  }
+
+  return {
+    idea,
+    summary_html: renderMarkdown(idea.summary_md),
+    author,
+    categories: (cats ?? []).map((c: any) => c.categories),
+    answers,
+    pot: { pot_cents: pot?.pot_cents ?? 0, funder_count: pot?.funder_count ?? 0 },
+    funders,
+    comments,
+    interestCount: interestCount ?? 0,
+    myInterestId,
+    isAdmin,
+    userId: user?.id ?? null,
+    canSubmit: !!user && idea.status === 'open',
+    canFund: !!user && idea.status === 'open',
+    canEngage: !!user
+  };
+};
+
+export const actions: Actions = {
+  pledge: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to fund this idea' });
+    const fd = await request.formData();
+    const dollars = Number(fd.get('amount') ?? '');
+    if (!Number.isFinite(dollars) || dollars <= 0) return fail(400, { message: 'Enter an amount greater than 0' });
+    const { error: e } = await supabase.from('idea_funding').insert({
+      idea_id: params.id, funder_id: user.id, amount_cents: Math.round(dollars * 100), status: 'committed'
+    });
+    if (e) return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  comment: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to comment' });
+    const fd = await request.formData();
+    const body_md = String(fd.get('body_md') ?? '').trim();
+    if (!body_md) return fail(400, { message: 'Write something first' });
+    if (body_md.length > 10000) return fail(400, { message: 'Comment is too long (max 10,000 characters)' });
+    // RLS enforces author = self + visible idea + legacy pinned
+    const { error: e } = await supabase.from('comments').insert({
+      idea_id: params.id, author_id: user.id, body_md
+    });
+    if (e) return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  delete_comment: async ({ request, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const fd = await request.formData();
+    // RLS allows deleting only your own comment (or admin); .select() surfaces a no-op
+    const { data: del, error: e } = await supabase.from('comments')
+      .delete().eq('id', String(fd.get('comment_id'))).select('id');
+    if (e) return fail(400, { message: e.message });
+    if (!del?.length) return fail(403, { message: 'Not allowed to delete that comment' });
+    return { ok: true };
+  },
+
+  interest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to express interest' });
+    const fd = await request.formData();
+    const note_md = String(fd.get('note_md') ?? '').trim().slice(0, 2000) || null;
+    const { error: e } = await supabase.from('interest').insert({
+      idea_id: params.id, profile_id: user.id, note_md
+    });
+    if (e) {
+      // a duplicate (double-click / stale tab) means "already interested" — idempotent, don't leak the constraint name
+      if ((e as { code?: string }).code === '23505') return { ok: true };
+      return fail(400, { message: e.message });
+    }
+    return { ok: true };
+  },
+
+  uninterest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const { data: del, error: e } = await supabase.from('interest')
+      .delete().eq('idea_id', params.id).eq('profile_id', user.id).select('id');
+    if (e) return fail(400, { message: e.message });
+    if (!del?.length) return fail(409, { message: 'You were not marked interested' });
+    return { ok: true };
+  }
+};
+```
+
+- [ ] **Step 3: REPLACE `src/routes/ideas/[id]/+page.svelte`** (sanitized idea body via `Markdown`; comments + interest sections; keeps BountyMeter/pledge/answers)
+
+```svelte
+<script lang="ts">
+  import StatusBadge from '$lib/components/StatusBadge.svelte';
+  import AnswerCard from '$lib/components/AnswerCard.svelte';
+  import BountyMeter from '$lib/components/BountyMeter.svelte';
+  import Money from '$lib/components/Money.svelte';
+  import Markdown from '$lib/components/Markdown.svelte';
+  let { data, form } = $props();
+</script>
+<div class="grid gap-6 lg:grid-cols-[1fr_280px]">
+  <div>
+    <article class="rounded-2xl border p-6" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
+      <div class="mb-2 flex items-center justify-between">
+        <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{data.idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
+        <StatusBadge status={data.idea.status} />
+      </div>
+      <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.idea.title}</h1>
+      {#if data.author}<p class="text-sm" style="color:var(--faint)">by <a href="/u/{data.author.handle}" style="color:var(--green-deep)">{data.author.display_name ?? data.author.handle}</a></p>{/if}
+      {#if data.idea.claim}<p class="mt-3 italic" style="color:var(--body)">{data.idea.claim}</p>{/if}
+      {#if data.summary_html}<Markdown html={data.summary_html} class="mt-3" />{/if}
+      {#if data.categories.length}<div class="mt-4 flex flex-wrap gap-2">{#each data.categories as c}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--line); color:var(--muted)">{c.title}</span>{/each}</div>{/if}
+      {#if data.idea.source_url}<p class="mt-4 text-sm"><a href={data.idea.source_url} target="_blank" rel="noopener" style="color:var(--green-deep)">Source ↗</a></p>{/if}
+    </article>
+
+    <section class="mt-8">
+      <div class="mb-3 flex items-center justify-between">
+        <h2 class="text-xl font-bold" style="color:var(--ink)">Answers</h2>
+        {#if data.canSubmit}<a href="/ideas/{data.idea.id}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>{/if}
+      </div>
+      {#if data.answers.length === 0}<p style="color:var(--muted)">No answers yet.</p>{:else}
+        <div class="flex flex-col gap-3">{#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}</div>
+      {/if}
+    </section>
+
+    <section class="mt-8">
+      <h2 class="mb-3 text-xl font-bold" style="color:var(--ink)">Discussion</h2>
+      {#if data.canEngage}
+        <form method="POST" action="?/comment" class="mb-4 flex flex-col gap-2">
+          <textarea name="body_md" required placeholder="Add a comment (markdown)" rows="3" class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
+          <button class="self-start rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Comment</button>
+        </form>
+      {/if}
+      {#if data.comments.length === 0}<p style="color:var(--muted)">No comments yet.</p>{:else}
+        <ul class="flex flex-col gap-3">
+          {#each data.comments as c (c.id)}
+            <li class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+              <div class="mb-1 flex items-center justify-between">
+                <span class="text-sm" style="color:var(--faint)">{c.author?.display_name ?? c.author?.handle ?? 'Anonymous'}</span>
+                {#if data.userId === c.author_id || data.isAdmin}
+                  <form method="POST" action="?/delete_comment">
+                    <input type="hidden" name="comment_id" value={c.id} />
+                    <button class="text-xs" style="color:var(--neg)">Delete</button>
+                  </form>
+                {/if}
+              </div>
+              <Markdown html={c.body_html} />
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </div>
+
+  <aside class="flex flex-col gap-4">
+    <BountyMeter potCents={data.pot.pot_cents} funderCount={data.pot.funder_count} currency={data.idea.currency ?? 'USD'} />
+
+    {#if data.canFund}
+      <form method="POST" action="?/pledge" class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+        <label class="text-xs uppercase tracking-wide" style="color:var(--faint)">Fund this idea ($)
+          <input name="amount" type="number" min="0.01" step="0.01" placeholder="0.00" required class="mt-1 block w-full rounded-xl border px-3 py-2" style="border-color:var(--line)" />
+        </label>
+        <button class="mt-3 w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Pledge</button>
+        <p class="mt-2 text-xs" style="color:var(--faint)">A pledge is a commitment — no funds move yet.</p>
+      </form>
+    {/if}
+
+    <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+      <div class="flex items-baseline justify-between">
+        <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">Interested</span>
+        <span class="text-sm tabular-nums" style="color:var(--ink)">{data.interestCount}</span>
+      </div>
+      {#if data.canEngage}
+        {#if data.myInterestId}
+          <form method="POST" action="?/uninterest" class="mt-2">
+            <button class="w-full rounded-xl border px-4 py-2 text-sm" style="border-color:var(--green); color:var(--green-deep)">Interested ✓ — withdraw</button>
+          </form>
+        {:else}
+          <form method="POST" action="?/interest" class="mt-2">
+            <button class="w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">I'm interested</button>
+          </form>
+        {/if}
+      {/if}
+    </div>
+
+    {#if data.funders.length}
+      <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+        <p class="mb-2 text-xs uppercase tracking-wide" style="color:var(--faint)">Funders</p>
+        <ul class="flex flex-col gap-1 text-sm">
+          {#each data.funders as f (f.key)}
+            <li class="flex justify-between gap-2">
+              <span style="color:var(--body)">{f.name}</span>
+              <span class="tabular-nums" style="color:var(--ink)"><Money cents={f.amount_cents} currency={f.currency} /></span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    {#if form?.message}<p class="text-sm" style="color:var(--neg)">{form.message}</p>{/if}
+  </aside>
+</div>
+```
+
+- [ ] **Step 4: Verify** `npm run check` (0 errors) + `npm run build` (clean).
+
+- [ ] **Step 5: Commit** `git add src/routes/ideas src/lib/components/AnswerCard.svelte && git commit -m "feat: idea detail — sanitized markdown + comments + interest"`
+
+---
+
+## Task 6: Experts roster — `/experts`
+
+**Files:** `src/routes/experts/+page.server.ts`, `src/routes/experts/+page.svelte`
+
+- [ ] **Step 1: `+page.server.ts`** (public list of approved experts, featured first)
+
+```ts
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals: { supabase } }) => {
+  const { data: rawExperts } = await supabase
+    .from('experts')
+    .select('id, specialty, featured, profiles!experts_id_fkey(handle, display_name)')
+    .eq('status', 'approved')
+    .order('featured', { ascending: false });
+  const experts = (rawExperts ?? []).map((e: any) => ({
+    id: e.id,
+    specialty: e.specialty,
+    featured: e.featured,
+    profile: Array.isArray(e.profiles) ? (e.profiles[0] ?? null) : e.profiles
+  }));
+  return { experts };
+};
+```
+
+- [ ] **Step 2: `+page.svelte`**
+
+```svelte
+<script lang="ts">
+  let { data } = $props();
+</script>
+<h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Experts</h1>
+<p class="mb-6 text-sm" style="color:var(--muted)">Vetted researchers who post bounties on AI Safety Ideas.</p>
+{#if data.experts.length === 0}
+  <p style="color:var(--muted)">No experts yet.</p>
+{:else}
+  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    {#each data.experts as e (e.id)}
+      <a href="/u/{e.profile?.handle}" class="block rounded-2xl border p-5 transition" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="font-bold" style="color:var(--ink)">{e.profile?.display_name ?? e.profile?.handle ?? 'Expert'}</h2>
+          {#if e.featured}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--green); color:var(--green-deep)">Featured</span>{/if}
+        </div>
+        {#if e.specialty}<p class="mt-1 text-sm" style="color:var(--muted)">{e.specialty}</p>{/if}
+      </a>
+    {/each}
+  </div>
+{/if}
+```
+
+- [ ] **Step 3: Verify** `npm run check` (0 errors) + `npm run build` (clean).
+
+- [ ] **Step 4: Commit** `git add src/routes/experts && git commit -m "feat: public experts roster at /experts"`
+
+---
+
+## Task 7: Tests — E2E + full suite
+
+**Files:** `e2e/social.spec.ts`
+
+- [ ] **Step 1: E2E `e2e/social.spec.ts`**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+// Plan 5's new public surface. The authed comment/interest WRITE path is enforced at the RLS layer (proven by
+// pgTAP) and type-checked end-to-end; a full authed browser flow is deferred to the ETL/launch hardening pass.
+test('experts roster renders', async ({ page }) => {
+  await page.goto('/experts');
+  await expect(page.getByRole('heading', { name: 'Experts' })).toBeVisible();
+});
+
+test('experts roster is public (no login redirect)', async ({ page }) => {
+  await page.goto('/experts');
+  await expect(page).toHaveURL(/\/experts$/);
+});
+```
+
+- [ ] **Step 2: Run the full suite**, in order:
+- `npm run check` → 0 errors
+- `npx vitest run` → all pass (existing + `renderMarkdown`)
+- `supabase test db` → all pgTAP pass (Plans 1–4 + the 18 new Plan-5 assertions)
+- `npm run build` → clean
+- `npx playwright test` → all pass (free the port first if needed)
+
+- [ ] **Step 3: Commit** — stage only the new test file explicitly (NOT `git add .`, to avoid sweeping in untracked `.claude/settings.json`): `git add e2e/social.spec.ts && git commit -m "test: experts roster + browse E2E"`
+
+---
+
+## Done-when (Plan 5 acceptance)
+
+- `comments` + `interest` exist with RLS; the **18-assertion** pgTAP suite proves: a member comments/expresses-interest only as themselves on a *visible* idea (`legacy_id` **and** non-empty `legacy` both pinned); comments **and** interest on a *draft* idea are not leaked; one interest per member per idea (unique → 23505); a member deletes only their own comment, an **admin** can moderate (delete) any, and a member withdraws only their own interest.
+- User-authored Markdown (idea summary, answer explanations, comments, profile bios) renders as **sanitized HTML** via the server-only `renderMarkdown` (`marked` + DOMPurify, `FORBID_TAGS` form-controls + `FORBID_ATTR` style + a `rel=noopener` link hook); the unit test proves `<script>`/`on*`/`javascript:`/`data:` AND the surviving-element boundary (`<img onerror>`) AND form/style injection are all neutralized. The only `{@html}` in the app is `Markdown.svelte` rendering that already-sanitized string. (The plain-text hypothesis `claim` is **not** run through markdown.)
+- The idea page has a Discussion section (post a comment + own/**admin**-moderate delete; bodies length-capped) and an Interested toggle + count (idempotent on double-submit).
+- `/experts` lists approved experts (featured first), linking to `/u/[handle]`.
+- `legacy_id` + `legacy jsonb` carried so the old `comments` + `idea_user_interest_relation` ETL is lossless — **this completes the Phase-1 schema; the one-big ETL is unblocked.**
+- All suites green; no secrets; no raw `@html` of unsanitized input; advisors show **no new findings** (`interest.profile_id` is indexed; one policy per command). Per-endpoint rate-limiting (spec §9) stays in the deferred app-wide pass; an inline length cap bounds payloads in the meantime.
+
+**After merge:** controller applies the Plan-5 migration to cloud `gjomchhbsbtauzkpyjwa` via MCP + re-runs advisors. Then the **one-big ETL** (full restore: 265 accounts+emails, 238 ideas, 83 comments, 133 interests, funding/results → the new schema via the `legacy_*` anchors, run as service-role) — to be brainstormed + planned on its own (PII-sensitive: old emails, auth users, password/identity migration). Remaining Phase-1 polish (verify→payout signature animation, app-wide rate-limiting) can follow or fold into the ETL launch.

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// Plan 5's new public surface. The authed comment/interest WRITE path is enforced at the RLS layer (proven by
+// pgTAP) and type-checked end-to-end; a full authed browser flow is deferred to the ETL/launch hardening pass.
+test('experts roster renders', async ({ page }) => {
+  await page.goto('/experts');
+  await expect(page.getByRole('heading', { name: 'Experts' })).toBeVisible();
+});
+
+test('experts roster is public (no login redirect)', async ({ page }) => {
+  await page.goto('/experts');
+  await expect(page).toHaveURL(/\/experts$/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@supabase/ssr": "^0.10.3",
-				"@supabase/supabase-js": "^2.107.0"
+				"@supabase/supabase-js": "^2.107.0",
+				"isomorphic-dompurify": "^3.16.0",
+				"marked": "^18.0.5"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
@@ -35,7 +37,6 @@
 			"version": "5.1.11",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
 			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -52,7 +53,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
 			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -69,7 +69,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
 			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -79,7 +78,6 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
@@ -121,7 +119,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
 			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.0"
@@ -134,7 +131,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
 			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -154,7 +150,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
 			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -178,7 +173,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
 			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -206,7 +200,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -229,7 +222,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
 			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -254,7 +246,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
 			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -308,7 +299,6 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
 			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -1878,7 +1868,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@vercel/nft": {
@@ -2148,7 +2138,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
 			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
@@ -2257,7 +2246,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -2271,7 +2259,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
 			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-mimetype": "^5.0.0",
@@ -2303,7 +2290,6 @@
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
@@ -2350,6 +2336,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dompurify": {
+			"version": "3.4.8",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+			"integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.22.2",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
@@ -2368,7 +2363,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
 			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20.19.0"
@@ -2495,7 +2489,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
 			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.6.0"
@@ -2531,7 +2524,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-reference": {
@@ -2542,6 +2534,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
+			}
+		},
+		"node_modules/isomorphic-dompurify": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.16.0.tgz",
+			"integrity": "sha512-KzTJsMuVPqPwBOD0F6jKXoV/+v8CSx0rxVp+/67KV6Xbw++0zD/avT3bZsgwR0M5QRMiOE+QqQtoZLEJYy1C4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"dompurify": "^3.4.8",
+				"jsdom": "^29.1.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jiti": {
@@ -2565,7 +2570,6 @@
 			"version": "29.1.1",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
 			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.1.11",
@@ -2896,7 +2900,6 @@
 			"version": "11.5.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
 			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -2922,11 +2925,22 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
@@ -3106,7 +3120,6 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
 			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"entities": "^8.0.0"
@@ -3254,7 +3267,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3285,7 +3297,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3352,7 +3363,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"xmlchars": "^2.2.0"
@@ -3407,7 +3417,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3484,7 +3493,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
@@ -3573,7 +3581,6 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
 			"integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tldts-core": "^7.4.2"
@@ -3586,7 +3593,6 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
 			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/totalist": {
@@ -3603,7 +3609,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
 			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^7.0.5"
@@ -3616,7 +3621,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
 			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -3649,7 +3653,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
 			"integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -3854,7 +3857,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
 			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"xml-name-validator": "^5.0.0"
@@ -3867,7 +3869,6 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
 			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20"
@@ -3877,7 +3878,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
 			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -3887,7 +3887,6 @@
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
 			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.11.0",
@@ -3919,7 +3918,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
 			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
@@ -3929,7 +3927,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
 	},
 	"dependencies": {
 		"@supabase/ssr": "^0.10.3",
-		"@supabase/supabase-js": "^2.107.0"
+		"@supabase/supabase-js": "^2.107.0",
+		"isomorphic-dompurify": "^3.16.0",
+		"marked": "^18.0.5"
 	}
 }

--- a/src/lib/components/AnswerCard.svelte
+++ b/src/lib/components/AnswerCard.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import StatusBadge from './StatusBadge.svelte';
   import Money from './Money.svelte';
+  import Markdown from './Markdown.svelte';
   type Artifact = { id: string; kind: string; url: string; label: string | null };
   let { answer }: {
     answer: {
-      id: string; title: string; explanation_md: string | null; status: string;
+      id: string; title: string; explanation_html?: string | null; status: string;
       payout_amount_cents: number | null; answer_artifacts?: Artifact[] | null;
       submitter?: { handle: string; display_name: string | null } | null;
     }
@@ -16,7 +17,7 @@
     <StatusBadge status={answer.status} />
   </div>
   {#if answer.submitter}<p class="text-sm" style="color:var(--faint)">by {answer.submitter.display_name ?? answer.submitter.handle}</p>{/if}
-  {#if answer.explanation_md}<p class="mt-2 whitespace-pre-wrap text-sm" style="color:var(--body)">{answer.explanation_md}</p>{/if}
+  {#if answer.explanation_html}<Markdown html={answer.explanation_html} class="mt-2" />{/if}
   {#if answer.answer_artifacts?.length}
     <ul class="mt-3 flex flex-col gap-1 text-sm">
       {#each answer.answer_artifacts as a (a.id)}

--- a/src/lib/components/Markdown.svelte
+++ b/src/lib/components/Markdown.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  // `html` MUST be the output of $lib/server/markdown#renderMarkdown (already sanitized server-side).
+  let { html, class: klass = '' }: { html: string; class?: string } = $props();
+</script>
+{#if html}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags — server-sanitized via renderMarkdown -->
+  <div class="prose-sm {klass}" style="color:var(--body)">{@html html}</div>
+{/if}

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './server/markdown';
+
+describe('renderMarkdown', () => {
+  it('renders basic markdown', () => {
+    const html = renderMarkdown('**bold** and [link](https://example.com)');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('href="https://example.com"');
+  });
+  it('strips <script>', () => {
+    const html = renderMarkdown('hi <script>alert(1)</script>');
+    expect(html).not.toContain('<script>');
+  });
+  it('strips event handlers and javascript: urls', () => {
+    const html = renderMarkdown('<a href="javascript:alert(1)" onclick="x()">x</a>');
+    expect(html).not.toContain('onclick');
+    expect(html.toLowerCase()).not.toContain('javascript:');
+  });
+  it('strips onerror on a SURVIVING <img> (the real boundary case)', () => {
+    const html = renderMarkdown('<img src=x onerror=alert(1)>');
+    expect(html).toContain('<img');                 // the element survives DOMPurify's html profile…
+    expect(html.toLowerCase()).not.toContain('onerror'); // …but the handler attribute is stripped
+  });
+  it('strips form controls (phishing) and the style attribute (clickjacking)', () => {
+    const f = renderMarkdown('<form action="https://evil"><input name="x"></form>');
+    expect(f.toLowerCase()).not.toContain('<form');
+    expect(f.toLowerCase()).not.toContain('<input');
+    const s = renderMarkdown('<a href="https://x" style="position:fixed;inset:0">x</a>');
+    expect(s).not.toContain('style=');
+  });
+  it('neutralizes data:text/html links', () => {
+    const html = renderMarkdown('[x](data:text/html,<script>alert(1)</script>)');
+    expect(html.toLowerCase()).not.toContain('data:text/html');
+  });
+  it('empty/nullish → empty string', () => {
+    expect(renderMarkdown('')).toBe('');
+    expect(renderMarkdown(null)).toBe('');
+    expect(renderMarkdown(undefined)).toBe('');
+  });
+});

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -1,0 +1,28 @@
+import { marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+
+marked.setOptions({ gfm: true, breaks: true });
+
+// Defense-in-depth: any link that opens a new tab must not reach window.opener (reverse-tabnabbing).
+// Registered once at module load (DOMPurify is a singleton in isomorphic-dompurify).
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target')) {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+/**
+ * Render user-authored Markdown to SANITIZED HTML, server-side.
+ * Lives under $lib/server so the heavy deps never ship to the browser.
+ * DOMPurify's default HTML profile strips <script>, on* handlers, and javascript:/data: URLs; on top of that we
+ * forbid interactive form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing).
+ */
+export function renderMarkdown(md: string | null | undefined): string {
+  if (!md) return '';
+  const html = marked.parse(md, { async: false }) as string;
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ['form', 'input', 'button', 'select', 'option', 'textarea', 'label', 'fieldset', 'style'],
+    FORBID_ATTR: ['style']
+  });
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -252,6 +252,61 @@ export type Database = {
         }
         Relationships: []
       }
+      comments: {
+        Row: {
+          author_id: string | null
+          body_md: string
+          created_at: string
+          id: string
+          idea_id: string
+          legacy: Json
+          legacy_id: number | null
+          reply_to: string | null
+        }
+        Insert: {
+          author_id?: string | null
+          body_md: string
+          created_at?: string
+          id?: string
+          idea_id: string
+          legacy?: Json
+          legacy_id?: number | null
+          reply_to?: string | null
+        }
+        Update: {
+          author_id?: string | null
+          body_md?: string
+          created_at?: string
+          id?: string
+          idea_id?: string
+          legacy?: Json
+          legacy_id?: number | null
+          reply_to?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "comments_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "comments_idea_id_fkey"
+            columns: ["idea_id"]
+            isOneToOne: false
+            referencedRelation: "ideas"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "comments_reply_to_fkey"
+            columns: ["reply_to"]
+            isOneToOne: false
+            referencedRelation: "comments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       experts: {
         Row: {
           approved_at: string | null
@@ -536,6 +591,51 @@ export type Database = {
           },
         ]
       }
+      interest: {
+        Row: {
+          created_at: string
+          id: string
+          idea_id: string
+          legacy: Json
+          legacy_id: number | null
+          note_md: string | null
+          profile_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          idea_id: string
+          legacy?: Json
+          legacy_id?: number | null
+          note_md?: string | null
+          profile_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          idea_id?: string
+          legacy?: Json
+          legacy_id?: number | null
+          note_md?: string | null
+          profile_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "interest_idea_id_fkey"
+            columns: ["idea_id"]
+            isOneToOne: false
+            referencedRelation: "ideas"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "interest_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -590,8 +690,62 @@ export type Database = {
           },
         ]
       }
+      pg_all_foreign_keys: {
+        Row: {
+          fk_columns: unknown[] | null
+          fk_constraint_name: unknown
+          fk_schema_name: unknown
+          fk_table_name: unknown
+          fk_table_oid: unknown
+          is_deferrable: boolean | null
+          is_deferred: boolean | null
+          match_type: string | null
+          on_delete: string | null
+          on_update: string | null
+          pk_columns: unknown[] | null
+          pk_constraint_name: unknown
+          pk_index_name: unknown
+          pk_schema_name: unknown
+          pk_table_name: unknown
+          pk_table_oid: unknown
+        }
+        Relationships: []
+      }
+      tap_funky: {
+        Row: {
+          args: string | null
+          is_definer: boolean | null
+          is_strict: boolean | null
+          is_visible: boolean | null
+          kind: unknown
+          langoid: unknown
+          name: unknown
+          oid: unknown
+          owner: unknown
+          returns: string | null
+          returns_set: boolean | null
+          schema: unknown
+          volatility: string | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
+      _cleanup: { Args: never; Returns: boolean }
+      _contract_on: { Args: { "": string }; Returns: unknown }
+      _currtest: { Args: never; Returns: number }
+      _db_privs: { Args: never; Returns: unknown[] }
+      _extensions: { Args: never; Returns: unknown[] }
+      _get: { Args: { "": string }; Returns: number }
+      _get_latest: { Args: { "": string }; Returns: number[] }
+      _get_note: { Args: { "": string }; Returns: string }
+      _is_verbose: { Args: never; Returns: boolean }
+      _prokind: { Args: { p_oid: unknown }; Returns: unknown }
+      _query: { Args: { "": string }; Returns: string }
+      _refine_vol: { Args: { "": string }; Returns: string }
+      _table_privs: { Args: never; Returns: unknown[] }
+      _temptypes: { Args: { "": string }; Returns: string }
+      _todo: { Args: never; Returns: string }
       admin_approve_payout: {
         Args: { p_answer_id: string; p_note?: string }
         Returns: {
@@ -650,7 +804,79 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      col_is_null:
+        | {
+            Args: {
+              column_name: unknown
+              description?: string
+              schema_name: unknown
+              table_name: unknown
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              column_name: unknown
+              description?: string
+              table_name: unknown
+            }
+            Returns: string
+          }
+      col_not_null:
+        | {
+            Args: {
+              column_name: unknown
+              description?: string
+              schema_name: unknown
+              table_name: unknown
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              column_name: unknown
+              description?: string
+              table_name: unknown
+            }
+            Returns: string
+          }
+      diag:
+        | {
+            Args: { msg: unknown }
+            Returns: {
+              error: true
+            } & "Could not choose the best candidate function between: public.diag(msg => text), public.diag(msg => anyelement). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
+          }
+        | {
+            Args: { msg: string }
+            Returns: {
+              error: true
+            } & "Could not choose the best candidate function between: public.diag(msg => text), public.diag(msg => anyelement). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
+          }
+      diag_test_name: { Args: { "": string }; Returns: string }
+      do_tap:
+        | { Args: never; Returns: string[] }
+        | { Args: { "": string }; Returns: string[] }
+      fail:
+        | { Args: never; Returns: string }
+        | { Args: { "": string }; Returns: string }
+      findfuncs: { Args: { "": string }; Returns: string[] }
+      finish: { Args: { exception_on_failure?: boolean }; Returns: string[] }
+      has_unique: { Args: { "": string }; Returns: string }
+      in_todo: { Args: never; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
+      is_empty: { Args: { "": string }; Returns: string }
+      isnt_empty: { Args: { "": string }; Returns: string }
+      lives_ok: { Args: { "": string }; Returns: string }
+      no_plan: { Args: never; Returns: boolean[] }
+      num_failed: { Args: never; Returns: number }
+      os_name: { Args: never; Returns: string }
+      pass:
+        | { Args: never; Returns: string }
+        | { Args: { "": string }; Returns: string }
+      pg_version: { Args: never; Returns: string }
+      pg_version_num: { Args: never; Returns: number }
+      pgtap_version: { Args: never; Returns: number }
       reject_answer: {
         Args: { p_answer_id: string; p_note?: string }
         Returns: {
@@ -742,6 +968,12 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      runtests:
+        | { Args: never; Returns: string[] }
+        | { Args: { "": string }; Returns: string[] }
+      skip:
+        | { Args: { "": string }; Returns: string }
+        | { Args: { how_many: number; why: string }; Returns: string }
       start_review: {
         Args: { p_answer_id: string }
         Returns: {
@@ -771,6 +1003,16 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      throws_ok: { Args: { "": string }; Returns: string }
+      todo:
+        | { Args: { how_many: number }; Returns: boolean[] }
+        | { Args: { how_many: number; why: string }; Returns: boolean[] }
+        | { Args: { why: string }; Returns: boolean[] }
+        | { Args: { how_many: number; why: string }; Returns: boolean[] }
+      todo_end: { Args: never; Returns: boolean[] }
+      todo_start:
+        | { Args: never; Returns: boolean[] }
+        | { Args: { "": string }; Returns: boolean[] }
       verify_answer: {
         Args: {
           p_answer_id: string
@@ -810,7 +1052,9 @@ export type Database = {
       [_ in never]: never
     }
     CompositeTypes: {
-      [_ in never]: never
+      _time_trial_type: {
+        a_time: number | null
+      }
     }
   }
 }

--- a/src/routes/console/+page.server.ts
+++ b/src/routes/console/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { renderMarkdown } from '$lib/server/markdown';
 
 async function requireExpert(supabase: any, userId: string | undefined) {
   if (!userId) return false;
@@ -35,7 +36,8 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
   const queue = (rawQueue ?? []).map((q: any) => ({
     ...q,
     submitter: Array.isArray(q.submitter) ? (q.submitter[0] ?? null) : q.submitter,
-    ideas: Array.isArray(q.ideas) ? (q.ideas[0] ?? null) : q.ideas
+    ideas: Array.isArray(q.ideas) ? (q.ideas[0] ?? null) : q.ideas,
+    explanation_html: renderMarkdown(q.explanation_md)
   }));
 
   return { ideas: ideas ?? [], queue };

--- a/src/routes/console/+page.svelte
+++ b/src/routes/console/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import StatusBadge from '$lib/components/StatusBadge.svelte';
   import Money from '$lib/components/Money.svelte';
+  import Markdown from '$lib/components/Markdown.svelte';
   let { data, form } = $props();
 </script>
 <h1 class="mb-4 text-2xl font-bold" style="color:var(--ink)">Expert console</h1>
@@ -33,7 +34,7 @@
           </div>
           <StatusBadge status={a.status} />
         </div>
-        {#if a.explanation_md}<p class="mb-2 whitespace-pre-wrap text-sm" style="color:var(--body)">{a.explanation_md}</p>{/if}
+        <Markdown html={a.explanation_html} class="mb-2" />
         {#if a.answer_artifacts?.length}
           <ul class="mb-3 flex flex-col gap-1 text-sm">
             {#each a.answer_artifacts as art (art.id)}

--- a/src/routes/experts/+page.server.ts
+++ b/src/routes/experts/+page.server.ts
@@ -1,0 +1,16 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals: { supabase } }) => {
+  const { data: rawExperts } = await supabase
+    .from('experts')
+    .select('id, specialty, featured, profiles!experts_id_fkey(handle, display_name)')
+    .eq('status', 'approved')
+    .order('featured', { ascending: false });
+  const experts = (rawExperts ?? []).map((e: any) => ({
+    id: e.id,
+    specialty: e.specialty,
+    featured: e.featured,
+    profile: Array.isArray(e.profiles) ? (e.profiles[0] ?? null) : e.profiles
+  }));
+  return { experts };
+};

--- a/src/routes/experts/+page.svelte
+++ b/src/routes/experts/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+<h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Experts</h1>
+<p class="mb-6 text-sm" style="color:var(--muted)">Vetted researchers who post bounties on AI Safety Ideas.</p>
+{#if data.experts.length === 0}
+  <p style="color:var(--muted)">No experts yet.</p>
+{:else}
+  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    {#each data.experts as e (e.id)}
+      <a href="/u/{e.profile?.handle}" class="block rounded-2xl border p-5 transition" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="font-bold" style="color:var(--ink)">{e.profile?.display_name ?? e.profile?.handle ?? 'Expert'}</h2>
+          {#if e.featured}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--green); color:var(--green-deep)">Featured</span>{/if}
+        </div>
+        {#if e.specialty}<p class="mt-1 text-sm" style="color:var(--muted)">{e.specialty}</p>{/if}
+      </a>
+    {/each}
+  </div>
+{/if}

--- a/src/routes/ideas/[id]/+page.server.ts
+++ b/src/routes/ideas/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { renderMarkdown } from '$lib/server/markdown';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
@@ -27,21 +28,19 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     .eq('idea_id', idea.id)
     .order('created_at', { ascending: true });
   const answers = (rawAnswers ?? []).map((a: any) => ({
-    ...a,
+    id: a.id, title: a.title, status: a.status, payout_amount_cents: a.payout_amount_cents,
+    answer_artifacts: a.answer_artifacts,
+    explanation_html: renderMarkdown(a.explanation_md),   // field-picked: don't ship raw explanation_md to the client
     submitter: Array.isArray(a.submitter) ? (a.submitter[0] ?? null) : a.submitter
   }));
 
-  // funding: pot (view) + the active funder list (idea_funding has ONE fk to profiles, so no embed hint needed)
   const { data: pot } = await supabase
     .from('bounty_pot').select('pot_cents, funder_count').eq('idea_id', idea.id).maybeSingle();
   const { data: rawFunders } = await supabase
     .from('idea_funding')
     .select('amount_cents, currency, funder_id, funder:profiles(handle, display_name)')
-    .eq('idea_id', idea.id)
-    .in('status', ['committed', 'escrowed'])
+    .eq('idea_id', idea.id).in('status', ['committed', 'escrowed'])
     .order('created_at', { ascending: false });
-  // Aggregate by funder so top-ups collapse to one row (and the list agrees with bounty_pot.funder_count);
-  // null funder_id (deleted account) buckets as a single 'anon' row, matching the view's coalesce(...,'anon').
   const funderMap = new Map<string, { key: string; name: string; amount_cents: number; currency: string }>();
   for (const f of (rawFunders ?? []) as any[]) {
     const prof = Array.isArray(f.funder) ? (f.funder[0] ?? null) : f.funder;
@@ -54,17 +53,49 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   }
   const funders = [...funderMap.values()];
 
+  // comments (flat, oldest first) with sanitized bodies
+  const { data: rawComments } = await supabase
+    .from('comments')
+    .select('id, body_md, author_id, created_at, author:profiles(handle, display_name)')
+    .eq('idea_id', idea.id)
+    .order('created_at', { ascending: true });
+  const comments = (rawComments ?? []).map((c: any) => ({
+    id: c.id,
+    author_id: c.author_id,
+    author: Array.isArray(c.author) ? (c.author[0] ?? null) : c.author,
+    body_html: renderMarkdown(c.body_md)
+  }));
+
+  // interest: total + whether the current user is interested
+  const { count: interestCount } = await supabase
+    .from('interest').select('id', { count: 'exact', head: true }).eq('idea_id', idea.id);
+  let myInterestId: string | null = null;
+  let isAdmin = false;
+  if (user) {
+    const { data: mine } = await supabase
+      .from('interest').select('id').eq('idea_id', idea.id).eq('profile_id', user.id).maybeSingle();
+    myInterestId = mine?.id ?? null;
+    // real admin status (from the DB, never user_metadata) so an admin sees the moderation delete control
+    const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+    isAdmin = me?.is_admin === true;
+  }
+
   return {
     idea,
+    summary_html: renderMarkdown(idea.summary_md),
     author,
     categories: (cats ?? []).map((c: any) => c.categories),
     answers,
-    // bounty_pot is a VIEW → every column is typed `number | null`; coalesce the INNER values (the outer `?? {…}`
-    // only covers the no-row case) so BountyMeter's `number` props type-check.
     pot: { pot_cents: pot?.pot_cents ?? 0, funder_count: pot?.funder_count ?? 0 },
     funders,
+    comments,
+    interestCount: interestCount ?? 0,
+    myInterestId,
+    isAdmin,
+    userId: user?.id ?? null,
     canSubmit: !!user && idea.status === 'open',
-    canFund: !!user && idea.status === 'open'
+    canFund: !!user && idea.status === 'open',
+    canEngage: !!user
   };
 };
 
@@ -75,11 +106,63 @@ export const actions: Actions = {
     const fd = await request.formData();
     const dollars = Number(fd.get('amount') ?? '');
     if (!Number.isFinite(dollars) || dollars <= 0) return fail(400, { message: 'Enter an amount greater than 0' });
-    // RLS enforces funder = self, status pinned 'committed', and the idea must be open
     const { error: e } = await supabase.from('idea_funding').insert({
       idea_id: params.id, funder_id: user.id, amount_cents: Math.round(dollars * 100), status: 'committed'
     });
     if (e) return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  comment: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to comment' });
+    const fd = await request.formData();
+    const body_md = String(fd.get('body_md') ?? '').trim();
+    if (!body_md) return fail(400, { message: 'Write something first' });
+    if (body_md.length > 10000) return fail(400, { message: 'Comment is too long (max 10,000 characters)' });
+    // RLS enforces author = self + visible idea + legacy pinned
+    const { error: e } = await supabase.from('comments').insert({
+      idea_id: params.id, author_id: user.id, body_md
+    });
+    if (e) return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  delete_comment: async ({ request, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const fd = await request.formData();
+    // RLS allows deleting only your own comment (or admin); .select() surfaces a no-op
+    const { data: del, error: e } = await supabase.from('comments')
+      .delete().eq('id', String(fd.get('comment_id'))).select('id');
+    if (e) return fail(400, { message: e.message });
+    if (!del?.length) return fail(403, { message: 'Not allowed to delete that comment' });
+    return { ok: true };
+  },
+
+  interest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to express interest' });
+    const fd = await request.formData();
+    const note_md = String(fd.get('note_md') ?? '').trim().slice(0, 2000) || null;
+    const { error: e } = await supabase.from('interest').insert({
+      idea_id: params.id, profile_id: user.id, note_md
+    });
+    if (e) {
+      // a duplicate (double-click / stale tab) means "already interested" — idempotent, don't leak the constraint name
+      if ((e as { code?: string }).code === '23505') return { ok: true };
+      return fail(400, { message: e.message });
+    }
+    return { ok: true };
+  },
+
+  uninterest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const { data: del, error: e } = await supabase.from('interest')
+      .delete().eq('idea_id', params.id).eq('profile_id', user.id).select('id');
+    if (e) return fail(400, { message: e.message });
+    if (!del?.length) return fail(409, { message: 'You were not marked interested' });
     return { ok: true };
   }
 };

--- a/src/routes/ideas/[id]/+page.svelte
+++ b/src/routes/ideas/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import AnswerCard from '$lib/components/AnswerCard.svelte';
   import BountyMeter from '$lib/components/BountyMeter.svelte';
   import Money from '$lib/components/Money.svelte';
+  import Markdown from '$lib/components/Markdown.svelte';
   let { data, form } = $props();
 </script>
 <div class="grid gap-6 lg:grid-cols-[1fr_280px]">
@@ -15,7 +16,7 @@
       <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.idea.title}</h1>
       {#if data.author}<p class="text-sm" style="color:var(--faint)">by <a href="/u/{data.author.handle}" style="color:var(--green-deep)">{data.author.display_name ?? data.author.handle}</a></p>{/if}
       {#if data.idea.claim}<p class="mt-3 italic" style="color:var(--body)">{data.idea.claim}</p>{/if}
-      {#if data.idea.summary_md}<p class="mt-3 whitespace-pre-wrap" style="color:var(--body)">{data.idea.summary_md}</p>{/if}
+      {#if data.summary_html}<Markdown html={data.summary_html} class="mt-3" />{/if}
       {#if data.categories.length}<div class="mt-4 flex flex-wrap gap-2">{#each data.categories as c}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--line); color:var(--muted)">{c.title}</span>{/each}</div>{/if}
       {#if data.idea.source_url}<p class="mt-4 text-sm"><a href={data.idea.source_url} target="_blank" rel="noopener" style="color:var(--green-deep)">Source ↗</a></p>{/if}
     </article>
@@ -23,16 +24,38 @@
     <section class="mt-8">
       <div class="mb-3 flex items-center justify-between">
         <h2 class="text-xl font-bold" style="color:var(--ink)">Answers</h2>
-        {#if data.canSubmit}
-          <a href="/ideas/{data.idea.id}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>
-        {/if}
+        {#if data.canSubmit}<a href="/ideas/{data.idea.id}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>{/if}
       </div>
-      {#if data.answers.length === 0}
-        <p style="color:var(--muted)">No answers yet.</p>
-      {:else}
-        <div class="flex flex-col gap-3">
-          {#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}
-        </div>
+      {#if data.answers.length === 0}<p style="color:var(--muted)">No answers yet.</p>{:else}
+        <div class="flex flex-col gap-3">{#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}</div>
+      {/if}
+    </section>
+
+    <section class="mt-8">
+      <h2 class="mb-3 text-xl font-bold" style="color:var(--ink)">Discussion</h2>
+      {#if data.canEngage}
+        <form method="POST" action="?/comment" class="mb-4 flex flex-col gap-2">
+          <textarea name="body_md" required placeholder="Add a comment (markdown)" rows="3" class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
+          <button class="self-start rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Comment</button>
+        </form>
+      {/if}
+      {#if data.comments.length === 0}<p style="color:var(--muted)">No comments yet.</p>{:else}
+        <ul class="flex flex-col gap-3">
+          {#each data.comments as c (c.id)}
+            <li class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+              <div class="mb-1 flex items-center justify-between">
+                <span class="text-sm" style="color:var(--faint)">{c.author?.display_name ?? c.author?.handle ?? 'Anonymous'}</span>
+                {#if data.userId === c.author_id || data.isAdmin}
+                  <form method="POST" action="?/delete_comment">
+                    <input type="hidden" name="comment_id" value={c.id} />
+                    <button class="text-xs" style="color:var(--neg)">Delete</button>
+                  </form>
+                {/if}
+              </div>
+              <Markdown html={c.body_html} />
+            </li>
+          {/each}
+        </ul>
       {/if}
     </section>
   </div>
@@ -43,14 +66,30 @@
     {#if data.canFund}
       <form method="POST" action="?/pledge" class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
         <label class="text-xs uppercase tracking-wide" style="color:var(--faint)">Fund this idea ($)
-          <input name="amount" type="number" min="0.01" step="0.01" placeholder="0.00" required
-                 class="mt-1 block w-full rounded-xl border px-3 py-2" style="border-color:var(--line)" />
+          <input name="amount" type="number" min="0.01" step="0.01" placeholder="0.00" required class="mt-1 block w-full rounded-xl border px-3 py-2" style="border-color:var(--line)" />
         </label>
         <button class="mt-3 w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Pledge</button>
         <p class="mt-2 text-xs" style="color:var(--faint)">A pledge is a commitment — no funds move yet.</p>
-        {#if form?.message}<p class="mt-2 text-sm" style="color:var(--neg)">{form.message}</p>{/if}
       </form>
     {/if}
+
+    <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+      <div class="flex items-baseline justify-between">
+        <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">Interested</span>
+        <span class="text-sm tabular-nums" style="color:var(--ink)">{data.interestCount}</span>
+      </div>
+      {#if data.canEngage}
+        {#if data.myInterestId}
+          <form method="POST" action="?/uninterest" class="mt-2">
+            <button class="w-full rounded-xl border px-4 py-2 text-sm" style="border-color:var(--green); color:var(--green-deep)">Interested ✓ — withdraw</button>
+          </form>
+        {:else}
+          <form method="POST" action="?/interest" class="mt-2">
+            <button class="w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">I'm interested</button>
+          </form>
+        {/if}
+      {/if}
+    </div>
 
     {#if data.funders.length}
       <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
@@ -65,5 +104,7 @@
         </ul>
       </div>
     {/if}
+
+    {#if form?.message}<p class="text-sm" style="color:var(--neg)">{form.message}</p>{/if}
   </aside>
 </div>

--- a/src/routes/u/[handle]/+page.server.ts
+++ b/src/routes/u/[handle]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { renderMarkdown } from '$lib/server/markdown';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase } }) => {
   const { data: profile } = await supabase
@@ -8,7 +9,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase } }) => 
     .eq('handle', params.handle)
     .single();
   if (!profile) error(404, 'Profile not found');
-  return { profile };
+  return { profile, bio_html: renderMarkdown(profile.bio_md) };
 };
 
 export const actions: Actions = {

--- a/src/routes/u/[handle]/+page.svelte
+++ b/src/routes/u/[handle]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import Markdown from '$lib/components/Markdown.svelte';
   let { data, form } = $props();
   let isSelf = $derived(data.user?.id === data.profile.id);
 </script>
 <article class="rounded-2xl border p-6" style="border-color:var(--line);background:var(--surface);box-shadow:var(--shadow-1)">
   <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.profile.display_name ?? data.profile.handle}</h1>
   <p style="color:var(--faint)">@{data.profile.handle}{#if data.profile.career_stage} · {data.profile.career_stage}{/if}</p>
-  <p class="mt-3" style="color:var(--body)">{data.profile.bio_md ?? ''}</p>
+  <Markdown html={data.bio_html} class="mt-3" />
 
   {#if isSelf}
     <form method="POST" action="?/update" class="mt-6 flex flex-col gap-2">

--- a/supabase/migrations/20260605192616_comments_interest.sql
+++ b/supabase/migrations/20260605192616_comments_interest.sql
@@ -1,0 +1,67 @@
+-- ============ comments (flat in v1 UI; reply_to stored for ETL + future threading) ============
+create table public.comments (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  author_id  uuid references public.profiles(id) on delete set null,
+  body_md    text not null,
+  reply_to   uuid references public.comments(id) on delete cascade,
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+alter table public.comments enable row level security;
+create index comments_idea_id_idx on public.comments (idea_id);
+create index comments_reply_to_idx on public.comments (reply_to);
+create index comments_author_id_idx on public.comments (author_id);
+
+-- SELECT: readable when its idea is visible (ideas RLS hides drafts) OR the caller is the author
+-- (mirrors idea_funding's "own row always visible" branch, so an author keeps their comment if the idea reverts to draft)
+create policy "comments readable when idea visible or own" on public.comments for select
+  using (
+    (select auth.uid()) = author_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: any member comments as themselves on a visible idea; author + legacy pinned
+create policy "members comment on visible ideas" on public.comments for insert to authenticated
+  with check (
+    (select auth.uid()) = author_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: the author, or an admin (moderation)
+create policy "author or admin deletes comment" on public.comments for delete to authenticated
+  using ((select auth.uid()) = author_id or public.is_admin());
+-- NOTE: no UPDATE policy — editing is delete-and-repost in v1.
+
+-- ============ interest (one per member per idea; a toggle) ============
+create table public.interest (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  profile_id uuid references public.profiles(id) on delete set null,
+  note_md    text,
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (idea_id, profile_id)
+);
+alter table public.interest enable row level security;
+create index interest_idea_id_idx on public.interest (idea_id);
+create index interest_profile_id_idx on public.interest (profile_id);  -- covers the profile_id FK (set-null cascade) + advisor
+
+-- SELECT: readable when the idea is visible OR the caller is the interested member
+create policy "interest readable when idea visible or own" on public.interest for select
+  using (
+    (select auth.uid()) = profile_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: a member expresses their OWN interest on a visible idea; profile + legacy pinned
+create policy "members express interest on visible ideas" on public.interest for insert to authenticated
+  with check (
+    (select auth.uid()) = profile_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: a member withdraws their own interest
+create policy "member withdraws own interest" on public.interest for delete to authenticated
+  using ((select auth.uid()) = profile_id);
+-- NOTE: no UPDATE policy — toggle is insert/delete; note set at insert.

--- a/supabase/tests/database/comments_interest_test.sql
+++ b/supabase/tests/database/comments_interest_test.sql
@@ -1,0 +1,94 @@
+begin;
+select plan(18);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),  -- author/expert
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now()),    -- member
+  ('00000000-0000-0000-0000-000000000000','33333333-3333-3333-3333-333333333333','authenticated','authenticated','carol@example.com','x', now(), now(), now()),  -- admin
+  ('00000000-0000-0000-0000-000000000000','44444444-4444-4444-4444-444444444444','authenticated','authenticated','dave@example.com','x', now(), now(), now());
+
+update public.profiles set is_admin = true where id = '33333333-3333-3333-3333-333333333333';
+insert into public.experts (id, status) values ('11111111-1111-1111-1111-111111111111','approved');
+insert into public.ideas (id, author_id, type, title, status) values
+  ('a0000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','open_ended','Open idea','open'),
+  ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','open_ended','Draft idea','draft');
+
+set local role authenticated;
+
+-- ===== bob comments + expresses interest (insert pinning) =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','Nice idea');
+select ok((select count(*) from public.comments) = 1, '1: member comments on a visible idea');                                              -- 1
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md)
+  values ('a0000000-0000-0000-0000-000000000001','33333333-3333-3333-3333-333333333333','spoof') $$,
+  '42501', null, '2: cannot comment as another author');                                                                                    -- 2
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md)
+  values ('a0000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222','on draft') $$,
+  '42501', null, '3: cannot comment on a draft idea');                                                                                      -- 3
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md, legacy_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','squat',7) $$,
+  '42501', null, '4: cannot set legacy_id on a live comment');                                                                              -- 4
+select throws_ok($$ insert into public.comments (idea_id, author_id, body_md, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','squat','{"a":1}'::jsonb) $$,
+  '42501', null, '5: cannot set a non-empty legacy on a live comment');                                                                     -- 5
+insert into public.interest (id, idea_id, profile_id, note_md)
+  values ('d0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','keen');
+select ok((select count(*) from public.interest) = 1, '6: member expresses interest');                                                     -- 6
+select throws_ok($$ insert into public.interest (idea_id, profile_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222') $$,
+  '23505', null, '7: one interest per member per idea (unique)');                                                                           -- 7
+select throws_ok($$ insert into public.interest (idea_id, profile_id)
+  values ('a0000000-0000-0000-0000-000000000001','33333333-3333-3333-3333-333333333333') $$,
+  '42501', null, '8: cannot express interest on behalf of another');                                                                        -- 8
+select throws_ok($$ insert into public.interest (idea_id, profile_id, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','{"a":1}'::jsonb) $$,
+  '42501', null, '9: cannot set a non-empty legacy on a live interest');                                                                    -- 9
+
+-- ===== anon can read comments/interest on a visible idea =====
+set local role anon;
+select ok((select count(*) from public.comments) = 1, '10: comments are publicly readable on a visible idea');                             -- 10
+select ok((select count(*) from public.interest) = 1, '11: interest is publicly readable on a visible idea');                              -- 11
+
+-- ===== draft-idea comment AND interest are not leaked (seed both as owner, bypass RLS) =====
+reset role;
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','draft comment');
+insert into public.interest (id, idea_id, profile_id)
+  values ('d0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111');
+set local role anon;
+select is((select count(*) from public.comments where idea_id='a0000000-0000-0000-0000-000000000002'),
+  0::bigint, '12: comments on a draft idea are not leaked to the public');                                                                  -- 12
+select is((select count(*) from public.interest where idea_id='a0000000-0000-0000-0000-000000000002'),
+  0::bigint, '13: interest on a draft idea is not leaked to the public');                                                                   -- 13
+
+-- ===== delete: non-author can't; admin can (moderation); author can delete own =====
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';  -- dave
+delete from public.comments where id='c0000000-0000-0000-0000-000000000001';
+select is((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000001'),
+  1::bigint, '14: a non-author/non-admin cannot delete a comment');                                                                        -- 14
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","role":"authenticated"}';  -- admin carol
+delete from public.comments where id='c0000000-0000-0000-0000-000000000001';
+select ok((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000001') = 0,
+  '15: an admin can delete a comment (moderation)');                                                                                       -- 15
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';  -- bob
+insert into public.comments (id, idea_id, author_id, body_md)
+  values ('c0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','my own');
+delete from public.comments where id='c0000000-0000-0000-0000-000000000002';
+select ok((select count(*) from public.comments where id='c0000000-0000-0000-0000-000000000002') = 0,
+  '16: an author can delete their own comment');                                                                                           -- 16
+
+-- ===== interest: cannot withdraw another's; can withdraw own =====
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';  -- dave
+delete from public.interest where id='d0000000-0000-0000-0000-000000000001';
+select is((select count(*) from public.interest where id='d0000000-0000-0000-0000-000000000001'),
+  1::bigint, '17: a member cannot withdraw another member''s interest');                                                                   -- 17
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';  -- bob
+delete from public.interest where id='d0000000-0000-0000-0000-000000000001';
+select ok((select count(*) from public.interest where id='d0000000-0000-0000-0000-000000000001') = 0,
+  '18: a member withdraws their own interest');                                                                                            -- 18
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Finishes the **Phase-1 data model** (the last spec §6 tables), adds a public **experts roster**, and introduces a **server-side Markdown sanitizer** so user content renders as real, safe HTML. **This completes the Phase-1 schema — the one-big ETL is now unblocked.**

- **`comments` + `interest`** tables + RLS (visibility-gated read incl. own-branch; pinned insert; comment delete = own **or admin**; interest = one-per-member toggle; no UPDATE; `legacy_*` ETL anchors).
- **Server-side sanitizer** — `$lib/server/markdown.ts#renderMarkdown` (`marked` + `isomorphic-dompurify`), kept out of the client bundle. Applied to idea summaries, answer explanations, comments, and profile bios via a single `Markdown.svelte` (the app's only `{@html}`, consuming pre-sanitized HTML).
- **Idea page Discussion** (post a comment + own/admin-moderate delete) and an **Interested** toggle + count.
- **`/experts`** — public roster of approved experts (featured first), linking to `/u/[handle]`.

## Hardened after a 6-lens adversarial review (XSS-weighted)

The sanitizer was verified XSS-safe for script/handler/URL by the review; fixes folded in before coding:

- **Sanitizer config hardened beyond DOMPurify defaults:** `FORBID_TAGS` forbids interactive form controls (anti-phishing) and `FORBID_ATTR` drops `style` (anti-clickjacking); an `afterSanitizeAttributes` hook adds `rel=noopener` to `target` links. The unit test now covers the real boundary case (`<img onerror>`, where the element survives) plus form/style/`data:`.
- **`interest.profile_id` indexed** so the `unindexed_foreign_keys` advisor stays clean.
- **Admin comment moderation wired in the UI** (`isAdmin` is a real `profiles.is_admin` lookup — was hardcoded `false`, leaving the RLS moderation path unreachable).
- **`interest` double-submit is idempotent** (treats the `23505` unique violation as "already interested", no raw constraint message); comment/interest bodies length-capped.
- `claim` rendered as plain text (not markdown); answers/comments wire objects field-picked (no raw `*_md` shipped); pgTAP grown to **plan(18)** (legacy-jsonb pin, author-self-delete, interest-on-draft).

## Test plan

All suites green (independently re-verified by a final holistic review, incl. firing **15 XSS vectors** through `renderMarkdown` — all neutralized — and confirming `marked`/`dompurify` are absent from the client bundle):

- [x] `npm run check` — 0 errors
- [x] `npx vitest run` — 19 passed (incl. the sanitizer cases)
- [x] `supabase test db` — 96 pgTAP tests PASS (`comments_interest_test.sql` = **18/18**)
- [x] `npm run build` — clean
- [x] `npx playwright test` — 11 passed

## After merge (controller)

- Apply the Plan-5 migration to cloud `gjomchhbsbtauzkpyjwa` via the Supabase MCP + re-run `get_advisors`.
- **Next: the one-big ETL** — full restore of 265 accounts+emails, 238 ideas, 83 comments, 133 interests, funding/results into the new schema via the `legacy_*` anchors (run as service-role). PII-sensitive (old emails/auth users) — to be brainstormed + planned on its own. Remaining polish (verify→payout signature animation, app-wide rate-limiting) can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)