### PR TITLE
feat: Restore v2 — comments/interest/answers + idea voting with sort-by-top

### DIFF
--- a/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
+++ b/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
@@ -61,8 +61,8 @@ create table public.idea_votes (
   unique (idea_id, profile_id)
 );
 alter table public.idea_votes enable row level security;
-create index idea_votes_idea_id_idx on public.idea_votes (idea_id);
 create index idea_votes_profile_id_idx on public.idea_votes (profile_id);
+-- (no separate idea_id index: the unique (idea_id, profile_id) doubles as it — leading column)
 
 -- SELECT: readable when the idea is visible (leverages ideas RLS) OR it is the caller's own vote
 create policy "votes readable when idea visible or own" on public.idea_votes for select
@@ -177,7 +177,7 @@ select * from finish();
 rollback;
 ```
 
-- [ ] **Step 3: Run** `supabase db reset` (applies the migration) then `supabase test db` → expect `idea_votes_test` 14/14 plus all existing suites still green (96 + 14).
+- [ ] **Step 3: Run** `supabase db reset` (applies the migration) then `supabase test db` → expect `idea_votes_test` 15/15 (incl. the UPDATE-is-noop pin, test 8b) plus all existing suites still green (96 + 15 = 111).
 - [ ] **Step 4: Regenerate the DB types** (the client is typed — without this every `from('idea_votes')` in Task 4 is a TS error): `supabase gen types typescript --local > src/lib/types/database.ts`, then `npm run check` → 0 errors.
 - [ ] **Step 5: Commit** `git add supabase/migrations supabase/tests/database/idea_votes_test.sql src/lib/types/database.ts && git commit -m "feat(votes): idea_votes table + RLS + totals view + pgTAP + types"`
 
@@ -976,7 +976,7 @@ jq -Rs '{query: .}' scripts/etl/restore-v2.generated.sql | curl -sS -m 600 \
 ---
 
 ## Done-when (Restore v2 acceptance)
-- `supabase test db` green incl. `idea_votes_test` 14/14; `npx vitest run` green (etl + votes + browse); `npm run check` 0 errors; `npm run build` succeeds.
+- `supabase test db` green incl. `idea_votes_test` 15/15 (111 total); `npx vitest run` green (etl + votes + browse); `npm run check` 0 errors; `npm run build` succeeds.
 - `npm run etl:restore-v2` deterministically emits a gitignored artifact (83/13/133/5/5/387 printed).
 - Local rehearsal: embedded asserts pass, orphan scans 0, threading resolved, idempotent re-run, UI shows scores/sort/votes/comments/answers.
 - Cloud: counts verified, advisors at baseline, smoke test passes, PAT revoked.

--- a/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
+++ b/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
@@ -15,7 +15,7 @@
 ## Key design decisions
 - **FK resolution via scalar subqueries.** v1 minted idea UUIDs at generation time, so v2 emits `(select id from public.ideas where legacy_id = N)` for every idea reference (and `public.answers`/`public.comments` equivalents). Resolved at apply time → the same artifact works on the local rehearsal stack and cloud, stays idempotent, and a missing parent fails loudly (null into a `not null` column). Profile references stay **literal UUIDs** (v1 preserved them). The ref helpers validate `N` is an integer (no string interpolation of dump text into SQL).
 - **Comment threading is two-pass.** A multi-row INSERT cannot see its own rows, so pass 1 inserts all comments with `reply_to` omitted; pass 2 emits one idempotent `update … where c.legacy_id = <id> and c.reply_to is null` per reply.
-- **Same envelope as v1:** `begin` → `set session_replication_role = replica` → inserts (`on conflict (legacy_id) do nothing`) → reply updates → `origin` → `do $$ assert … $$` (counts + orphan scans, since FKs were deferred) → `commit`.
+- **Same envelope as v1:** `begin` → `set session_replication_role = replica` → inserts → reply updates → `origin` → `do $$ assert … $$` → `commit`. Conflict handling: `on conflict (legacy_id) do nothing` for comments/answers/artifacts; **targetless `on conflict do nothing` for interest/idea_votes** (they also carry `unique (idea_id, profile_id)` — an organic post-restore row on the same pair must displace the legacy insert, not abort the transaction). The orphan scans in the assert block are the ONLY FK verification — replica mode disables RI triggers and they are never re-validated.
 - **Privileged inserts are the point:** the load runs as `postgres` (table owner → bypasses RLS), which is what lets it insert `status='verified'` answers and legacy columns that the client INSERT policies pin shut.
 - **Votes:** `value in (-1,1)`, one row per (idea, profile); toggle = DELETE + INSERT (no UPDATE policy, same as `interest`). Old likes import as `value = 1`, weight kept in `legacy`.
 
@@ -92,9 +92,10 @@ create view public.idea_vote_totals
     count(*) filter (where value = -1)        as down_count
   from public.idea_votes
   group by idea_id;
+grant select on public.idea_vote_totals to anon, authenticated;   -- mirrors bounty_pot (idea_funding migration)
 ```
 
-(The `value` check lives on the table constraint only — a single deterministic error source; the policy pins identity/visibility/legacy.)
+(The `value` check lives on the table constraint only — a single deterministic error source; the policy pins identity/visibility/legacy. Accepted product decision: individual votes — including downvotes — are publicly attributable via the API, same as comments.)
 
 - [ ] **Step 2: Write the failing pgTAP test** `supabase/tests/database/idea_votes_test.sql` (conventions per `comments_interest_test.sql`: the `handle_new_user` trigger auto-creates profiles)
 
@@ -162,6 +163,11 @@ select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000
   '12: draft author can vote their own draft');
 
 set local role anon;
+-- CRITICAL: clear the stale JWT claims — `set local role` does NOT reset request.jwt.claims, so
+-- auth.uid() would still be alice and the own-row SELECT branch would leak her draft vote into
+-- test 14. The POLICY is correct; only an uncleared fixture would make it look broken. Do NOT
+-- "fix" a red test 14 by weakening the policy or the view.
+set local request.jwt.claims = '';
 select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000-0000-0000-000000000001') = 1,
   '13: anon sees votes on visible ideas');
 select ok((select count(*) from public.idea_vote_totals where idea_id = 'a0000000-0000-0000-0000-000000000002') = 0,
@@ -172,7 +178,8 @@ rollback;
 ```
 
 - [ ] **Step 3: Run** `supabase db reset` (applies the migration) then `supabase test db` → expect `idea_votes_test` 14/14 plus all existing suites still green (96 + 14).
-- [ ] **Step 4: Commit** `git add supabase/migrations supabase/tests/database/idea_votes_test.sql && git commit -m "feat(votes): idea_votes table + RLS + totals view + pgTAP"`
+- [ ] **Step 4: Regenerate the DB types** (the client is typed — without this every `from('idea_votes')` in Task 4 is a TS error): `supabase gen types typescript --local > src/lib/types/database.ts`, then `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add supabase/migrations supabase/tests/database/idea_votes_test.sql src/lib/types/database.ts && git commit -m "feat(votes): idea_votes table + RLS + totals view + pgTAP + types"`
 
 ---
 
@@ -297,7 +304,7 @@ export function toComment(c: Row): SqlRow {
       anon_author_url: c.anon_author_url ?? undefined,
       upvotes: c.upvotes ?? undefined
     }),
-    created_at: lit(c.created_at ?? null)
+    created_at: lit(c.created_at ?? { sql: 'now()' })   // explicit NULL would abort on the NOT NULL column
   };
 }
 
@@ -316,7 +323,7 @@ export function toInterest(r: Row): SqlRow {
     profile_id: lit(r.user ?? null),
     note_md: lit(nullifBlank(r.how)),
     legacy: jsonbLit({ contact_if_started: r.contact_if_started ?? undefined }),
-    created_at: lit(r.created_at ?? null)
+    created_at: lit(r.created_at ?? { sql: 'now()' })
   };
 }
 
@@ -339,7 +346,7 @@ export function toAnswerFromResult(r: Row, titles: Map<string, string>): SqlRow 
       from_date: r.from_date ?? undefined,
       original: r.original ?? undefined
     }),
-    created_at: lit(r.created_at ?? null)
+    created_at: lit(r.created_at ?? { sql: 'now()' })
   };
 }
 
@@ -352,7 +359,7 @@ export function toAnswerArtifact(r: Row): SqlRow | null {
     answer_id: answerRef(r.id),
     kind: lit('url'),
     url: lit(url),
-    created_at: lit(r.created_at ?? null)
+    created_at: lit(r.created_at ?? { sql: 'now()' })
   };
 }
 
@@ -364,7 +371,7 @@ export function toVote(l: Row): SqlRow {
     profile_id: lit(l.user ?? null),
     value: '1',
     legacy: jsonbLit({ size: l.size ?? undefined }),
-    created_at: lit(l.created_at ?? null)
+    created_at: lit(l.created_at ?? { sql: 'now()' })
   };
 }
 
@@ -444,18 +451,61 @@ describe('buildDocumentV2', () => {
     );
   });
 
-  it('uses on conflict (legacy_id) everywhere and >= count assertions', () => {
+  it('arbitrates ALL unique constraints on interest/votes (targetless) and legacy_id elsewhere', () => {
     const doc = buildDocumentV2(data);
-    expect(doc).toContain('on conflict (legacy_id) do nothing');
-    expect(doc).toMatch(/assert \(select count\(\*\) from public\.comments\) >= \d+/);
+    const seg = (from: string, to: string) => doc.slice(doc.indexOf(from), doc.indexOf(to));
+    // comments/answers/artifacts: legacy_id is their only unique key
+    expect(seg('insert into public.comments', 'update public.comments')).toContain('on conflict (legacy_id) do nothing;');
+    // interest/idea_votes ALSO carry unique (idea_id, profile_id): an organic post-restore row on the
+    // same pair must NOT abort the load — a targetless `on conflict do nothing` arbitrates ANY unique index
+    expect(seg('insert into public.interest', 'insert into public.answers')).toContain('on conflict do nothing;');
+    expect(seg('insert into public.interest', 'insert into public.answers')).not.toContain('on conflict (');
+    expect(seg('insert into public.idea_votes', 'set session_replication_role = origin')).toContain('on conflict do nothing;');
+    expect(seg('insert into public.idea_votes', 'set session_replication_role = origin')).not.toContain('on conflict (');
+  });
+
+  it('asserts legacy-scoped counts where exact, totals where displacement is possible', () => {
+    const doc = buildDocumentV2(data);
+    // comments/answers/artifacts can't be displaced → exact legacy-scoped counts (organic-immune)
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.comments where legacy_id is not null\) >= \d+/);
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.answers where legacy_id is not null\) >= \d+/);
+    // interest/votes: an organic row on the same (idea_id, profile_id) DISPLACES the legacy insert,
+    // so legacy-scoped counts could undershoot — assert totals (legacy + displacing organic ≥ source)
     expect(doc).toMatch(/assert \(select count\(\*\) from public\.idea_votes\) >= \d+/);
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.interest\) >= \d+/);
+    expect(doc).toContain('orphan comment idea');   // full spec §5 orphan-scan list
+    expect(doc).toContain('orphan artifact answer');
   });
 });
 ```
 
 - [ ] **Step 2: Run to verify failure** `npx vitest run scripts/etl/emit.test.ts` → FAIL (`buildDocumentV2` missing).
 
-- [ ] **Step 3: Implement** (append to `scripts/etl/emit.ts`)
+- [ ] **Step 3a: Extend `insertRows` for targetless conflicts.** In `scripts/etl/sql.ts`, make the conflict target optional — an empty/omitted target emits a targetless `on conflict do nothing` (arbitrates ANY unique index):
+
+```ts
+export function insertRows(
+  table: string, columns: string[], rows: Record<string, string>[], conflictTarget?: string
+): string {
+  if (rows.length === 0) return '';
+  const tuples = rows.map((r) => `  (${columns.map((c) => r[c] ?? 'NULL').join(', ')})`).join(',\n');
+  const conflict = conflictTarget ? `on conflict (${conflictTarget}) do nothing;` : 'on conflict do nothing;';
+  return `insert into ${table} (${columns.join(', ')}) values\n${tuples}\n${conflict}\n`;
+}
+```
+
+Append to `scripts/etl/sql.test.ts`:
+
+```ts
+  it('insertRows() omits the conflict target when none is given (arbitrates any unique index)', () => {
+    const sql = insertRows('public.t', ['id'], [{ id: lit('1') }]);
+    expect(sql.trim().endsWith('on conflict do nothing;')).toBe(true);
+  });
+```
+
+(All v1 call sites pass a target — behavior unchanged; `npx vitest run scripts/etl/sql.test.ts` must stay green.)
+
+- [ ] **Step 3b: Implement** (append to `scripts/etl/emit.ts`)
 
 ```ts
 /** v2 target column lists (only columns the ETL sets; defaults cover the rest). */
@@ -499,33 +549,48 @@ export function buildDocumentV2(data: EmitDataV2): string {
       })
       .join('\n')
   );
-  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest, 'legacy_id'));
+  // interest + idea_votes ALSO carry unique (idea_id, profile_id): an organic post-restore row on the
+  // same pair must DISPLACE the legacy insert, not abort the transaction → targetless on conflict.
+  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest));
   parts.push(insertRows('public.answers', [...ANSWERS_COLUMNS], data.answers, 'legacy_id'));
   parts.push(insertRows('public.answer_artifacts', [...ARTIFACTS_COLUMNS], data.artifacts, 'legacy_id'));
-  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes, 'legacy_id'));
+  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes));
 
   parts.push('set session_replication_role = origin;');
 
-  // counts (>= so re-runs never trip) + orphan scans (FK checks were deferred under replica)
+  // VERIFICATION IS HERE OR NOWHERE: replica mode DISABLES the RI triggers and restoring `origin`
+  // never re-validates rows — these scans are the only FK-integrity check for the load.
+  // Counts: comments/answers/artifacts can't be displaced → exact legacy-scoped; interest/votes can be
+  // displaced by an organic (idea_id, profile_id) row → assert totals (legacy + displacing organic).
   parts.push(
     [
       'do $$ begin',
-      "  assert (select count(*) from public.comments) >= 83, 'comments count too low';",
+      "  assert (select count(*) from public.comments where legacy_id is not null) >= 83, 'comments count too low';",
       "  assert (select count(*) from public.interest) >= 133, 'interest count too low';",
-      "  assert (select count(*) from public.answers) >= 5, 'answers count too low';",
-      "  assert (select count(*) from public.answer_artifacts) >= 5, 'artifacts count too low';",
+      "  assert (select count(*) from public.answers where legacy_id is not null) >= 5, 'answers count too low';",
+      "  assert (select count(*) from public.answer_artifacts where legacy_id is not null) >= 5, 'artifacts count too low';",
       "  assert (select count(*) from public.idea_votes) >= 387, 'votes count too low';",
-      "  assert (select count(*) from public.comments where reply_to is not null) >= 13, 'reply links too low';",
+      "  assert (select count(*) from public.comments where legacy_id is not null and reply_to is not null) >= 13, 'reply links too low';",
       '  assert (select count(*) from public.comments c left join public.profiles p on p.id = c.author_id',
       "          where c.author_id is not null and p.id is null) = 0, 'orphan comment author';",
+      '  assert (select count(*) from public.comments c left join public.ideas i on i.id = c.idea_id',
+      "          where i.id is null) = 0, 'orphan comment idea';",
       '  assert (select count(*) from public.comments c left join public.comments p on p.id = c.reply_to',
       "          where c.reply_to is not null and p.id is null) = 0, 'orphan reply_to';",
-      '  assert (select count(*) from public.interest i left join public.profiles p on p.id = i.profile_id',
-      "          where i.profile_id is not null and p.id is null) = 0, 'orphan interest profile';",
+      '  assert (select count(*) from public.interest x left join public.profiles p on p.id = x.profile_id',
+      "          where x.profile_id is not null and p.id is null) = 0, 'orphan interest profile';",
+      '  assert (select count(*) from public.interest x left join public.ideas i on i.id = x.idea_id',
+      "          where i.id is null) = 0, 'orphan interest idea';",
       '  assert (select count(*) from public.answers a left join public.profiles p on p.id = a.submitter_id',
       "          where a.submitter_id is not null and p.id is null) = 0, 'orphan answer submitter';",
+      '  assert (select count(*) from public.answers a left join public.ideas i on i.id = a.idea_id',
+      "          where i.id is null) = 0, 'orphan answer idea';",
+      '  assert (select count(*) from public.answer_artifacts t left join public.answers a on a.id = t.answer_id',
+      "          where a.id is null) = 0, 'orphan artifact answer';",
       '  assert (select count(*) from public.idea_votes v left join public.profiles p on p.id = v.profile_id',
       "          where p.id is null) = 0, 'orphan vote profile';",
+      '  assert (select count(*) from public.idea_votes v left join public.ideas i on i.id = v.idea_id',
+      "          where i.id is null) = 0, 'orphan vote idea';",
       'end $$;'
     ].join('\n')
   );
@@ -588,7 +653,7 @@ main();
 In `package.json` `scripts` add: `"etl:restore-v2": "tsx scripts/etl/restore-v2.ts"`.
 
 - [ ] **Step 5: Run** `npx vitest run scripts/etl` → all green (v1 + v2). `npm run check` → 0 errors.
-- [ ] **Step 6: Commit** `git add scripts/etl/emit.ts scripts/etl/emit.test.ts scripts/etl/restore-v2.ts package.json && git commit -m "feat(etl): v2 emitter + restore-v2 CLI"`
+- [ ] **Step 6: Commit** `git add scripts/etl/sql.ts scripts/etl/sql.test.ts scripts/etl/emit.ts scripts/etl/emit.test.ts scripts/etl/restore-v2.ts package.json && git commit -m "feat(etl): v2 emitter + restore-v2 CLI"`
 
 ---
 
@@ -652,27 +717,54 @@ Run `npx vitest run src/lib/votes.test.ts` → PASS.
 ```svelte
 <script lang="ts">
   import { enhance } from '$app/forms';
-  let { score, myVote, canVote }: { score: number; myVote: 1 | -1 | null; canVote: boolean } = $props();
+  let { score, myVote, canVote, signinHref }: {
+    score: number; myVote: 1 | -1 | null; canVote: boolean; signinHref?: string;
+  } = $props();
+
+  // Optimistic local view (spec §6): apply the expected outcome immediately, reconcile when the
+  // action's load re-run delivers fresh props (the $effect clears the override on every prop change).
+  let pending = $state(false);
+  let optimistic = $state<{ score: number; myVote: 1 | -1 | null } | null>(null);
+  $effect(() => { void score; void myVote; optimistic = null; });
+  const view = $derived(optimistic ?? { score, myVote });
+
+  const submit = (value: 1 | -1) => () => {
+    const cur = view;
+    optimistic = cur.myVote === value
+      ? { score: cur.score - value, myVote: null }                        // same arrow → unvote
+      : { score: cur.score + value - (cur.myVote ?? 0), myVote: value };  // vote / switch
+    pending = true;
+    return async ({ update }: { update: () => Promise<void> }) => {
+      await update();           // re-runs the load → fresh score/myVote → $effect clears optimistic
+      pending = false;
+    };
+  };
 </script>
 <div class="flex items-center gap-1.5 rounded-xl border px-2 py-1"
      style="border-color:var(--line); background:var(--surface)">
-  <form method="POST" action={myVote === 1 ? '?/unvote' : '?/vote'} use:enhance>
-    <input type="hidden" name="value" value="1" />
-    <button class="px-1 transition disabled:opacity-40" disabled={!canVote} aria-label="Upvote"
-            aria-pressed={myVote === 1}
-            style="color:{myVote === 1 ? 'var(--green-deep)' : 'var(--muted)'}">▲</button>
-  </form>
-  <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{score}</span>
-  <form method="POST" action={myVote === -1 ? '?/unvote' : '?/vote'} use:enhance>
-    <input type="hidden" name="value" value="-1" />
-    <button class="px-1 transition disabled:opacity-40" disabled={!canVote} aria-label="Downvote"
-            aria-pressed={myVote === -1}
-            style="color:{myVote === -1 ? 'var(--neg)' : 'var(--muted)'}">▼</button>
-  </form>
+  {#if !canVote && signinHref}
+    <a href={signinHref} class="px-1" aria-label="Sign in to vote" style="color:var(--muted)">▲</a>
+    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{view.score}</span>
+    <a href={signinHref} class="px-1" aria-label="Sign in to vote" style="color:var(--muted)">▼</a>
+  {:else}
+    <form method="POST" action={view.myVote === 1 ? '?/unvote' : '?/vote'} use:enhance={submit(1)}>
+      <input type="hidden" name="value" value="1" />
+      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Upvote"
+              aria-pressed={view.myVote === 1}
+              style="color:{view.myVote === 1 ? 'var(--green-deep)' : 'var(--muted)'}">▲</button>
+    </form>
+    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{view.score}</span>
+    <form method="POST" action={view.myVote === -1 ? '?/unvote' : '?/vote'} use:enhance={submit(-1)}>
+      <input type="hidden" name="value" value="-1" />
+      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Downvote"
+              aria-pressed={view.myVote === -1}
+              style="color:{view.myVote === -1 ? 'var(--neg)' : 'var(--muted)'}">▼</button>
+    </form>
+  {/if}
 </div>
 ```
 
-(Active upvote = `--green-deep` small mark; active downvote = `--neg`, the semantic negative. `use:enhance` re-runs the load after the action — no full reload. If signed out the buttons are disabled; the page already exposes a sign-in link with `?next=`.)
+(Active upvote = `--green-deep` small mark; active downvote = `--neg`, the semantic negative. The optimistic override + `pending` guard satisfy spec §6 — instant feedback, no double-submit; the load re-run reconciles to server truth. Signed-out users get the arrows as links to `signinHref` — there is no pre-existing `?next=` sign-in link on the idea page, so the control carries its own.)
 
 - [ ] **Step 4: Idea detail — load + actions.** In `src/routes/ideas/[id]/+page.server.ts`:
 
@@ -724,7 +816,8 @@ To `actions` add:
 - [ ] **Step 5: Mount the control.** In `src/routes/ideas/[id]/+page.svelte`, import `VoteControl` and render it in the header row next to the title/status:
 
 ```svelte
-<VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage} />
+<VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage}
+             signinHref={`/login?next=/ideas/${data.idea.id}`} />
 ```
 
 (Match the file's existing header layout — place it inside the same flex row as the `StatusBadge`.)
@@ -741,7 +834,8 @@ export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
   const sort = url.searchParams.get('sort') === 'top' ? 'top' : 'new';
   const page = Math.max(0, Number(url.searchParams.get('page') ?? 0));
 
-  // vote totals are small (≤ #ideas rows) — fetch once, used by both sorts for the card scores
+  // vote totals are small (≤ #ideas rows; ~240 today, well under PostgREST's 1000-row cap — revisit
+  // both whole-set fetches if the idea count ever approaches 1000) — fetched once for the card scores
   const { data: totals } = await supabase.from('idea_vote_totals').select('idea_id, score');
 
   let base = supabase
@@ -862,10 +956,18 @@ Note for the implementer: the `order()` mock above resolves the promise (the rea
 
 > Controller-only. Subagents never touch cloud.
 
-- [ ] Apply the `idea_votes` migration to `gjomchhbsbtauzkpyjwa` via MCP `apply_migration`.
-- [ ] **Checkpoint with the owner**, then apply the rehearsed artifact via the Management API over 443 (psql ports are blocked on the owner's network; the artifact must NOT stream through MCP `execute_sql`):
-  `jq -Rs '{query: .}' scripts/etl/restore-v2.generated.sql | curl -sS -m 600 -X POST "https://api.supabase.com/v1/projects/gjomchhbsbtauzkpyjwa/database/query" -H "Authorization: Bearer <fresh owner PAT>" -H "Content-Type: application/json" --data-binary @-` → expect HTTP 201.
-- [ ] Verify on cloud (MCP `execute_sql`): the Task-5 count + orphan queries; expect 83/133/5/5/387 (+ any new organic rows).
+- [ ] **PR merged first** (the deployed app must already have the vote UI + the repo the migration file), then apply the `idea_votes` migration to `gjomchhbsbtauzkpyjwa` via MCP `apply_migration`.
+- [ ] **Checkpoint with the owner** (a fresh PAT is needed — the v1 token was revoked), then apply the rehearsed artifact via the Management API over 443 (psql ports are blocked on the owner's network; the artifact must NOT stream through MCP `execute_sql`). Keep the PAT out of argv/history: have the owner paste it into a `chmod 600` temp file, then:
+
+```bash
+jq -Rs '{query: .}' scripts/etl/restore-v2.generated.sql | curl -sS -m 600 \
+  -X POST "https://api.supabase.com/v1/projects/gjomchhbsbtauzkpyjwa/database/query" \
+  -H @<(printf 'Authorization: Bearer %s\n' "$(cat /tmp/sb-pat)") -H "Content-Type: application/json" \
+  --data-binary @- -o /tmp/restore-v2-response.json -w "http=%{http_code}\n"
+```
+
+  **Treat anything other than `http=201` as failure** (the transaction rolled back — read the response body; do not retry blindly). Delete `/tmp/sb-pat` immediately after.
+- [ ] Verify on cloud (MCP `execute_sql`), organic-data-immune: `count(*) … where legacy_id is not null` per table → expect exactly **83 comments / 5 answers / 5 artifacts**, reply_to set on 13 legacy comments, and `interest`/`idea_votes` legacy counts + displaced pairs summing to **133 / 387** (displaced = organic rows sharing an (idea_id, profile_id) pair with a skipped legacy row — normally 0 this soon after launch). Then the orphan scans → all 0.
 - [ ] Re-run `get_advisors` (security + performance) — expect the accepted baseline only (`idea_vote_totals` is security_invoker; both new FKs are indexed).
 - [ ] Smoke test on the deployed app: `/ideas?sort=top`, a restored comment thread, a verified answer, casting + removing a vote.
 - [ ] Remind the owner to **revoke the PAT** (and rotate the DB password if not already done after v1).

--- a/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
+++ b/docs/superpowers/plans/2026-06-06-etl-restore-v2.md
@@ -1,0 +1,881 @@
+# ETL Restore v2 (Comments, Interest, Answers, Votes) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development for Tasks 1–4. Steps use checkbox (`- [ ]`) syntax. **Tasks 5–6 are CONTROLLER-ONLY** (they touch the real PII backup + the cloud project) — a subagent must NOT run them. Subagents must never read `~/Downloads/db_cluster-*.backup`, touch the cloud project, or edit `CLAUDE.md`/`docs/`/`.claude/`/`src_legacy_v0/`.
+
+**Goal:** Restore the remaining old-platform content (83 comments, 133 interests, 5 results→verified answers, 387 likes→upvotes) and ship the new **idea voting feature** (`idea_votes` table + RLS + totals view + minimal UI + sort-by-score).
+
+**Architecture:** One new migration (`idea_votes` + `idea_vote_totals` security-invoker view, RLS mirroring `interest`), new pure transforms + a `buildDocumentV2` emitter in the existing `scripts/etl/` machinery (idea/answer FKs resolved by **scalar subqueries on `legacy_id`** so one artifact works on any environment; comment threading is **two-pass** insert-then-update), and a thin UI layer (VoteControl on the idea page, score on cards, `?sort=top` on `/ideas`). Spec: `docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md`.
+
+**Tech Stack:** TypeScript via `tsx`, `vitest` (synthetic fixtures only), pgTAP, SvelteKit 2 / Svelte 5 runes, supabase-js v2 (RLS does all mutation enforcement — no RPCs).
+
+**Security:** the backup + `scripts/etl/*.generated.sql` contain PII and are gitignored (already covered). The v2 CLI prints **counts only**. Verified source facts (controller probed): perfect referential integrity in all 4 source tables; 0 duplicate interest pairs; all 13 `reply_to` point to lower ids; all 5 results have a link.
+
+---
+
+## Key design decisions
+- **FK resolution via scalar subqueries.** v1 minted idea UUIDs at generation time, so v2 emits `(select id from public.ideas where legacy_id = N)` for every idea reference (and `public.answers`/`public.comments` equivalents). Resolved at apply time → the same artifact works on the local rehearsal stack and cloud, stays idempotent, and a missing parent fails loudly (null into a `not null` column). Profile references stay **literal UUIDs** (v1 preserved them). The ref helpers validate `N` is an integer (no string interpolation of dump text into SQL).
+- **Comment threading is two-pass.** A multi-row INSERT cannot see its own rows, so pass 1 inserts all comments with `reply_to` omitted; pass 2 emits one idempotent `update … where c.legacy_id = <id> and c.reply_to is null` per reply.
+- **Same envelope as v1:** `begin` → `set session_replication_role = replica` → inserts (`on conflict (legacy_id) do nothing`) → reply updates → `origin` → `do $$ assert … $$` (counts + orphan scans, since FKs were deferred) → `commit`.
+- **Privileged inserts are the point:** the load runs as `postgres` (table owner → bypasses RLS), which is what lets it insert `status='verified'` answers and legacy columns that the client INSERT policies pin shut.
+- **Votes:** `value in (-1,1)`, one row per (idea, profile); toggle = DELETE + INSERT (no UPDATE policy, same as `interest`). Old likes import as `value = 1`, weight kept in `legacy`.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/<ts>_idea_votes.sql` | `idea_votes` table + RLS + `idea_vote_totals` view |
+| `supabase/tests/database/idea_votes_test.sql` | pgTAP for every policy + the view |
+| `scripts/etl/transform.ts` (extend) | `ideaRef`/`answerRef`, `toComment`, `commentReplies`, `toInterest`, `toAnswerFromResult`, `toAnswerArtifact`, `toVote`, `dedupeVotes` |
+| `scripts/etl/emit.ts` (extend) | v2 column lists + `buildDocumentV2` |
+| `scripts/etl/restore-v2.ts` | CLI: backup → parse → transform → `restore-v2.generated.sql` |
+| `src/lib/votes.ts` + `votes.test.ts` | pure score-merge + top-sort helpers |
+| `src/lib/components/VoteControl.svelte` | ▲ score ▼ control (form actions + enhance) |
+| `src/routes/ideas/[id]/+page.server.ts` (extend) | vote totals + my vote in load; `vote`/`unvote` actions |
+| `src/routes/ideas/[id]/+page.svelte` (extend) | mount VoteControl |
+| `src/routes/ideas/+page.server.ts` (rewrite load) | `?sort=top` + scores on cards |
+| `src/routes/ideas/+page.svelte` (extend) | sort link-nav (mirrors the type filter) |
+| `src/lib/components/IdeaCard.svelte` (extend) | optional score chip |
+
+---
+
+## Task 1: `idea_votes` migration + pgTAP
+
+**Files:**
+- Create: `supabase/migrations/<generated>_idea_votes.sql` (via `supabase migration new idea_votes` — never invent the filename)
+- Create: `supabase/tests/database/idea_votes_test.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `supabase migration new idea_votes` → note the generated path. Content:
+
+```sql
+-- ============ idea_votes (one up/down vote per member per idea; toggle = delete + re-insert) ============
+create table public.idea_votes (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade, -- a vote without a voter is meaningless
+  value      smallint not null check (value in (-1, 1)),
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (idea_id, profile_id)
+);
+alter table public.idea_votes enable row level security;
+create index idea_votes_idea_id_idx on public.idea_votes (idea_id);
+create index idea_votes_profile_id_idx on public.idea_votes (profile_id);
+
+-- SELECT: readable when the idea is visible (leverages ideas RLS) OR it is the caller's own vote
+create policy "votes readable when idea visible or own" on public.idea_votes for select
+  using (
+    (select auth.uid()) = profile_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: a member casts their OWN vote on a visible idea; legacy pinned (service-role-only)
+create policy "members vote on visible ideas" on public.idea_votes for insert to authenticated
+  with check (
+    (select auth.uid()) = profile_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: a member removes their own vote
+create policy "member removes own vote" on public.idea_votes for delete to authenticated
+  using ((select auth.uid()) = profile_id);
+-- NOTE: no UPDATE policy — switching a vote is delete + re-insert (same toggle pattern as interest).
+
+-- ============ idea_vote_totals (security_invoker: respects the caller's idea visibility) ============
+create view public.idea_vote_totals
+  with (security_invoker = true) as
+  select
+    idea_id,
+    coalesce(sum(value), 0)::bigint           as score,
+    count(*) filter (where value = 1)         as up_count,
+    count(*) filter (where value = -1)        as down_count
+  from public.idea_votes
+  group by idea_id;
+```
+
+(The `value` check lives on the table constraint only — a single deterministic error source; the policy pins identity/visibility/legacy.)
+
+- [ ] **Step 2: Write the failing pgTAP test** `supabase/tests/database/idea_votes_test.sql` (conventions per `comments_interest_test.sql`: the `handle_new_user` trigger auto-creates profiles)
+
+```sql
+begin;
+select plan(14);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),  -- expert author
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','44444444-4444-4444-4444-444444444444','authenticated','authenticated','dave@example.com','x', now(), now(), now());
+
+insert into public.experts (id, status) values ('11111111-1111-1111-1111-111111111111','approved');
+insert into public.ideas (id, author_id, type, title, status) values
+  ('a0000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','open_ended','Open idea','open'),
+  ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','open_ended','Draft idea','draft');
+
+set local role authenticated;
+
+-- ===== bob votes (insert pinning) =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1);
+select ok((select count(*) from public.idea_votes) = 1, '1: member upvotes a visible idea');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','44444444-4444-4444-4444-444444444444',1) $$,
+  '42501', null, '2: cannot vote as another member');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222',1) $$,
+  '42501', null, '3: cannot vote on a draft idea you cannot see');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value, legacy_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1,7) $$,
+  '42501', null, '4: cannot set legacy_id on a live vote');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1,'{"a":1}'::jsonb) $$,
+  '42501', null, '5: cannot set a non-empty legacy on a live vote');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',0) $$,
+  '23514', null, '6: value must be -1 or 1');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',-1) $$,
+  '23505', null, '7: one vote per member per idea (switch = delete + re-insert)');
+
+-- ===== dave downvotes; deletes are own-only =====
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','44444444-4444-4444-4444-444444444444',-1);
+select ok((select count(*) from public.idea_votes) = 2, '8: second member downvotes');
+delete from public.idea_votes where profile_id = '22222222-2222-2222-2222-222222222222';
+select ok((select count(*) from public.idea_votes) = 2, '9: deleting another member''s vote is a no-op');
+select results_eq(
+  $$ select score, up_count, down_count from public.idea_vote_totals where idea_id = 'a0000000-0000-0000-0000-000000000001' $$,
+  $$ values (0::bigint, 1::bigint, 1::bigint) $$,
+  '10: totals view aggregates score/up/down');
+delete from public.idea_votes where profile_id = '44444444-4444-4444-4444-444444444444';
+select ok((select count(*) from public.idea_votes where profile_id = '44444444-4444-4444-4444-444444444444') = 0,
+  '11: member removes own vote');
+
+-- ===== draft visibility (author can vote own draft; others see nothing) =====
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111',1);
+select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000-0000-0000-000000000002') = 1,
+  '12: draft author can vote their own draft');
+
+set local role anon;
+select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000-0000-0000-000000000001') = 1,
+  '13: anon sees votes on visible ideas');
+select ok((select count(*) from public.idea_vote_totals where idea_id = 'a0000000-0000-0000-0000-000000000002') = 0,
+  '14: draft votes invisible to anon through the view (security_invoker)');
+
+select * from finish();
+rollback;
+```
+
+- [ ] **Step 3: Run** `supabase db reset` (applies the migration) then `supabase test db` → expect `idea_votes_test` 14/14 plus all existing suites still green (96 + 14).
+- [ ] **Step 4: Commit** `git add supabase/migrations supabase/tests/database/idea_votes_test.sql && git commit -m "feat(votes): idea_votes table + RLS + totals view + pgTAP"`
+
+---
+
+## Task 2: v2 transforms
+
+**Files:**
+- Modify: `scripts/etl/transform.ts` (append)
+- Modify: `scripts/etl/transform.test.ts` (append)
+
+- [ ] **Step 1: Write the failing tests** (append to `scripts/etl/transform.test.ts`)
+
+```ts
+import {
+  ideaRef, answerRef, toComment, commentReplies, toInterest,
+  toAnswerFromResult, toAnswerArtifact, toVote, dedupeVotes
+} from './transform';
+
+describe('v2 ref helpers', () => {
+  it('emit integer-validated scalar subqueries', () => {
+    expect(ideaRef('14')).toBe("(select id from public.ideas where legacy_id = 14)");
+    expect(answerRef('3')).toBe("(select id from public.answers where legacy_id = 3)");
+    expect(() => ideaRef('14; drop table x')).toThrow();
+    expect(() => ideaRef(null)).toThrow();
+  });
+});
+
+describe('v2 transforms', () => {
+  it('toComment maps body/author and keeps reply/anon/upvotes in legacy', () => {
+    const c = toComment({ id: '96', created_at: '2022-06-30 06:41:09+00', idea: '16',
+      author: '0ab224d1-75b6-44e5-b868-26018ca607fe', text: 'Yes!', reply_to: '69',
+      anon_author: null, anon_author_url: null, upvotes: '2' });
+    expect(c.legacy_id).toBe("'96'");
+    expect(c.idea_id).toBe("(select id from public.ideas where legacy_id = 16)");
+    expect(c.author_id).toBe("'0ab224d1-75b6-44e5-b868-26018ca607fe'");
+    expect(c.body_md).toBe("'Yes!'");
+    expect(c.legacy).toContain('"reply_to":"69"');
+    expect(c.legacy).toContain('"upvotes":"2"');
+    expect(c.reply_to).toBeUndefined();           // threading is pass-2
+  });
+  it('toComment keeps empty text as empty string and null author as NULL', () => {
+    const c = toComment({ id: '175', created_at: '2023-07-07 15:24:15+00', idea: '242',
+      author: null, text: '', reply_to: null, anon_author: null, anon_author_url: null, upvotes: null });
+    expect(c.body_md).toBe("''");
+    expect(c.author_id).toBe('NULL');
+  });
+  it('commentReplies returns only rows with reply_to', () => {
+    const rows = [
+      { id: '96', reply_to: '69' }, { id: '97', reply_to: null }
+    ] as any[];
+    expect(commentReplies(rows)).toEqual([{ legacy_id: '96', reply_legacy_id: '69' }]);
+  });
+  it('toInterest maps how→note_md (blank→NULL) and contact flag→legacy', () => {
+    const i = toInterest({ id: '14', created_at: '2022-06-14 12:14:29+00',
+      user: '3590e5a9-da55-49f8-9d61-726c0b0203fe', idea: '18', contact_if_started: 'f', how: '' });
+    expect(i.note_md).toBe('NULL');
+    expect(i.profile_id).toBe("'3590e5a9-da55-49f8-9d61-726c0b0203fe'");
+    expect(i.legacy).toContain('"contact_if_started":"f"');
+  });
+  it('toAnswerFromResult maps to a verified answer with a title fallback', () => {
+    const titles = new Map([['14', 'Old idea title']]);
+    const a = toAnswerFromResult({ id: '3', created_at: '2022-11-21 12:05:13+00', idea: '14',
+      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', description: '', image_link: 'http://img',
+      type: 'ambiguous', title: '', author: 'COCO, Nina', link: 'http://itch.io/x',
+      from_date: '2022-11-13', original: 'f' }, titles);
+    expect(a.title).toBe("'Result: Old idea title'");
+    expect(a.status).toBe("'verified'");
+    expect(a.verified_at).toBe("'2022-11-21 12:05:13+00'");
+    expect(a.explanation_md).toBe('NULL');
+    expect(a.legacy).toContain('"author":"COCO, Nina"');
+  });
+  it('toAnswerArtifact emits a url artifact only when link is non-blank', () => {
+    const art = toAnswerArtifact({ id: '3', created_at: 'x', link: 'http://itch.io/x' } as any);
+    expect(art!.answer_id).toBe("(select id from public.answers where legacy_id = 3)");
+    expect(art!.kind).toBe("'url'");
+    expect(toAnswerArtifact({ id: '9', created_at: 'x', link: '' } as any)).toBeNull();
+  });
+  it('toVote maps a like to an upvote, weight in legacy', () => {
+    const v = toVote({ id: '7', created_at: '2022-07-01 00:00:00+00',
+      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', idea: '14', size: '3' });
+    expect(v.value).toBe('1');
+    expect(v.legacy).toContain('"size":"3"');
+  });
+  it('dedupeVotes keeps the earliest per (user, idea)', () => {
+    const { kept, dropped } = dedupeVotes([
+      { id: '2', created_at: '2022-02-01', user: 'u1', idea: '5', size: '1' },
+      { id: '1', created_at: '2022-01-01', user: 'u1', idea: '5', size: '1' },
+      { id: '3', created_at: '2022-03-01', user: 'u2', idea: '5', size: '1' }
+    ] as any[]);
+    expect(kept.map((r: any) => r.id)).toEqual(['1', '3']);
+    expect(dropped).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** `npx vitest run scripts/etl/transform.test.ts` → FAIL (missing exports).
+
+- [ ] **Step 3: Implement** (append to `scripts/etl/transform.ts`)
+
+```ts
+// ───────────────────────────── Restore v2 ─────────────────────────────
+
+/** Scalar-subquery ref against a legacy_id anchor. Validates the id is an integer (never interpolate dump text). */
+function legacyRef(table: string, legacyId: string | null | undefined): string {
+  const n = Number(legacyId);
+  if (legacyId == null || !Number.isInteger(n)) throw new Error(`invalid legacy id for ${table}`);
+  return `(select id from public.${table} where legacy_id = ${n})`;
+}
+export const ideaRef = (legacyId: string | null | undefined) => legacyRef('ideas', legacyId);
+export const answerRef = (legacyId: string | null | undefined) => legacyRef('answers', legacyId);
+export const commentRef = (legacyId: string | null | undefined) => legacyRef('comments', legacyId);
+
+/** old `public.comments` → new `public.comments` (spec §5). reply_to is set in pass 2 (see commentReplies). */
+export function toComment(c: Row): SqlRow {
+  return {
+    legacy_id: lit(c.id),
+    idea_id: ideaRef(c.idea),
+    author_id: lit(c.author ?? null),
+    body_md: lit(c.text ?? ''),                       // empty-text rows are real thread anchors — keep ''
+    legacy: jsonbLit({
+      reply_to: c.reply_to ?? undefined,
+      anon_author: c.anon_author ?? undefined,
+      anon_author_url: c.anon_author_url ?? undefined,
+      upvotes: c.upvotes ?? undefined
+    }),
+    created_at: lit(c.created_at ?? null)
+  };
+}
+
+/** The (child, parent) legacy-id pairs that need the pass-2 reply_to update. */
+export function commentReplies(rows: Row[]): { legacy_id: string; reply_legacy_id: string }[] {
+  return rows
+    .filter((r) => r.reply_to != null && r.id != null)
+    .map((r) => ({ legacy_id: r.id as string, reply_legacy_id: r.reply_to as string }));
+}
+
+/** old `idea_user_interest_relation` → `public.interest` (spec §5). */
+export function toInterest(r: Row): SqlRow {
+  return {
+    legacy_id: lit(r.id),
+    idea_id: ideaRef(r.idea),
+    profile_id: lit(r.user ?? null),
+    note_md: lit(nullifBlank(r.how)),
+    legacy: jsonbLit({ contact_if_started: r.contact_if_started ?? undefined }),
+    created_at: lit(r.created_at ?? null)
+  };
+}
+
+/** old `results` → `public.answers` as verified historical outputs (spec §5). `titles` = old idea id → title. */
+export function toAnswerFromResult(r: Row, titles: Map<string, string>): SqlRow {
+  const title = nullifBlank(r.title) ?? `Result: ${(r.idea != null && titles.get(r.idea)) || 'untitled idea'}`;
+  return {
+    legacy_id: lit(r.id),
+    idea_id: ideaRef(r.idea),
+    submitter_id: lit(r.user ?? null),
+    title: lit(title),
+    explanation_md: lit(nullifBlank(r.description)),
+    status: lit('verified'),
+    verified_at: lit(r.created_at ?? null),           // old table names no verifier; verified_by stays NULL
+    legacy: jsonbLit({
+      author: r.author ?? undefined,
+      image_link: nullifBlank(r.image_link) ?? undefined,
+      type: r.type ?? undefined,
+      link: nullifBlank(r.link) ?? undefined,
+      from_date: r.from_date ?? undefined,
+      original: r.original ?? undefined
+    }),
+    created_at: lit(r.created_at ?? null)
+  };
+}
+
+/** One `answer_artifacts` row per result with a non-blank link; null otherwise. */
+export function toAnswerArtifact(r: Row): SqlRow | null {
+  const url = nullifBlank(r.link);
+  if (!url) return null;
+  return {
+    legacy_id: lit(r.id),
+    answer_id: answerRef(r.id),
+    kind: lit('url'),
+    url: lit(url),
+    created_at: lit(r.created_at ?? null)
+  };
+}
+
+/** old `idea_user_likes` → `public.idea_votes` as upvotes; old weight kept in legacy (spec §5). */
+export function toVote(l: Row): SqlRow {
+  return {
+    legacy_id: lit(l.id),
+    idea_id: ideaRef(l.idea),
+    profile_id: lit(l.user ?? null),
+    value: '1',
+    legacy: jsonbLit({ size: l.size ?? undefined }),
+    created_at: lit(l.created_at ?? null)
+  };
+}
+
+/** Guard for `unique (idea_id, profile_id)`: keep the earliest like per (user, idea). */
+export function dedupeVotes(rows: Row[]): { kept: Row[]; dropped: number } {
+  const sorted = [...rows].sort((a, b) => String(a.created_at ?? '').localeCompare(String(b.created_at ?? '')));
+  const seen = new Set<string>();
+  const kept: Row[] = [];
+  for (const r of sorted) {
+    const key = `${r.user}|${r.idea}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push(r);
+  }
+  return { kept, dropped: rows.length - kept.length };
+}
+```
+
+- [ ] **Step 4: Run** `npx vitest run scripts/etl/transform.test.ts` → PASS (all v1 tests must stay green).
+- [ ] **Step 5: Commit** `git add scripts/etl/transform.ts scripts/etl/transform.test.ts && git commit -m "feat(etl): v2 transforms (comments/interest/answers/votes) with legacy-ref subqueries"`
+
+---
+
+## Task 3: v2 emitter + CLI
+
+**Files:**
+- Modify: `scripts/etl/emit.ts` (append)
+- Modify: `scripts/etl/emit.test.ts` (append)
+- Create: `scripts/etl/restore-v2.ts`
+- Modify: `package.json` (add script)
+
+- [ ] **Step 1: Write the failing tests** (append to `scripts/etl/emit.test.ts`)
+
+```ts
+import { buildDocumentV2 } from './emit';
+
+describe('buildDocumentV2', () => {
+  const data = {
+    comments: [{ legacy_id: "'96'" }],
+    replies: [{ legacy_id: '96', reply_legacy_id: '69' }],
+    interest: [{ legacy_id: "'14'" }],
+    answers: [{ legacy_id: "'3'" }],
+    artifacts: [{ legacy_id: "'3'" }],
+    votes: [{ legacy_id: "'7'" }]
+  } as any;
+
+  it('wraps in a transaction with the replica bracket and ends with assertions', () => {
+    const doc = buildDocumentV2(data);
+    expect(doc.startsWith('begin;')).toBe(true);
+    expect(doc).toContain('set session_replication_role = replica;');
+    expect(doc).toContain('set session_replication_role = origin;');
+    expect(doc).toMatch(/do \$\$[\s\S]*assert[\s\S]*\$\$/);
+    expect(doc).toContain('orphan comment author');
+    expect(doc).toContain('orphan reply_to');
+    expect(doc.trim().endsWith('commit;')).toBe(true);
+  });
+
+  it('orders inserts comments → replies-update → interest → answers → artifacts → votes', () => {
+    const doc = buildDocumentV2(data);
+    const order = [
+      'insert into public.comments',
+      'update public.comments',
+      'insert into public.interest',
+      'insert into public.answers',
+      'insert into public.answer_artifacts',
+      'insert into public.idea_votes'
+    ].map((s) => doc.indexOf(s));
+    expect(order.every((n) => n >= 0)).toBe(true);
+    for (let k = 1; k < order.length; k++) expect(order[k - 1]).toBeLessThan(order[k]);
+  });
+
+  it('emits idempotent reply updates guarded by "reply_to is null"', () => {
+    const doc = buildDocumentV2(data);
+    expect(doc).toContain(
+      'update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = 69)\n' +
+      'where c.legacy_id = 96 and c.reply_to is null;'
+    );
+  });
+
+  it('uses on conflict (legacy_id) everywhere and >= count assertions', () => {
+    const doc = buildDocumentV2(data);
+    expect(doc).toContain('on conflict (legacy_id) do nothing');
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.comments\) >= \d+/);
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.idea_votes\) >= \d+/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** `npx vitest run scripts/etl/emit.test.ts` → FAIL (`buildDocumentV2` missing).
+
+- [ ] **Step 3: Implement** (append to `scripts/etl/emit.ts`)
+
+```ts
+/** v2 target column lists (only columns the ETL sets; defaults cover the rest). */
+export const COMMENTS_COLUMNS = ['legacy_id', 'idea_id', 'author_id', 'body_md', 'legacy', 'created_at'] as const;
+export const INTEREST_COLUMNS = ['legacy_id', 'idea_id', 'profile_id', 'note_md', 'legacy', 'created_at'] as const;
+export const ANSWERS_COLUMNS = ['legacy_id', 'idea_id', 'submitter_id', 'title', 'explanation_md', 'status', 'verified_at', 'legacy', 'created_at'] as const;
+export const ARTIFACTS_COLUMNS = ['legacy_id', 'answer_id', 'kind', 'url', 'created_at'] as const;
+export const VOTES_COLUMNS = ['legacy_id', 'idea_id', 'profile_id', 'value', 'legacy', 'created_at'] as const;
+
+export type EmitDataV2 = {
+  comments: SqlRow[];
+  replies: { legacy_id: string; reply_legacy_id: string }[];
+  interest: SqlRow[];
+  answers: SqlRow[];
+  artifacts: SqlRow[];
+  votes: SqlRow[];
+};
+
+/**
+ * Restore-v2 document (spec §4): begin → replica → comments → reply updates → interest → answers
+ * → artifacts → idea_votes → origin → count + orphan assertions → commit. Idempotent throughout
+ * (`on conflict (legacy_id) do nothing`; reply updates guarded by `reply_to is null`).
+ * Idea/answer FKs are scalar subqueries on legacy_id, resolved at apply time (see transform.ts refs).
+ */
+export function buildDocumentV2(data: EmitDataV2): string {
+  const parts: string[] = [];
+  parts.push('begin;');
+  parts.push('set session_replication_role = replica;');
+
+  parts.push(insertRows('public.comments', [...COMMENTS_COLUMNS], data.comments, 'legacy_id'));
+  parts.push(
+    data.replies
+      .map((r) => {
+        const child = Number(r.legacy_id);
+        const parent = Number(r.reply_legacy_id);
+        if (!Number.isInteger(child) || !Number.isInteger(parent)) throw new Error('invalid reply pair');
+        return (
+          `update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = ${parent})\n` +
+          `where c.legacy_id = ${child} and c.reply_to is null;`
+        );
+      })
+      .join('\n')
+  );
+  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest, 'legacy_id'));
+  parts.push(insertRows('public.answers', [...ANSWERS_COLUMNS], data.answers, 'legacy_id'));
+  parts.push(insertRows('public.answer_artifacts', [...ARTIFACTS_COLUMNS], data.artifacts, 'legacy_id'));
+  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes, 'legacy_id'));
+
+  parts.push('set session_replication_role = origin;');
+
+  // counts (>= so re-runs never trip) + orphan scans (FK checks were deferred under replica)
+  parts.push(
+    [
+      'do $$ begin',
+      "  assert (select count(*) from public.comments) >= 83, 'comments count too low';",
+      "  assert (select count(*) from public.interest) >= 133, 'interest count too low';",
+      "  assert (select count(*) from public.answers) >= 5, 'answers count too low';",
+      "  assert (select count(*) from public.answer_artifacts) >= 5, 'artifacts count too low';",
+      "  assert (select count(*) from public.idea_votes) >= 387, 'votes count too low';",
+      "  assert (select count(*) from public.comments where reply_to is not null) >= 13, 'reply links too low';",
+      '  assert (select count(*) from public.comments c left join public.profiles p on p.id = c.author_id',
+      "          where c.author_id is not null and p.id is null) = 0, 'orphan comment author';",
+      '  assert (select count(*) from public.comments c left join public.comments p on p.id = c.reply_to',
+      "          where c.reply_to is not null and p.id is null) = 0, 'orphan reply_to';",
+      '  assert (select count(*) from public.interest i left join public.profiles p on p.id = i.profile_id',
+      "          where i.profile_id is not null and p.id is null) = 0, 'orphan interest profile';",
+      '  assert (select count(*) from public.answers a left join public.profiles p on p.id = a.submitter_id',
+      "          where a.submitter_id is not null and p.id is null) = 0, 'orphan answer submitter';",
+      '  assert (select count(*) from public.idea_votes v left join public.profiles p on p.id = v.profile_id',
+      "          where p.id is null) = 0, 'orphan vote profile';",
+      'end $$;'
+    ].join('\n')
+  );
+
+  parts.push('commit;');
+  return parts.filter((p) => p.trim() !== '').join('\n\n') + '\n';
+}
+```
+
+- [ ] **Step 4: Implement the CLI** `scripts/etl/restore-v2.ts`
+
+```ts
+/**
+ * Restore-v2 CLI — comments / interest / results→answers(+artifacts) / likes→votes.
+ * Prints COUNTS only (never row contents) — backup + generated SQL contain PII (gitignored).
+ *
+ * Usage: `npm run etl:restore-v2 [path/to/backup]`
+ * (Controller-only against the real backup; subagents use synthetic fixtures.)
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseCopyBlock } from './parse-dump';
+import * as t from './transform';
+import { buildDocumentV2 } from './emit';
+
+const BACKUP = process.argv[2] ?? `${process.env.HOME}/Downloads/db_cluster-16-10-2025@02-48-41.backup`;
+const OUT = new URL('./restore-v2.generated.sql', import.meta.url).pathname;
+
+function main() {
+  const dump = readFileSync(BACKUP, 'utf8');
+
+  const commentsRaw = parseCopyBlock(dump, 'public.comments').rows;
+  const interestRaw = parseCopyBlock(dump, 'public.idea_user_interest_relation').rows;
+  const resultsRaw = parseCopyBlock(dump, 'public.results').rows;
+  const likesRaw = parseCopyBlock(dump, 'public.idea_user_likes').rows;
+  const ideasRaw = parseCopyBlock(dump, 'public.ideas').rows;   // only for the answer-title fallback
+
+  const titles = new Map<string, string>();
+  for (const i of ideasRaw) if (i.id && i.title) titles.set(i.id, i.title);
+
+  const comments = commentsRaw.map((c) => t.toComment(c));
+  const replies = t.commentReplies(commentsRaw);
+  const interest = interestRaw.map((r) => t.toInterest(r));
+  const answers = resultsRaw.map((r) => t.toAnswerFromResult(r, titles));
+  const artifacts = resultsRaw.map((r) => t.toAnswerArtifact(r)).filter((a): a is NonNullable<typeof a> => a !== null);
+  const { kept, dropped } = t.dedupeVotes(likesRaw);
+  const votes = kept.map((l) => t.toVote(l));
+
+  writeFileSync(OUT, buildDocumentV2({ comments, replies, interest, answers, artifacts, votes }), 'utf8');
+
+  // COUNTS ONLY — never row contents (PII discipline).
+  console.log(
+    `wrote ${OUT}: comments=${comments.length} replies=${replies.length} interest=${interest.length} ` +
+      `answers=${answers.length} artifacts=${artifacts.length} votes=${votes.length} (deduped ${dropped})`
+  );
+}
+
+main();
+```
+
+In `package.json` `scripts` add: `"etl:restore-v2": "tsx scripts/etl/restore-v2.ts"`.
+
+- [ ] **Step 5: Run** `npx vitest run scripts/etl` → all green (v1 + v2). `npm run check` → 0 errors.
+- [ ] **Step 6: Commit** `git add scripts/etl/emit.ts scripts/etl/emit.test.ts scripts/etl/restore-v2.ts package.json && git commit -m "feat(etl): v2 emitter + restore-v2 CLI"`
+
+---
+
+## Task 4: Vote UI + sort-by-score
+
+**Files:**
+- Create: `src/lib/votes.ts`, `src/lib/votes.test.ts`, `src/lib/components/VoteControl.svelte`
+- Modify: `src/lib/components/IdeaCard.svelte`, `src/routes/ideas/+page.server.ts`, `src/routes/ideas/+page.svelte`, `src/routes/ideas/[id]/+page.server.ts`, `src/routes/ideas/[id]/+page.svelte`
+
+- [ ] **Step 1: Write the failing test** `src/lib/votes.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { attachScores, sortTop } from './votes';
+
+describe('votes helpers', () => {
+  it('attachScores joins totals onto ideas, defaulting 0', () => {
+    const out = attachScores(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ idea_id: 'b', score: 5 }]
+    );
+    expect(out).toEqual([{ id: 'a', score: 0 }, { id: 'b', score: 5 }]);
+  });
+  it('sortTop orders by score desc, then created_at desc', () => {
+    const out = sortTop([
+      { id: 'a', score: 1, created_at: '2024-01-01' },
+      { id: 'b', score: 5, created_at: '2023-01-01' },
+      { id: 'c', score: 1, created_at: '2025-01-01' }
+    ]);
+    expect(out.map((r) => r.id)).toEqual(['b', 'c', 'a']);
+  });
+});
+```
+
+- [ ] **Step 2: Implement** `src/lib/votes.ts`
+
+```ts
+export type VoteTotal = { idea_id: string; score: number };
+
+/** Join vote totals onto idea rows; ideas without votes get score 0 (the view omits them). */
+export function attachScores<T extends { id: string }>(
+  ideas: T[],
+  totals: VoteTotal[]
+): (T & { score: number })[] {
+  const byIdea = new Map(totals.map((t) => [t.idea_id, t.score]));
+  return ideas.map((i) => ({ ...i, score: byIdea.get(i.id) ?? 0 }));
+}
+
+/** Score desc, ties broken by created_at desc. */
+export function sortTop<T extends { score: number; created_at?: string | null }>(rows: T[]): T[] {
+  return [...rows].sort(
+    (a, b) => b.score - a.score || String(b.created_at ?? '').localeCompare(String(a.created_at ?? ''))
+  );
+}
+```
+
+Run `npx vitest run src/lib/votes.test.ts` → PASS.
+
+- [ ] **Step 3: VoteControl component** `src/lib/components/VoteControl.svelte`
+
+```svelte
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  let { score, myVote, canVote }: { score: number; myVote: 1 | -1 | null; canVote: boolean } = $props();
+</script>
+<div class="flex items-center gap-1.5 rounded-xl border px-2 py-1"
+     style="border-color:var(--line); background:var(--surface)">
+  <form method="POST" action={myVote === 1 ? '?/unvote' : '?/vote'} use:enhance>
+    <input type="hidden" name="value" value="1" />
+    <button class="px-1 transition disabled:opacity-40" disabled={!canVote} aria-label="Upvote"
+            aria-pressed={myVote === 1}
+            style="color:{myVote === 1 ? 'var(--green-deep)' : 'var(--muted)'}">▲</button>
+  </form>
+  <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{score}</span>
+  <form method="POST" action={myVote === -1 ? '?/unvote' : '?/vote'} use:enhance>
+    <input type="hidden" name="value" value="-1" />
+    <button class="px-1 transition disabled:opacity-40" disabled={!canVote} aria-label="Downvote"
+            aria-pressed={myVote === -1}
+            style="color:{myVote === -1 ? 'var(--neg)' : 'var(--muted)'}">▼</button>
+  </form>
+</div>
+```
+
+(Active upvote = `--green-deep` small mark; active downvote = `--neg`, the semantic negative. `use:enhance` re-runs the load after the action — no full reload. If signed out the buttons are disabled; the page already exposes a sign-in link with `?next=`.)
+
+- [ ] **Step 4: Idea detail — load + actions.** In `src/routes/ideas/[id]/+page.server.ts`:
+
+To the `load`, after the interest block, add:
+
+```ts
+  // votes: totals + the caller's own vote
+  const { data: voteTotals } = await supabase
+    .from('idea_vote_totals').select('score').eq('idea_id', idea.id).maybeSingle();
+  let myVote: 1 | -1 | null = null;
+  if (user) {
+    const { data: mv } = await supabase
+      .from('idea_votes').select('value').eq('idea_id', idea.id).eq('profile_id', user.id).maybeSingle();
+    myVote = (mv?.value as 1 | -1 | undefined) ?? null;
+  }
+```
+
+and to the returned object add: `score: voteTotals?.score ?? 0, myVote,`.
+
+To `actions` add:
+
+```ts
+  vote: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to vote' });
+    const fd = await request.formData();
+    const value = Number(fd.get('value'));
+    if (value !== 1 && value !== -1) return fail(400, { message: 'Invalid vote' });
+    // switch = delete own row first (no UPDATE policy), then insert; a 23505 race means a vote
+    // already landed — treat as ok (the page re-load shows the truth)
+    await supabase.from('idea_votes').delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    const { error: e } = await supabase.from('idea_votes').insert({
+      idea_id: params.id, profile_id: user.id, value
+    });
+    if (e && (e as { code?: string }).code !== '23505') return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  unvote: async ({ params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const { error: e } = await supabase.from('idea_votes')
+      .delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    if (e) return fail(400, { message: e.message });
+    return { ok: true };
+  },
+```
+
+- [ ] **Step 5: Mount the control.** In `src/routes/ideas/[id]/+page.svelte`, import `VoteControl` and render it in the header row next to the title/status:
+
+```svelte
+<VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage} />
+```
+
+(Match the file's existing header layout — place it inside the same flex row as the `StatusBadge`.)
+
+- [ ] **Step 6: Browse page — sort + scores.** Replace `src/routes/ideas/+page.server.ts` with:
+
+```ts
+import type { PageServerLoad } from './$types';
+import { attachScores, sortTop } from '$lib/votes';
+
+const PAGE = 24;
+export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
+  const type = url.searchParams.get('type');       // 'hypothesis' | 'open_ended' | null
+  const sort = url.searchParams.get('sort') === 'top' ? 'top' : 'new';
+  const page = Math.max(0, Number(url.searchParams.get('page') ?? 0));
+
+  // vote totals are small (≤ #ideas rows) — fetch once, used by both sorts for the card scores
+  const { data: totals } = await supabase.from('idea_vote_totals').select('idea_id, score');
+
+  let base = supabase
+    .from('ideas')
+    .select('id, title, summary_md, type, status, created_at', { count: 'exact' })
+    .neq('status', 'draft');
+  if (type === 'hypothesis' || type === 'open_ended') base = base.eq('type', type);
+
+  if (sort === 'top') {
+    // global sort by score needs the whole (small) set; slice the page in memory
+    const { data: all } = await base.order('created_at', { ascending: false });
+    const ranked = sortTop(attachScores(all ?? [], totals ?? []));
+    return {
+      ideas: ranked.slice(page * PAGE, (page + 1) * PAGE),
+      count: ranked.length, page, pageSize: PAGE, type, sort
+    };
+  }
+
+  const { data: ideas, count } = await base
+    .order('created_at', { ascending: false })
+    .range(page * PAGE, page * PAGE + PAGE - 1);
+  return {
+    ideas: attachScores(ideas ?? [], totals ?? []),
+    count: count ?? 0, page, pageSize: PAGE, type, sort
+  };
+};
+```
+
+- [ ] **Step 7: Browse page markup.** In `src/routes/ideas/+page.svelte`, add a sort nav under the type nav (mirroring its link pattern), and thread `sort` through the pagination links:
+
+```svelte
+<nav class="mb-6 -mt-4 flex gap-2 text-sm">
+  <a href="/ideas{data.type ? `?type=${data.type}` : ''}"
+     style="color:{data.sort === 'top' ? 'var(--muted)' : 'var(--green-deep)'}">Newest</a>
+  <a href="/ideas?{data.type ? `type=${data.type}&` : ''}sort=top"
+     style="color:{data.sort === 'top' ? 'var(--green-deep)' : 'var(--muted)'}">Top</a>
+</nav>
+```
+
+Pagination hrefs become `/ideas?{data.type ? `type=${data.type}&` : ''}{data.sort === 'top' ? 'sort=top&' : ''}page={…}`.
+
+In `src/lib/components/IdeaCard.svelte`, extend the prop type with `score?: number` and add next to the `StatusBadge`:
+
+```svelte
+{#if typeof idea.score === 'number'}
+  <span class="text-xs font-semibold tabular-nums" style="color:var(--muted)">▲ {idea.score}</span>
+{/if}
+```
+
+- [ ] **Step 8: Update the browse-load test.** `src/routes/ideas/ideas.test.ts`'s `mkLocals` must now serve two queries (`idea_vote_totals` and `ideas`). Replace the file with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { load } from './+page.server';
+
+function mkLocals(rows: unknown[], totals: unknown[] = []) {
+  const make = (table: string): any => {
+    if (table === 'idea_vote_totals') return { select: () => Promise.resolve({ data: totals }) };
+    // thenable builder: serves both `…order().range()` (new) and a directly-awaited `…order()` (top)
+    const result = { data: rows, count: rows.length };
+    const builder: any = {
+      select() { return this; }, neq() { return this; }, eq() { return this; }, order() { return this; },
+      range() { return Promise.resolve(result); },
+      then(resolve: any, reject: any) { return Promise.resolve(result).then(resolve, reject); }
+    };
+    return builder;
+  };
+  return { supabase: { from: (t: string) => make(t) } } as any;
+}
+
+describe('ideas browse load', () => {
+  it('returns ideas + count with scores attached', async () => {
+    const res = (await load({
+      url: new URL('http://x/ideas'),
+      locals: mkLocals([{ id: '1', title: 'A' }], [{ idea_id: '1', score: 3 }])
+    } as any)) as any;
+    expect(res.ideas).toEqual([{ id: '1', title: 'A', score: 3 }]);
+    expect(res.count).toBe(1);
+  });
+  it('sort=top ranks by score desc', async () => {
+    const res = (await load({
+      url: new URL('http://x/ideas?sort=top'),
+      locals: mkLocals(
+        [{ id: '1', created_at: '2024-01-02' }, { id: '2', created_at: '2024-01-01' }],
+        [{ idea_id: '2', score: 9 }]
+      )
+    } as any)) as any;
+    expect(res.ideas.map((i: any) => i.id)).toEqual(['2', '1']);
+  });
+});
+```
+
+Note for the implementer: the `order()` mock above resolves the promise (the real builder is thenable after `.order()` when no `.range()` follows); make the mock match however the final query chain is written — the assertion targets are the returned `ideas`/`count`, not the mock's shape.
+
+- [ ] **Step 9: Run everything.** `npm run check` → 0 errors; `npx vitest run` → all green; `npm run build` → succeeds.
+- [ ] **Step 10: Commit** `git add -A -- src && git commit -m "feat(votes): VoteControl + idea-page voting + /ideas scores & sort-by-top"`
+
+---
+
+## Task 5 (CONTROLLER ONLY — real PII backup, local): rehearse
+
+> A subagent must NOT do this — it reads the real backup. The controller runs it.
+
+- [ ] Generate: `npm run etl:restore-v2` → expect `comments=83 replies=13 interest=133 answers=5 artifacts=5 votes=387 (deduped 0)`.
+- [ ] Fresh local stack: `supabase db reset` (applies the `idea_votes` migration), then apply **v1 first** (its artifact still exists; regenerate with `npm run etl:restore-v1` if not), then v2 — both via
+  `docker exec -i supabase_db_aisafetyideas psql -U postgres -d postgres -v ON_ERROR_STOP=1 < scripts/etl/restore-v<N>.generated.sql > /tmp/restore-v<N>.log 2>&1; echo exit=$?` (capture the exit code directly — never pipe psql into `tail`).
+- [ ] Verify locally:
+  - counts: comments 83 / interest 133 / answers 5 / artifacts 5 / votes 387; `reply_to` set on 13 comments.
+  - orphan scans (same queries as the embedded asserts) → all 0.
+  - spot-check: a threaded comment resolves its parent; an idea's score in `idea_vote_totals` matches its old like count; a verified answer shows on its idea page with its artifact link.
+  - idempotency: re-apply the v2 artifact → `INSERT 0 0` everywhere, `UPDATE 0`, counts unchanged.
+  - UI: `npm run dev` → `/ideas?sort=top` ranks restored ideas by score; idea page shows VoteControl + restored comments/answers.
+- [ ] Confirm `git status` shows `restore-v2.generated.sql` ignored. Do not commit it.
+
+---
+
+## Task 6 (CONTROLLER ONLY — cloud + PII): load to cloud
+
+> Controller-only. Subagents never touch cloud.
+
+- [ ] Apply the `idea_votes` migration to `gjomchhbsbtauzkpyjwa` via MCP `apply_migration`.
+- [ ] **Checkpoint with the owner**, then apply the rehearsed artifact via the Management API over 443 (psql ports are blocked on the owner's network; the artifact must NOT stream through MCP `execute_sql`):
+  `jq -Rs '{query: .}' scripts/etl/restore-v2.generated.sql | curl -sS -m 600 -X POST "https://api.supabase.com/v1/projects/gjomchhbsbtauzkpyjwa/database/query" -H "Authorization: Bearer <fresh owner PAT>" -H "Content-Type: application/json" --data-binary @-` → expect HTTP 201.
+- [ ] Verify on cloud (MCP `execute_sql`): the Task-5 count + orphan queries; expect 83/133/5/5/387 (+ any new organic rows).
+- [ ] Re-run `get_advisors` (security + performance) — expect the accepted baseline only (`idea_vote_totals` is security_invoker; both new FKs are indexed).
+- [ ] Smoke test on the deployed app: `/ideas?sort=top`, a restored comment thread, a verified answer, casting + removing a vote.
+- [ ] Remind the owner to **revoke the PAT** (and rotate the DB password if not already done after v1).
+- [ ] Update project memory: Restore v2 complete (counts) — the old-platform restore is DONE; remaining: post-ETL polish (rate-limiting, verify→payout animation, fuller E2E).
+
+---
+
+## Done-when (Restore v2 acceptance)
+- `supabase test db` green incl. `idea_votes_test` 14/14; `npx vitest run` green (etl + votes + browse); `npm run check` 0 errors; `npm run build` succeeds.
+- `npm run etl:restore-v2` deterministically emits a gitignored artifact (83/13/133/5/5/387 printed).
+- Local rehearsal: embedded asserts pass, orphan scans 0, threading resolved, idempotent re-run, UI shows scores/sort/votes/comments/answers.
+- Cloud: counts verified, advisors at baseline, smoke test passes, PAT revoked.
+- No PII committed; CLI logs counts only.

--- a/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
+++ b/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
@@ -46,7 +46,8 @@ create table public.idea_votes (
 );
 ```
 
-- Indexes: `idea_id`, `profile_id` (covers both FKs; the unique adds `(idea_id, profile_id)`).
+- Indexes: `profile_id` (covers its FK); the `unique (idea_id, profile_id)` doubles as the
+  `idea_id` index (leading column) — no separate idea_id index.
 - **RLS mirrors `interest` exactly:**
   - SELECT: idea visible (leverages ideas RLS via `exists`) **or** own row.
   - INSERT (`to authenticated`): `auth.uid() = profile_id`, `legacy_id is null and

--- a/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
+++ b/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
@@ -1,0 +1,180 @@
+# ETL Restore v2 — Comments, Interest, Answers, Votes (design)
+
+**Date:** 2026-06-06 · **Status:** approved by owner (this session)
+**Depends on:** Restore v1 (merged PR #49, applied to cloud 2026-06-06) — all user + idea FK targets exist with `legacy_id` anchors.
+
+## 1. Goal
+
+Restore the remaining community content from the old backup
+(`~/Downloads/db_cluster-16-10-2025@02-48-41.backup`) into the new schema, and ship the
+**idea voting feature** (new `idea_votes` table + RLS + minimal UI) seeded with the old likes.
+
+| Source (old) | Rows | Target (new) | Notes |
+|---|---|---|---|
+| `comments` | 83 | `public.comments` | incl. 13 replies, 7 authorless, 4 empty-text |
+| `idea_user_interest_relation` | 133 | `public.interest` | 0 duplicate (user, idea) pairs |
+| `results` | 5 | `public.answers` (+ `answer_artifacts`) | historical outputs → `status='verified'` |
+| `idea_user_likes` | 387 | `public.idea_votes` (NEW) | each like = one upvote; weight → legacy |
+| `idea_user_funding_relation` | **0** | — | empty; nothing to restore |
+| tail (`saved_projects` 1, `project_results` 1, `collaboration_requests` 1) + cut features (`nodes`, `nodes_ideas`, `superprojects`, `books`, `book_tags`, `achievements`, `problems`, `metrics`, `investments`, `rejections`, `idea_problem_relation`, `idea_superproject_relation`, `idea_user_mentorship_relation`) | — | **skipped** (owner decision) | backup remains the permanent archive |
+
+**Verified source facts (probed 2026-06-06):** referential integrity is perfect — every
+`author`/`user`/`idea` reference in all four source tables resolves against the old `users`
+(265) and `ideas` (238) sets. All 13 comment `reply_to` values point to lower (earlier) ids.
+0 anonymous comments. 387 likes span 202 ideas / 67 users.
+
+## 2. Owner decisions (this session)
+
+1. **Results → verified answers** (not skipped): they are accepted historical outputs.
+2. **Likes → a real up/down-vote feature**: new `idea_votes` table, ETL seeds old likes as
+   upvotes, minimal UI ships in this plan.
+3. **Tail + cut features skipped.**
+4. Each old like = **one upvote** (`value = 1`); the old `size` weight survives in `legacy`.
+
+## 3. New migration: `idea_votes` (+ totals view)
+
+```sql
+create table public.idea_votes (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade, -- a vote without a voter is meaningless
+  value      smallint not null check (value in (-1, 1)),
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (idea_id, profile_id)
+);
+```
+
+- Indexes: `idea_id`, `profile_id` (covers both FKs; the unique adds `(idea_id, profile_id)`).
+- **RLS mirrors `interest` exactly:**
+  - SELECT: idea visible (leverages ideas RLS via `exists`) **or** own row.
+  - INSERT (`to authenticated`): `auth.uid() = profile_id`, `value in (-1,1)` (redundant with
+    the check constraint but keeps the policy self-documenting), `legacy_id is null and
+    legacy = '{}'::jsonb` pinned, idea visible.
+  - DELETE (`to authenticated`): own row.
+  - **No UPDATE** — switching a vote is delete + re-insert (same toggle pattern as `interest`).
+- **`idea_vote_totals` view** (`security_invoker = true`, mirrors `bounty_pot`):
+  `idea_id, score (sum), up_count, down_count` — grouped over `idea_votes`.
+- pgTAP coverage for all policies (vote-as-self ok, vote-as-other denied, legacy pinning,
+  delete-own-only, draft-idea invisible, view respects invoker).
+- Applied to cloud via MCP `apply_migration` **before** the data load (controller step).
+
+## 4. ETL mechanics (`scripts/etl/restore-v2.ts`)
+
+Reuses `parse-dump.ts`, `sql.ts`, `emit.ts` machinery verbatim; new transforms in
+`transform.ts`; a `buildDocumentV2` emitter. Output: gitignored
+`scripts/etl/restore-v2.generated.sql` (covered by the existing `scripts/etl/*.generated.sql`
+ignore). CLI logs **counts only**, never row contents.
+
+**Envelope (same as v1):** `begin;` → `set session_replication_role = replica;` → inserts →
+reply-to update → `set session_replication_role = origin;` → `do $$ … assert … $$;` →
+`commit;`. Every insert `on conflict (legacy_id) do nothing` → idempotent re-runs.
+Applied with fail-loud transport (`psql -v ON_ERROR_STOP=1` locally; Management API for cloud —
+any raised error aborts the whole transaction).
+
+**FK resolution — scalar subqueries, resolved at apply time.** v1 minted the idea UUIDs at
+generation time, so v2 cannot know them statically; instead every idea reference is emitted as
+`(select id from public.ideas where legacy_id = N)`. One artifact therefore works on both the
+local rehearsal stack and cloud, stays idempotent, and a missing parent makes the insert fail
+loudly (null into a `not null` column) instead of silently mis-linking. Profile references stay
+**literal UUIDs** (v1 preserved them verbatim). At ~600 rows the subquery cost is negligible.
+(Rejected alternative: pre-querying the live DB to emit literal UUIDs — couples the artifact to
+one environment and adds a moving part for zero practical gain.)
+
+**Comment threading — two-pass.** A multi-row INSERT cannot see its own rows, so same-statement
+subselects on `comments` would fail. Pass 1 inserts all 83 comments with `reply_to = null`;
+pass 2 is one idempotent
+`update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = <old reply_to>) where c.legacy_id = <id> and c.reply_to is null;`
+per reply row (13 statements).
+
+## 5. Column mappings (unmapped → `legacy` jsonb, lossless)
+
+**comments → public.comments**
+- `id → legacy_id` · `created_at → created_at` · `idea → idea_id` (subquery) ·
+  `author → author_id` (literal uuid; the 7 null-author rows stay null) · `text → body_md`
+  (the 4 empty-text rows are kept as `''` — they are real thread anchors; `body_md` is
+  `not null`, `''` satisfies it) · `reply_to` → pass-2 update.
+- legacy: `{ reply_to (old id), anon_author, anon_author_url, upvotes }` (nulls dropped).
+
+**idea_user_interest_relation → public.interest**
+- `id → legacy_id` · `created_at` · `idea → idea_id` (subquery) · `user → profile_id` ·
+  `how → note_md` (empty string → null).
+- legacy: `{ contact_if_started }`.
+- `unique (idea_id, profile_id)` is safe: 0 duplicate pairs in the source.
+
+**results → public.answers (+ answer_artifacts)**
+- `id → legacy_id` · `created_at → created_at` · `idea → idea_id` (subquery) ·
+  `user → submitter_id` · `title → title`, with fallback for empty titles:
+  `'Result: ' || <old idea title>` (computed at generation time from the parsed ideas block) ·
+  `description → explanation_md` (empty → null) · `status = 'verified'` ·
+  `verified_at = created_at` · `verified_by = null` (the old table names no verifier) ·
+  payout columns null/default (`payout_currency 'USD'`).
+- legacy: `{ author (free-text names), image_link, type, link, from_date, original }`.
+- One `answer_artifacts` row per result with non-empty `link` (**all 5 have one**):
+  `legacy_id` ← old result id (conflict target) · `answer_id` (subquery on
+  `answers.legacy_id`) · `kind = 'url'` · `url = link` · `label = null` ·
+  `created_at` ← result created_at.
+- Note: `answers.updated_at` defaults to now() — acceptable (restore time is the last touch).
+
+**idea_user_likes → public.idea_votes**
+- `id → legacy_id` · `created_at` · `idea → idea_id` (subquery) · `user → profile_id` ·
+  `value = 1`.
+- legacy: `{ size }`.
+- If the source ever held duplicate (user, idea) likes, `unique (idea_id, profile_id)` +
+  `on conflict (legacy_id) do nothing` would still abort (unique violation is a different
+  conflict target) — the transform must **dedupe on (user, idea), keeping the earliest**, and
+  log the dropped count. (Probe says 387 distinct pairs — the dedupe is a guard, not a fix.)
+
+**Assertions (inside the transaction, after `origin`):**
+- counts: `comments >= 83`, `interest >= 133`, `answers >= 5`, `idea_votes >= 387`,
+  `answer_artifacts >= 5`.
+- FK orphan scans (FKs were deferred under replica): comments→ideas/profiles,
+  interest→ideas/profiles, idea_votes→ideas/profiles, answers→ideas/profiles,
+  reply_to→comments, artifacts→answers. All must be 0 broken.
+- replies: `count(reply_to is not null) >= 13`.
+
+## 6. Vote UI (minimal, this plan)
+
+- **Idea detail page:** compact `▲ score ▼` control. Own active vote renders in
+  `--green-deep` (small mark on white, per styleguide §1); inactive arrows `--muted`.
+  Toggle semantics: tap same arrow = remove vote (DELETE); tap other arrow = DELETE +
+  INSERT. Optimistic update, `snappy` spring, interruptible. Signed-out users see the
+  control disabled with a link to `/login?next=<idea>`.
+- **`/ideas` cards:** show the score (read from `idea_vote_totals`, coalesced to 0 in the
+  query layer — the view omits unvoted ideas).
+- No sort-by-score changes in this plan (the data is now there for later ranking work).
+- Server load functions join/fetch totals; mutations via plain supabase inserts/deletes
+  (RLS does the enforcement — no RPCs needed).
+
+## 7. Process & safety (same regime as v1)
+
+- **Subagents:** build on **synthetic fixtures only**; must never read the real backup, touch
+  cloud, or edit `CLAUDE.md`/`docs/`/`.claude/`/`src_legacy_v0/`. Local rehearsal and cloud
+  apply are **controller-only** tasks.
+- **PII:** backup + generated artifact never committed (gitignore already covers
+  `scripts/etl/*.generated.sql`); CLI prints counts only.
+- **Cloud transport:** owner's network blocks outbound 5432/6543 — apply via Supabase
+  Management API `POST /v1/projects/gjomchhbsbtauzkpyjwa/database/query` over 443 (proven in
+  v1; 1MB artifact OK; v2's will be far smaller). Requires a fresh owner PAT (the v1 token is
+  to be revoked); remind the owner to revoke it again afterwards.
+- **Order of operations:** merge PR → MCP `apply_migration` (`idea_votes`) on cloud → local
+  rehearsal (fresh stack: v1 artifact, then migration, then v2 artifact, then idempotency
+  re-run) → cloud apply → cloud count/orphan verification → `get_advisors` re-run (expect:
+  baseline + nothing new; `idea_vote_totals` is security_invoker).
+- **Plan review:** 6-lens adversarial Workflow review of the implementation plan before
+  building (per [[adversarial-plan-review-before-coding]]).
+
+## 8. Risks
+
+- **Local rehearsal needs v1 state first** — the rehearsal sequence above makes v1's artifact a
+  prerequisite; the v1 generated file still exists locally (regenerable from the backup if not).
+- **`answers` insert under RLS-bypass:** inserts run as table owner (`postgres`), bypassing the
+  INSERT policy's pinning (which forbids `status='verified'` + legacy columns) — that is the
+  point: the policy pins *clients*, the ETL is privileged. No policy changes needed.
+- **Verified answers become publicly readable** (existing SELECT policy) — intended: these are
+  historical public outputs.
+- **`handle_new_user` trigger suppression** is irrelevant here (no auth rows in v2), but the
+  replica bracket is kept for FK deferral + any content triggers.
+- **Vote UI double-submit race** (rapid toggle) — the unique constraint makes the worst case a
+  23505 the client treats as no-op; optimistic state reconciles on the next read.

--- a/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
+++ b/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
@@ -54,8 +54,11 @@ create table public.idea_votes (
     CHECK constraint only — a single deterministic error source, not duplicated in the policy.)
   - DELETE (`to authenticated`): own row.
   - **No UPDATE** — switching a vote is delete + re-insert (same toggle pattern as `interest`).
-- **`idea_vote_totals` view** (`security_invoker = true`, mirrors `bounty_pot`):
-  `idea_id, score (sum), up_count, down_count` — grouped over `idea_votes`.
+- **`idea_vote_totals` view** (`security_invoker = true`, mirrors `bounty_pot` including its
+  explicit `grant select … to anon, authenticated`): `idea_id, score (sum), up_count, down_count`
+  — grouped over `idea_votes`.
+- Accepted product decision: individual votes — including downvotes — are publicly attributable
+  via the API (same visibility model as comments).
 - pgTAP coverage for all policies (vote-as-self ok, vote-as-other denied, legacy pinning,
   delete-own-only, draft-idea invisible, view respects invoker).
 - Applied to cloud via MCP `apply_migration` **before** the data load (controller step).
@@ -69,7 +72,11 @@ ignore). CLI logs **counts only**, never row contents.
 
 **Envelope (same as v1):** `begin;` → `set session_replication_role = replica;` → inserts →
 reply-to update → `set session_replication_role = origin;` → `do $$ … assert … $$;` →
-`commit;`. Every insert `on conflict (legacy_id) do nothing` → idempotent re-runs.
+`commit;`. Conflict handling: `on conflict (legacy_id) do nothing` for comments/answers/artifacts;
+**targetless `on conflict do nothing` for interest/idea_votes** — those tables also carry
+`unique (idea_id, profile_id)`, and an organic post-restore row on the same pair must displace
+the legacy insert rather than abort the transaction (also keeps re-runs idempotent once organic
+rows exist).
 Applied with fail-loud transport (`psql -v ON_ERROR_STOP=1` locally; Management API for cloud —
 any raised error aborts the whole transaction).
 

--- a/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
+++ b/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
@@ -143,7 +143,11 @@ per reply row (13 statements).
   control disabled with a link to `/login?next=<idea>`.
 - **`/ideas` cards:** show the score (read from `idea_vote_totals`, coalesced to 0 in the
   query layer — the view omits unvoted ideas).
-- No sort-by-score changes in this plan (the data is now there for later ranking work).
+- **Sort-by-score (owner addition):** `/ideas` gains a sort control — `Newest` (default,
+  current behavior) · `Top` (score desc, ties broken by `created_at` desc). Driven by a
+  `?sort=top` URL param read in the server load; the load merges the totals into the idea
+  list and sorts server-side (238 ideas — no pagination concerns). The control follows the
+  `Label ▾` dropdown pattern from the styleguide.
 - Server load functions join/fetch totals; mutations via plain supabase inserts/deletes
   (RLS does the enforcement — no RPCs needed).
 

--- a/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
+++ b/docs/superpowers/specs/2026-06-06-etl-restore-v2-design.md
@@ -49,9 +49,9 @@ create table public.idea_votes (
 - Indexes: `idea_id`, `profile_id` (covers both FKs; the unique adds `(idea_id, profile_id)`).
 - **RLS mirrors `interest` exactly:**
   - SELECT: idea visible (leverages ideas RLS via `exists`) **or** own row.
-  - INSERT (`to authenticated`): `auth.uid() = profile_id`, `value in (-1,1)` (redundant with
-    the check constraint but keeps the policy self-documenting), `legacy_id is null and
-    legacy = '{}'::jsonb` pinned, idea visible.
+  - INSERT (`to authenticated`): `auth.uid() = profile_id`, `legacy_id is null and
+    legacy = '{}'::jsonb` pinned, idea visible. (The `value in (-1,1)` rule lives on the table
+    CHECK constraint only — a single deterministic error source, not duplicated in the policy.)
   - DELETE (`to authenticated`): own row.
   - **No UPDATE** — switching a vote is delete + re-insert (same toggle pattern as `interest`).
 - **`idea_vote_totals` view** (`security_invoker = true`, mirrors `bounty_pot`):
@@ -136,8 +136,9 @@ per reply row (13 statements).
 
 ## 6. Vote UI (minimal, this plan)
 
-- **Idea detail page:** compact `▲ score ▼` control. Own active vote renders in
-  `--green-deep` (small mark on white, per styleguide §1); inactive arrows `--muted`.
+- **Idea detail page:** compact `▲ score ▼` control. Own active upvote renders in
+  `--green-deep` (small mark on white, per styleguide §1), active downvote in `--neg`
+  (the semantic negative); inactive arrows `--muted`.
   Toggle semantics: tap same arrow = remove vote (DELETE); tap other arrow = DELETE +
   INSERT. Optimistic update, `snappy` spring, interruptible. Signed-out users see the
   control disabled with a link to `/login?next=<idea>`.
@@ -146,8 +147,8 @@ per reply row (13 statements).
 - **Sort-by-score (owner addition):** `/ideas` gains a sort control — `Newest` (default,
   current behavior) · `Top` (score desc, ties broken by `created_at` desc). Driven by a
   `?sort=top` URL param read in the server load; the load merges the totals into the idea
-  list and sorts server-side (238 ideas — no pagination concerns). The control follows the
-  `Label ▾` dropdown pattern from the styleguide.
+  list and sorts server-side (238 ideas — no pagination concerns). The control mirrors the
+  existing type-filter link nav on `/ideas` (two options don't warrant a dropdown).
 - Server load functions join/fetch totals; mutations via plain supabase inserts/deletes
   (RLS does the enforcement — no RPCs needed).
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"etl:restore-v1": "tsx scripts/etl/restore-v1.ts"
+		"etl:restore-v1": "tsx scripts/etl/restore-v1.ts",
+		"etl:restore-v2": "tsx scripts/etl/restore-v2.ts"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",

--- a/scripts/etl/emit.test.ts
+++ b/scripts/etl/emit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildDocument } from './emit';
+import { buildDocument, buildDocumentV2 } from './emit';
 
 describe('buildDocument', () => {
   it('wraps in a transaction, brackets the load with session_replication_role, and ends with assertions', () => {
@@ -79,5 +79,75 @@ describe('buildDocument', () => {
     expect(doc).toMatch(/assert \(select count\(\*\) from public\.ideas\) >= \d+/);
     expect(doc).toMatch(/assert \(select count\(\*\) from public\.profiles\) >= \d+/);
     expect(doc).not.toContain('assert (select count(*) from public.ideas) = ');
+  });
+});
+
+describe('buildDocumentV2', () => {
+  const data = {
+    comments: [{ legacy_id: "'96'" }],
+    replies: [{ legacy_id: '96', reply_legacy_id: '69' }],
+    interest: [{ legacy_id: "'14'" }],
+    answers: [{ legacy_id: "'3'" }],
+    artifacts: [{ legacy_id: "'3'" }],
+    votes: [{ legacy_id: "'7'" }]
+  } as any;
+
+  it('wraps in a transaction with the replica bracket and ends with assertions', () => {
+    const doc = buildDocumentV2(data);
+    expect(doc.startsWith('begin;')).toBe(true);
+    expect(doc).toContain('set session_replication_role = replica;');
+    expect(doc).toContain('set session_replication_role = origin;');
+    expect(doc).toMatch(/do \$\$[\s\S]*assert[\s\S]*\$\$/);
+    expect(doc).toContain('orphan comment author');
+    expect(doc).toContain('orphan reply_to');
+    expect(doc.trim().endsWith('commit;')).toBe(true);
+  });
+
+  it('orders inserts comments → replies-update → interest → answers → artifacts → votes', () => {
+    const doc = buildDocumentV2(data);
+    const order = [
+      'insert into public.comments',
+      'update public.comments',
+      'insert into public.interest',
+      'insert into public.answers',
+      'insert into public.answer_artifacts',
+      'insert into public.idea_votes'
+    ].map((s) => doc.indexOf(s));
+    expect(order.every((n) => n >= 0)).toBe(true);
+    for (let k = 1; k < order.length; k++) expect(order[k - 1]).toBeLessThan(order[k]);
+  });
+
+  it('emits idempotent reply updates guarded by "reply_to is null"', () => {
+    const doc = buildDocumentV2(data);
+    expect(doc).toContain(
+      'update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = 69)\n' +
+      'where c.legacy_id = 96 and c.reply_to is null;'
+    );
+  });
+
+  it('arbitrates ALL unique constraints on interest/votes (targetless) and legacy_id elsewhere', () => {
+    const doc = buildDocumentV2(data);
+    const seg = (from: string, to: string) => doc.slice(doc.indexOf(from), doc.indexOf(to));
+    // comments/answers/artifacts: legacy_id is their only unique key
+    expect(seg('insert into public.comments', 'update public.comments')).toContain('on conflict (legacy_id) do nothing;');
+    // interest/idea_votes ALSO carry unique (idea_id, profile_id): an organic post-restore row on the
+    // same pair must NOT abort the load — a targetless `on conflict do nothing` arbitrates ANY unique index
+    expect(seg('insert into public.interest', 'insert into public.answers')).toContain('on conflict do nothing;');
+    expect(seg('insert into public.interest', 'insert into public.answers')).not.toContain('on conflict (');
+    expect(seg('insert into public.idea_votes', 'set session_replication_role = origin')).toContain('on conflict do nothing;');
+    expect(seg('insert into public.idea_votes', 'set session_replication_role = origin')).not.toContain('on conflict (');
+  });
+
+  it('asserts legacy-scoped counts where exact, totals where displacement is possible', () => {
+    const doc = buildDocumentV2(data);
+    // comments/answers/artifacts can't be displaced → exact legacy-scoped counts (organic-immune)
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.comments where legacy_id is not null\) >= \d+/);
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.answers where legacy_id is not null\) >= \d+/);
+    // interest/votes: an organic row on the same (idea_id, profile_id) DISPLACES the legacy insert,
+    // so legacy-scoped counts could undershoot — assert totals (legacy + displacing organic ≥ source)
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.idea_votes\) >= \d+/);
+    expect(doc).toMatch(/assert \(select count\(\*\) from public\.interest\) >= \d+/);
+    expect(doc).toContain('orphan comment idea');   // full spec §5 orphan-scan list
+    expect(doc).toContain('orphan artifact answer');
   });
 });

--- a/scripts/etl/emit.test.ts
+++ b/scripts/etl/emit.test.ts
@@ -1,17 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { buildDocument, buildDocumentV2 } from './emit';
+import {
+  buildDocument, buildDocumentV2,
+  AUTH_USERS_COLUMNS, AUTH_IDENTITIES_COLUMNS, PROFILES_COLUMNS, EXPERTS_COLUMNS,
+  CATEGORIES_COLUMNS, IDEAS_COLUMNS, IDEA_CATEGORIES_COLUMNS, IDEA_RELATIONS_COLUMNS,
+  COMMENTS_COLUMNS, INTEREST_COLUMNS, ANSWERS_COLUMNS, ARTIFACTS_COLUMNS, VOTES_COLUMNS
+} from './emit';
+
+/** Fill all columns from `cols` with NULL, overriding with provided values. */
+const fill = (cols: readonly string[], overrides: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(cols.map((c) => [c, overrides[c] ?? 'NULL']));
 
 describe('buildDocument', () => {
   it('wraps in a transaction, brackets the load with session_replication_role, and ends with assertions', () => {
     const doc = buildDocument({
-      authUsers: [{ id: '11111111-1111-1111-1111-111111111111' }] as any,
+      authUsers: [fill(AUTH_USERS_COLUMNS, { id: "'11111111-1111-1111-1111-111111111111'" })],
       identities: [],
       users: [],
       ideas: [],
       categories: [],
       ideaCats: [],
       ideaRels: []
-    } as any);
+    });
     expect(doc.startsWith('begin;')).toBe(true);
     // NOT the ALTER TABLE form (postgres can't own auth.users); uses the SET that needs no ownership
     expect(doc).not.toContain('disable trigger');
@@ -31,14 +40,14 @@ describe('buildDocument', () => {
 
   it('orders inserts in dependency order and uses the right conflict targets', () => {
     const doc = buildDocument({
-      authUsers: [{ id: "'a'" }],
-      identities: [{ id: "'i'" }],
-      users: [{ id: "'u'" }],
-      experts: [{ id: "'e'" }],
-      ideas: [{ legacy_id: "'1'" }],
-      categories: [{ legacy_id: "'2'" }],
-      ideaCats: [{ idea_id: "'x'", category_id: "'y'" }],
-      ideaRels: [{ legacy_id: "'3'", parent_id: "'p'", child_id: "'c'" }]
+      authUsers: [fill(AUTH_USERS_COLUMNS, { id: "'a'" })],
+      identities: [fill(AUTH_IDENTITIES_COLUMNS, { id: "'i'" })],
+      users: [fill(PROFILES_COLUMNS, { id: "'u'" })],
+      experts: [fill(EXPERTS_COLUMNS, { id: "'e'" })],
+      ideas: [fill(IDEAS_COLUMNS, { legacy_id: "'1'" })],
+      categories: [fill(CATEGORIES_COLUMNS, { legacy_id: "'2'" })],
+      ideaCats: [fill(IDEA_CATEGORIES_COLUMNS, { idea_id: "'x'", category_id: "'y'" })],
+      ideaRels: [fill(IDEA_RELATIONS_COLUMNS, { legacy_id: "'3'", parent_id: "'p'", child_id: "'c'" })]
     });
 
     // dependency order: auth.users → auth.identities → profiles → experts → categories → ideas → idea_categories → idea_relations
@@ -84,13 +93,13 @@ describe('buildDocument', () => {
 
 describe('buildDocumentV2', () => {
   const data = {
-    comments: [{ legacy_id: "'96'" }],
+    comments: [fill(COMMENTS_COLUMNS, { legacy_id: "'96'", idea_id: '(select 1)', author_id: 'NULL', body_md: "''", legacy: "'{}'::jsonb", created_at: 'now()' })],
     replies: [{ legacy_id: '96', reply_legacy_id: '69' }],
-    interest: [{ legacy_id: "'14'" }],
-    answers: [{ legacy_id: "'3'" }],
-    artifacts: [{ legacy_id: "'3'" }],
-    votes: [{ legacy_id: "'7'" }]
-  } as any;
+    interest: [fill(INTEREST_COLUMNS, { legacy_id: "'14'", idea_id: '(select 1)', profile_id: 'NULL', note_md: 'NULL', legacy: "'{}'::jsonb", created_at: 'now()' })],
+    answers: [fill(ANSWERS_COLUMNS, { legacy_id: "'3'", idea_id: '(select 1)', submitter_id: 'NULL', title: "''", explanation_md: 'NULL', status: "'pending'", verified_at: 'NULL', legacy: "'{}'::jsonb", created_at: 'now()' })],
+    artifacts: [fill(ARTIFACTS_COLUMNS, { legacy_id: "'3'", answer_id: '(select 1)', kind: "'link'", url: "''", created_at: 'now()' })],
+    votes: [fill(VOTES_COLUMNS, { legacy_id: "'7'", idea_id: '(select 1)', profile_id: 'NULL', value: '1', legacy: "'{}'::jsonb", created_at: 'now()' })]
+  };
 
   it('wraps in a transaction with the replica bracket and ends with assertions', () => {
     const doc = buildDocumentV2(data);

--- a/scripts/etl/emit.test.ts
+++ b/scripts/etl/emit.test.ts
@@ -97,7 +97,7 @@ describe('buildDocumentV2', () => {
     replies: [{ legacy_id: '96', reply_legacy_id: '69' }],
     interest: [fill(INTEREST_COLUMNS, { legacy_id: "'14'", idea_id: '(select 1)', profile_id: 'NULL', note_md: 'NULL', legacy: "'{}'::jsonb", created_at: 'now()' })],
     answers: [fill(ANSWERS_COLUMNS, { legacy_id: "'3'", idea_id: '(select 1)', submitter_id: 'NULL', title: "''", explanation_md: 'NULL', status: "'pending'", verified_at: 'NULL', legacy: "'{}'::jsonb", created_at: 'now()' })],
-    artifacts: [fill(ARTIFACTS_COLUMNS, { legacy_id: "'3'", answer_id: '(select 1)', kind: "'link'", url: "''", created_at: 'now()' })],
+    artifacts: [fill(ARTIFACTS_COLUMNS, { legacy_id: "'3'", answer_id: '(select 1)', kind: "'url'", url: "''", created_at: 'now()' })],
     votes: [fill(VOTES_COLUMNS, { legacy_id: "'7'", idea_id: '(select 1)', profile_id: 'NULL', value: '1', legacy: "'{}'::jsonb", created_at: 'now()' })]
   };
 

--- a/scripts/etl/emit.ts
+++ b/scripts/etl/emit.ts
@@ -186,25 +186,24 @@ export function buildDocumentV2(data: EmitDataV2): string {
   parts.push('set session_replication_role = replica;');
 
   parts.push(insertRows('public.comments', [...COMMENTS_COLUMNS], data.comments, 'legacy_id'));
+  const INT = /^-?\d+$/;
   parts.push(
     data.replies
       .map((r) => {
-        const child = Number(r.legacy_id);
-        const parent = Number(r.reply_legacy_id);
-        if (!Number.isInteger(child) || !Number.isInteger(parent)) throw new Error('invalid reply pair');
+        if (!INT.test(r.legacy_id) || !INT.test(r.reply_legacy_id)) throw new Error('invalid reply pair');
         return (
-          `update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = ${parent})\n` +
-          `where c.legacy_id = ${child} and c.reply_to is null;`
+          `update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = ${r.reply_legacy_id})\n` +
+          `where c.legacy_id = ${r.legacy_id} and c.reply_to is null;`
         );
       })
       .join('\n')
   );
   // interest + idea_votes ALSO carry unique (idea_id, profile_id): an organic post-restore row on the
   // same pair must DISPLACE the legacy insert, not abort the transaction → targetless on conflict.
-  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest));
+  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest, null));
   parts.push(insertRows('public.answers', [...ANSWERS_COLUMNS], data.answers, 'legacy_id'));
   parts.push(insertRows('public.answer_artifacts', [...ARTIFACTS_COLUMNS], data.artifacts, 'legacy_id'));
-  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes));
+  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes, null));
 
   parts.push('set session_replication_role = origin;');
 
@@ -212,6 +211,7 @@ export function buildDocumentV2(data: EmitDataV2): string {
   // never re-validates rows — these scans are the only FK-integrity check for the load.
   // Counts: comments/answers/artifacts can't be displaced → exact legacy-scoped; interest/votes can be
   // displaced by an organic (idea_id, profile_id) row → assert totals (legacy + displacing organic).
+  // Thresholds are the controller-verified source counts (probed 2026-06-06); interest has 0 duplicate (user, idea) pairs in the dump, so 133 distinct rows is exact.
   parts.push(
     [
       'do $$ begin',

--- a/scripts/etl/emit.ts
+++ b/scripts/etl/emit.ts
@@ -157,3 +157,94 @@ export function buildDocument(data: EmitData): string {
   // join with blank lines; insertRows() returns '' for empty batches — filter those out.
   return parts.filter((p) => p.trim() !== '').join('\n\n') + '\n';
 }
+
+/** v2 target column lists (only columns the ETL sets; defaults cover the rest). */
+export const COMMENTS_COLUMNS = ['legacy_id', 'idea_id', 'author_id', 'body_md', 'legacy', 'created_at'] as const;
+export const INTEREST_COLUMNS = ['legacy_id', 'idea_id', 'profile_id', 'note_md', 'legacy', 'created_at'] as const;
+export const ANSWERS_COLUMNS = ['legacy_id', 'idea_id', 'submitter_id', 'title', 'explanation_md', 'status', 'verified_at', 'legacy', 'created_at'] as const;
+export const ARTIFACTS_COLUMNS = ['legacy_id', 'answer_id', 'kind', 'url', 'created_at'] as const;
+export const VOTES_COLUMNS = ['legacy_id', 'idea_id', 'profile_id', 'value', 'legacy', 'created_at'] as const;
+
+export type EmitDataV2 = {
+  comments: SqlRow[];
+  replies: { legacy_id: string; reply_legacy_id: string }[];
+  interest: SqlRow[];
+  answers: SqlRow[];
+  artifacts: SqlRow[];
+  votes: SqlRow[];
+};
+
+/**
+ * Restore-v2 document (spec §4): begin → replica → comments → reply updates → interest → answers
+ * → artifacts → idea_votes → origin → count + orphan assertions → commit. Idempotent throughout
+ * (conflict-suppressed inserts; reply updates guarded by `reply_to is null`).
+ * Idea/answer FKs are scalar subqueries on legacy_id, resolved at apply time (see transform.ts refs).
+ */
+export function buildDocumentV2(data: EmitDataV2): string {
+  const parts: string[] = [];
+  parts.push('begin;');
+  parts.push('set session_replication_role = replica;');
+
+  parts.push(insertRows('public.comments', [...COMMENTS_COLUMNS], data.comments, 'legacy_id'));
+  parts.push(
+    data.replies
+      .map((r) => {
+        const child = Number(r.legacy_id);
+        const parent = Number(r.reply_legacy_id);
+        if (!Number.isInteger(child) || !Number.isInteger(parent)) throw new Error('invalid reply pair');
+        return (
+          `update public.comments c set reply_to = (select p.id from public.comments p where p.legacy_id = ${parent})\n` +
+          `where c.legacy_id = ${child} and c.reply_to is null;`
+        );
+      })
+      .join('\n')
+  );
+  // interest + idea_votes ALSO carry unique (idea_id, profile_id): an organic post-restore row on the
+  // same pair must DISPLACE the legacy insert, not abort the transaction → targetless on conflict.
+  parts.push(insertRows('public.interest', [...INTEREST_COLUMNS], data.interest));
+  parts.push(insertRows('public.answers', [...ANSWERS_COLUMNS], data.answers, 'legacy_id'));
+  parts.push(insertRows('public.answer_artifacts', [...ARTIFACTS_COLUMNS], data.artifacts, 'legacy_id'));
+  parts.push(insertRows('public.idea_votes', [...VOTES_COLUMNS], data.votes));
+
+  parts.push('set session_replication_role = origin;');
+
+  // VERIFICATION IS HERE OR NOWHERE: replica mode DISABLES the RI triggers and restoring `origin`
+  // never re-validates rows — these scans are the only FK-integrity check for the load.
+  // Counts: comments/answers/artifacts can't be displaced → exact legacy-scoped; interest/votes can be
+  // displaced by an organic (idea_id, profile_id) row → assert totals (legacy + displacing organic).
+  parts.push(
+    [
+      'do $$ begin',
+      "  assert (select count(*) from public.comments where legacy_id is not null) >= 83, 'comments count too low';",
+      "  assert (select count(*) from public.interest) >= 133, 'interest count too low';",
+      "  assert (select count(*) from public.answers where legacy_id is not null) >= 5, 'answers count too low';",
+      "  assert (select count(*) from public.answer_artifacts where legacy_id is not null) >= 5, 'artifacts count too low';",
+      "  assert (select count(*) from public.idea_votes) >= 387, 'votes count too low';",
+      "  assert (select count(*) from public.comments where legacy_id is not null and reply_to is not null) >= 13, 'reply links too low';",
+      '  assert (select count(*) from public.comments c left join public.profiles p on p.id = c.author_id',
+      "          where c.author_id is not null and p.id is null) = 0, 'orphan comment author';",
+      '  assert (select count(*) from public.comments c left join public.ideas i on i.id = c.idea_id',
+      "          where i.id is null) = 0, 'orphan comment idea';",
+      '  assert (select count(*) from public.comments c left join public.comments p on p.id = c.reply_to',
+      "          where c.reply_to is not null and p.id is null) = 0, 'orphan reply_to';",
+      '  assert (select count(*) from public.interest x left join public.profiles p on p.id = x.profile_id',
+      "          where x.profile_id is not null and p.id is null) = 0, 'orphan interest profile';",
+      '  assert (select count(*) from public.interest x left join public.ideas i on i.id = x.idea_id',
+      "          where i.id is null) = 0, 'orphan interest idea';",
+      '  assert (select count(*) from public.answers a left join public.profiles p on p.id = a.submitter_id',
+      "          where a.submitter_id is not null and p.id is null) = 0, 'orphan answer submitter';",
+      '  assert (select count(*) from public.answers a left join public.ideas i on i.id = a.idea_id',
+      "          where i.id is null) = 0, 'orphan answer idea';",
+      '  assert (select count(*) from public.answer_artifacts t left join public.answers a on a.id = t.answer_id',
+      "          where a.id is null) = 0, 'orphan artifact answer';",
+      '  assert (select count(*) from public.idea_votes v left join public.profiles p on p.id = v.profile_id',
+      "          where p.id is null) = 0, 'orphan vote profile';",
+      '  assert (select count(*) from public.idea_votes v left join public.ideas i on i.id = v.idea_id',
+      "          where i.id is null) = 0, 'orphan vote idea';",
+      'end $$;'
+    ].join('\n')
+  );
+
+  parts.push('commit;');
+  return parts.filter((p) => p.trim() !== '').join('\n\n') + '\n';
+}

--- a/scripts/etl/restore-v2.ts
+++ b/scripts/etl/restore-v2.ts
@@ -1,0 +1,45 @@
+/**
+ * Restore-v2 CLI — comments / interest / results→answers(+artifacts) / likes→votes.
+ * Prints COUNTS only (never row contents) — backup + generated SQL contain PII (gitignored).
+ *
+ * Usage: `npm run etl:restore-v2 [path/to/backup]`
+ * (Controller-only against the real backup; subagents use synthetic fixtures.)
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseCopyBlock } from './parse-dump';
+import * as t from './transform';
+import { buildDocumentV2 } from './emit';
+
+const BACKUP = process.argv[2] ?? `${process.env.HOME}/Downloads/db_cluster-16-10-2025@02-48-41.backup`;
+const OUT = new URL('./restore-v2.generated.sql', import.meta.url).pathname;
+
+function main() {
+  const dump = readFileSync(BACKUP, 'utf8');
+
+  const commentsRaw = parseCopyBlock(dump, 'public.comments').rows;
+  const interestRaw = parseCopyBlock(dump, 'public.idea_user_interest_relation').rows;
+  const resultsRaw = parseCopyBlock(dump, 'public.results').rows;
+  const likesRaw = parseCopyBlock(dump, 'public.idea_user_likes').rows;
+  const ideasRaw = parseCopyBlock(dump, 'public.ideas').rows;   // only for the answer-title fallback
+
+  const titles = new Map<string, string>();
+  for (const i of ideasRaw) if (i.id && i.title) titles.set(i.id, i.title);
+
+  const comments = commentsRaw.map((c) => t.toComment(c));
+  const replies = t.commentReplies(commentsRaw);
+  const interest = interestRaw.map((r) => t.toInterest(r));
+  const answers = resultsRaw.map((r) => t.toAnswerFromResult(r, titles));
+  const artifacts = resultsRaw.map((r) => t.toAnswerArtifact(r)).filter((a): a is NonNullable<typeof a> => a !== null);
+  const { kept, dropped } = t.dedupeVotes(likesRaw);
+  const votes = kept.map((l) => t.toVote(l));
+
+  writeFileSync(OUT, buildDocumentV2({ comments, replies, interest, answers, artifacts, votes }), 'utf8');
+
+  // COUNTS ONLY — never row contents (PII discipline).
+  console.log(
+    `wrote ${OUT}: comments=${comments.length} replies=${replies.length} interest=${interest.length} ` +
+      `answers=${answers.length} artifacts=${artifacts.length} votes=${votes.length} (deduped ${dropped})`
+  );
+}
+
+main();

--- a/scripts/etl/sql.test.ts
+++ b/scripts/etl/sql.test.ts
@@ -24,4 +24,8 @@ describe('sql helpers', () => {
   it('insertRows() returns empty string for no rows', () => {
     expect(insertRows('public.t', ['id'], [], 'id')).toBe('');
   });
+  it('insertRows() omits the conflict target when none is given (arbitrates any unique index)', () => {
+    const sql = insertRows('public.t', ['id'], [{ id: lit('1') }]);
+    expect(sql.trim().endsWith('on conflict do nothing;')).toBe(true);
+  });
 });

--- a/scripts/etl/sql.test.ts
+++ b/scripts/etl/sql.test.ts
@@ -24,8 +24,11 @@ describe('sql helpers', () => {
   it('insertRows() returns empty string for no rows', () => {
     expect(insertRows('public.t', ['id'], [], 'id')).toBe('');
   });
-  it('insertRows() omits the conflict target when none is given (arbitrates any unique index)', () => {
-    const sql = insertRows('public.t', ['id'], [{ id: lit('1') }]);
+  it('insertRows() omits the conflict target when null (arbitrates any unique index)', () => {
+    const sql = insertRows('public.t', ['id'], [{ id: lit('1') }], null);
     expect(sql.trim().endsWith('on conflict do nothing;')).toBe(true);
+  });
+  it('insertRows() throws when a row is missing a listed column', () => {
+    expect(() => insertRows('public.t', ['id', 'name'], [{ id: "'1'" }], null)).toThrow(/missing column name/);
   });
 });

--- a/scripts/etl/sql.ts
+++ b/scripts/etl/sql.ts
@@ -15,10 +15,15 @@ export function jsonbLit(obj: Record<string, unknown>): string {
 
 /** An idempotent multi-row INSERT. `cells` rows are pre-rendered SQL (use lit()/jsonbLit()). */
 export function insertRows(
-  table: string, columns: string[], rows: Record<string, string>[], conflictTarget?: string
+  table: string, columns: string[], rows: Record<string, string>[], conflictTarget: string | null
 ): string {
   if (rows.length === 0) return '';
-  const tuples = rows.map((r) => `  (${columns.map((c) => r[c] ?? 'NULL').join(', ')})`).join(',\n');
+  const tuples = rows
+    .map((r) => `  (${columns.map((c) => {
+      if (!(c in r)) throw new Error(`${table}: row missing column ${c}`);
+      return r[c];
+    }).join(', ')})`)
+    .join(',\n');
   const conflict = conflictTarget ? `on conflict (${conflictTarget}) do nothing;` : 'on conflict do nothing;';
   return `insert into ${table} (${columns.join(', ')}) values\n${tuples}\n${conflict}\n`;
 }

--- a/scripts/etl/sql.ts
+++ b/scripts/etl/sql.ts
@@ -15,9 +15,10 @@ export function jsonbLit(obj: Record<string, unknown>): string {
 
 /** An idempotent multi-row INSERT. `cells` rows are pre-rendered SQL (use lit()/jsonbLit()). */
 export function insertRows(
-  table: string, columns: string[], rows: Record<string, string>[], conflictTarget: string
+  table: string, columns: string[], rows: Record<string, string>[], conflictTarget?: string
 ): string {
   if (rows.length === 0) return '';
   const tuples = rows.map((r) => `  (${columns.map((c) => r[c] ?? 'NULL').join(', ')})`).join(',\n');
-  return `insert into ${table} (${columns.join(', ')}) values\n${tuples}\non conflict (${conflictTarget}) do nothing;\n`;
+  const conflict = conflictTarget ? `on conflict (${conflictTarget}) do nothing;` : 'on conflict do nothing;';
+  return `insert into ${table} (${columns.join(', ')}) values\n${tuples}\n${conflict}\n`;
 }

--- a/scripts/etl/transform.test.ts
+++ b/scripts/etl/transform.test.ts
@@ -216,19 +216,19 @@ describe('v2 ref helpers', () => {
 
 describe('v2 transforms', () => {
   it('toComment maps body/author and keeps reply/anon/upvotes in legacy', () => {
-    const c = toComment({ id: '96', created_at: '2022-06-30 06:41:09+00', idea: '16',
-      author: '0ab224d1-75b6-44e5-b868-26018ca607fe', text: 'Yes!', reply_to: '69',
+    const c = toComment({ id: '96', created_at: '2022-06-30 06:00:00+00', idea: '16',
+      author: '22222222-2222-2222-2222-222222222222', text: 'Yes!', reply_to: '69',
       anon_author: null, anon_author_url: null, upvotes: '2' });
     expect(c.legacy_id).toBe("'96'");
     expect(c.idea_id).toBe("(select id from public.ideas where legacy_id = 16)");
-    expect(c.author_id).toBe("'0ab224d1-75b6-44e5-b868-26018ca607fe'");
+    expect(c.author_id).toBe("'22222222-2222-2222-2222-222222222222'");
     expect(c.body_md).toBe("'Yes!'");
     expect(c.legacy).toContain('"reply_to":"69"');
     expect(c.legacy).toContain('"upvotes":"2"');
     expect(c.reply_to).toBeUndefined();           // threading is pass-2
   });
   it('toComment keeps empty text as empty string and null author as NULL', () => {
-    const c = toComment({ id: '175', created_at: '2023-07-07 15:24:15+00', idea: '242',
+    const c = toComment({ id: '175', created_at: '2023-07-07 15:00:00+00', idea: '242',
       author: null, text: '', reply_to: null, anon_author: null, anon_author_url: null, upvotes: null });
     expect(c.body_md).toBe("''");
     expect(c.author_id).toBe('NULL');
@@ -247,33 +247,33 @@ describe('v2 transforms', () => {
     expect(commentReplies(rows)).toEqual([]);
   });
   it('toInterest maps how→note_md (blank→NULL) and contact flag→legacy', () => {
-    const i = toInterest({ id: '14', created_at: '2022-06-14 12:14:29+00',
-      user: '3590e5a9-da55-49f8-9d61-726c0b0203fe', idea: '18', contact_if_started: 'f', how: '' });
+    const i = toInterest({ id: '14', created_at: '2022-06-14 12:00:00+00',
+      user: '33333333-3333-3333-3333-333333333333', idea: '18', contact_if_started: 'f', how: '' });
     expect(i.note_md).toBe('NULL');
-    expect(i.profile_id).toBe("'3590e5a9-da55-49f8-9d61-726c0b0203fe'");
+    expect(i.profile_id).toBe("'33333333-3333-3333-3333-333333333333'");
     expect(i.legacy).toContain('"contact_if_started":"f"');
   });
   it('toAnswerFromResult maps to a verified answer with a title fallback', () => {
     const titles = new Map([['14', 'Old idea title']]);
-    const a = toAnswerFromResult({ id: '3', created_at: '2022-11-21 12:05:13+00', idea: '14',
-      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', description: '', image_link: 'http://img',
-      type: 'ambiguous', title: '', author: 'COCO, Nina', link: 'http://itch.io/x',
+    const a = toAnswerFromResult({ id: '3', created_at: '2022-11-21 12:00:00+00', idea: '14',
+      user: '22222222-2222-2222-2222-222222222222', description: '', image_link: 'http://img',
+      type: 'ambiguous', title: '', author: 'Test Author A, Test Author B', link: 'http://example.com/x',
       from_date: '2022-11-13', original: 'f' }, titles);
     expect(a.title).toBe("'Result: Old idea title'");
     expect(a.status).toBe("'verified'");
-    expect(a.verified_at).toBe("'2022-11-21 12:05:13+00'");
+    expect(a.verified_at).toBe("'2022-11-21 12:00:00+00'");
     expect(a.explanation_md).toBe('NULL');
-    expect(a.legacy).toContain('"author":"COCO, Nina"');
+    expect(a.legacy).toContain('"author":"Test Author A, Test Author B"');
   });
   it('toAnswerArtifact emits a url artifact only when link is non-blank', () => {
-    const art = toAnswerArtifact({ id: '3', created_at: 'x', link: 'http://itch.io/x' } as any);
+    const art = toAnswerArtifact({ id: '3', created_at: 'x', link: 'http://example.com/x' } as any);
     expect(art!.answer_id).toBe("(select id from public.answers where legacy_id = 3)");
     expect(art!.kind).toBe("'url'");
     expect(toAnswerArtifact({ id: '9', created_at: 'x', link: '' } as any)).toBeNull();
   });
   it('toVote maps a like to an upvote, weight in legacy', () => {
     const v = toVote({ id: '7', created_at: '2022-07-01 00:00:00+00',
-      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', idea: '14', size: '3' });
+      user: '22222222-2222-2222-2222-222222222222', idea: '14', size: '3' });
     expect(v.value).toBe('1');
     expect(v.legacy).toContain('"size":"3"');
   });

--- a/scripts/etl/transform.test.ts
+++ b/scripts/etl/transform.test.ts
@@ -191,3 +191,84 @@ describe('resolveIdeaRelations', () => {
     expect(rows[0].type).toBe("'related'");
   });
 });
+
+import {
+  ideaRef, answerRef, toComment, commentReplies, toInterest,
+  toAnswerFromResult, toAnswerArtifact, toVote, dedupeVotes
+} from './transform';
+
+describe('v2 ref helpers', () => {
+  it('emit integer-validated scalar subqueries', () => {
+    expect(ideaRef('14')).toBe("(select id from public.ideas where legacy_id = 14)");
+    expect(answerRef('3')).toBe("(select id from public.answers where legacy_id = 3)");
+    expect(() => ideaRef('14; drop table x')).toThrow();
+    expect(() => ideaRef(null)).toThrow();
+  });
+});
+
+describe('v2 transforms', () => {
+  it('toComment maps body/author and keeps reply/anon/upvotes in legacy', () => {
+    const c = toComment({ id: '96', created_at: '2022-06-30 06:41:09+00', idea: '16',
+      author: '0ab224d1-75b6-44e5-b868-26018ca607fe', text: 'Yes!', reply_to: '69',
+      anon_author: null, anon_author_url: null, upvotes: '2' });
+    expect(c.legacy_id).toBe("'96'");
+    expect(c.idea_id).toBe("(select id from public.ideas where legacy_id = 16)");
+    expect(c.author_id).toBe("'0ab224d1-75b6-44e5-b868-26018ca607fe'");
+    expect(c.body_md).toBe("'Yes!'");
+    expect(c.legacy).toContain('"reply_to":"69"');
+    expect(c.legacy).toContain('"upvotes":"2"');
+    expect(c.reply_to).toBeUndefined();           // threading is pass-2
+  });
+  it('toComment keeps empty text as empty string and null author as NULL', () => {
+    const c = toComment({ id: '175', created_at: '2023-07-07 15:24:15+00', idea: '242',
+      author: null, text: '', reply_to: null, anon_author: null, anon_author_url: null, upvotes: null });
+    expect(c.body_md).toBe("''");
+    expect(c.author_id).toBe('NULL');
+  });
+  it('commentReplies returns only rows with reply_to', () => {
+    const rows = [
+      { id: '96', reply_to: '69' }, { id: '97', reply_to: null }
+    ] as any[];
+    expect(commentReplies(rows)).toEqual([{ legacy_id: '96', reply_legacy_id: '69' }]);
+  });
+  it('toInterest maps how→note_md (blank→NULL) and contact flag→legacy', () => {
+    const i = toInterest({ id: '14', created_at: '2022-06-14 12:14:29+00',
+      user: '3590e5a9-da55-49f8-9d61-726c0b0203fe', idea: '18', contact_if_started: 'f', how: '' });
+    expect(i.note_md).toBe('NULL');
+    expect(i.profile_id).toBe("'3590e5a9-da55-49f8-9d61-726c0b0203fe'");
+    expect(i.legacy).toContain('"contact_if_started":"f"');
+  });
+  it('toAnswerFromResult maps to a verified answer with a title fallback', () => {
+    const titles = new Map([['14', 'Old idea title']]);
+    const a = toAnswerFromResult({ id: '3', created_at: '2022-11-21 12:05:13+00', idea: '14',
+      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', description: '', image_link: 'http://img',
+      type: 'ambiguous', title: '', author: 'COCO, Nina', link: 'http://itch.io/x',
+      from_date: '2022-11-13', original: 'f' }, titles);
+    expect(a.title).toBe("'Result: Old idea title'");
+    expect(a.status).toBe("'verified'");
+    expect(a.verified_at).toBe("'2022-11-21 12:05:13+00'");
+    expect(a.explanation_md).toBe('NULL');
+    expect(a.legacy).toContain('"author":"COCO, Nina"');
+  });
+  it('toAnswerArtifact emits a url artifact only when link is non-blank', () => {
+    const art = toAnswerArtifact({ id: '3', created_at: 'x', link: 'http://itch.io/x' } as any);
+    expect(art!.answer_id).toBe("(select id from public.answers where legacy_id = 3)");
+    expect(art!.kind).toBe("'url'");
+    expect(toAnswerArtifact({ id: '9', created_at: 'x', link: '' } as any)).toBeNull();
+  });
+  it('toVote maps a like to an upvote, weight in legacy', () => {
+    const v = toVote({ id: '7', created_at: '2022-07-01 00:00:00+00',
+      user: '0ab224d1-75b6-44e5-b868-26018ca607fe', idea: '14', size: '3' });
+    expect(v.value).toBe('1');
+    expect(v.legacy).toContain('"size":"3"');
+  });
+  it('dedupeVotes keeps the earliest per (user, idea)', () => {
+    const { kept, dropped } = dedupeVotes([
+      { id: '2', created_at: '2022-02-01', user: 'u1', idea: '5', size: '1' },
+      { id: '1', created_at: '2022-01-01', user: 'u1', idea: '5', size: '1' },
+      { id: '3', created_at: '2022-03-01', user: 'u2', idea: '5', size: '1' }
+    ] as any[]);
+    expect(kept.map((r: any) => r.id)).toEqual(['1', '3']);
+    expect(dropped).toBe(1);
+  });
+});

--- a/scripts/etl/transform.test.ts
+++ b/scripts/etl/transform.test.ts
@@ -204,6 +204,14 @@ describe('v2 ref helpers', () => {
     expect(() => ideaRef('14; drop table x')).toThrow();
     expect(() => ideaRef(null)).toThrow();
   });
+  it('rejects empty string, whitespace, scientific notation, hex, and floats', () => {
+    expect(() => ideaRef('')).toThrow();
+    expect(() => ideaRef('1e3')).toThrow();
+    expect(() => ideaRef('14.0')).toThrow();
+  });
+  it('preserves bigint values beyond Number.MAX_SAFE_INTEGER verbatim', () => {
+    expect(ideaRef('9007199254740993')).toBe("(select id from public.ideas where legacy_id = 9007199254740993)");
+  });
 });
 
 describe('v2 transforms', () => {
@@ -230,6 +238,13 @@ describe('v2 transforms', () => {
       { id: '96', reply_to: '69' }, { id: '97', reply_to: null }
     ] as any[];
     expect(commentReplies(rows)).toEqual([{ legacy_id: '96', reply_legacy_id: '69' }]);
+  });
+  it('commentReplies throws on non-integer ids', () => {
+    expect(() => commentReplies([{ id: '9', reply_to: 'x' }] as any[])).toThrow();
+  });
+  it('commentReplies skips self-replies', () => {
+    const rows = [{ id: '9', reply_to: '9' }] as any[];
+    expect(commentReplies(rows)).toEqual([]);
   });
   it('toInterest maps how→note_md (blank→NULL) and contact flag→legacy', () => {
     const i = toInterest({ id: '14', created_at: '2022-06-14 12:14:29+00',
@@ -262,6 +277,9 @@ describe('v2 transforms', () => {
     expect(v.value).toBe('1');
     expect(v.legacy).toContain('"size":"3"');
   });
+  it('toVote throws when user is null (profile_id is NOT NULL)', () => {
+    expect(() => toVote({ id: '9', created_at: 'x', user: null, idea: '14', size: null })).toThrow();
+  });
   it('dedupeVotes keeps the earliest per (user, idea)', () => {
     const { kept, dropped } = dedupeVotes([
       { id: '2', created_at: '2022-02-01', user: 'u1', idea: '5', size: '1' },
@@ -270,5 +288,12 @@ describe('v2 transforms', () => {
     ] as any[]);
     expect(kept.map((r: any) => r.id)).toEqual(['1', '3']);
     expect(dropped).toBe(1);
+  });
+  it('dedupeVotes keeps chronologically-earliest with fractional-second timestamps', () => {
+    const { kept } = dedupeVotes([
+      { id: '2', created_at: '2022-01-01 10:00:00.5+00', user: 'u1', idea: '5', size: null },
+      { id: '1', created_at: '2022-01-01 10:00:00+00',   user: 'u1', idea: '5', size: null }
+    ] as any[]);
+    expect(kept[0].id).toBe('1');
   });
 });

--- a/scripts/etl/transform.ts
+++ b/scripts/etl/transform.ts
@@ -228,11 +228,12 @@ export function resolveIdeaRelations(rels: Row[], ideaMap: Map<string, string>):
 
 // ───────────────────────────── Restore v2 ─────────────────────────────
 
-/** Scalar-subquery ref against a legacy_id anchor. Validates the id is an integer (never interpolate dump text). */
+/** Scalar-subquery ref against a legacy_id anchor. Validates the RAW string (bigint-safe, rejects ''/whitespace/'1e3'/'0x10'/'14.0'). */
 function legacyRef(table: string, legacyId: string | null | undefined): string {
-  const n = Number(legacyId);
-  if (legacyId == null || !Number.isInteger(n)) throw new Error(`invalid legacy id for ${table}`);
-  return `(select id from public.${table} where legacy_id = ${n})`;
+  if (legacyId == null || !/^-?\d+$/.test(legacyId)) {
+    throw new Error(`invalid legacy id for ${table}: ${JSON.stringify(legacyId)}`);
+  }
+  return `(select id from public.${table} where legacy_id = ${legacyId})`;
 }
 export const ideaRef = (legacyId: string | null | undefined) => legacyRef('ideas', legacyId);
 export const answerRef = (legacyId: string | null | undefined) => legacyRef('answers', legacyId);
@@ -257,9 +258,15 @@ export function toComment(c: Row): SqlRow {
 
 /** The (child, parent) legacy-id pairs that need the pass-2 reply_to update. */
 export function commentReplies(rows: Row[]): { legacy_id: string; reply_legacy_id: string }[] {
-  return rows
-    .filter((r) => r.reply_to != null && r.id != null)
-    .map((r) => ({ legacy_id: r.id as string, reply_legacy_id: r.reply_to as string }));
+  const INT = /^-?\d+$/;
+  const out: { legacy_id: string; reply_legacy_id: string }[] = [];
+  for (const r of rows) {
+    if (r.reply_to == null || r.id == null) continue;
+    if (!INT.test(r.id) || !INT.test(r.reply_to)) throw new Error(`invalid comment reply pair ${JSON.stringify(r.id)}→${JSON.stringify(r.reply_to)}`);
+    if (r.id === r.reply_to) continue; // self-reply: drop (stays in the row's legacy jsonb)
+    out.push({ legacy_id: r.id, reply_legacy_id: r.reply_to });
+  }
+  return out;
 }
 
 /** old `idea_user_interest_relation` → `public.interest` (spec §5). */
@@ -312,10 +319,11 @@ export function toAnswerArtifact(r: Row): SqlRow | null {
 
 /** old `idea_user_likes` → `public.idea_votes` as upvotes; old weight kept in legacy (spec §5). */
 export function toVote(l: Row): SqlRow {
+  if (l.user == null) throw new Error(`like ${l.id ?? '?'} has no user — idea_votes.profile_id is NOT NULL`);
   return {
     legacy_id: lit(l.id),
     idea_id: ideaRef(l.idea),
-    profile_id: lit(l.user ?? null),
+    profile_id: lit(l.user),
     value: '1',
     legacy: jsonbLit({ size: l.size ?? undefined }),
     created_at: lit(l.created_at ?? { sql: 'now()' })
@@ -324,7 +332,10 @@ export function toVote(l: Row): SqlRow {
 
 /** Guard for `unique (idea_id, profile_id)`: keep the earliest like per (user, idea). */
 export function dedupeVotes(rows: Row[]): { kept: Row[]; dropped: number } {
-  const sorted = [...rows].sort((a, b) => String(a.created_at ?? '').localeCompare(String(b.created_at ?? '')));
+  const cmp = (x: string, y: string) => (x < y ? -1 : x > y ? 1 : 0);
+  const sorted = [...rows].sort(
+    (a, b) => cmp(String(a.created_at ?? '~'), String(b.created_at ?? '~')) || cmp(String(a.id ?? ''), String(b.id ?? ''))
+  );
   const seen = new Set<string>();
   const kept: Row[] = [];
   for (const r of sorted) {

--- a/scripts/etl/transform.ts
+++ b/scripts/etl/transform.ts
@@ -225,3 +225,113 @@ export function resolveIdeaRelations(rels: Row[], ideaMap: Map<string, string>):
   }
   return out;
 }
+
+// ───────────────────────────── Restore v2 ─────────────────────────────
+
+/** Scalar-subquery ref against a legacy_id anchor. Validates the id is an integer (never interpolate dump text). */
+function legacyRef(table: string, legacyId: string | null | undefined): string {
+  const n = Number(legacyId);
+  if (legacyId == null || !Number.isInteger(n)) throw new Error(`invalid legacy id for ${table}`);
+  return `(select id from public.${table} where legacy_id = ${n})`;
+}
+export const ideaRef = (legacyId: string | null | undefined) => legacyRef('ideas', legacyId);
+export const answerRef = (legacyId: string | null | undefined) => legacyRef('answers', legacyId);
+export const commentRef = (legacyId: string | null | undefined) => legacyRef('comments', legacyId);
+
+/** old `public.comments` → new `public.comments` (spec §5). reply_to is set in pass 2 (see commentReplies). */
+export function toComment(c: Row): SqlRow {
+  return {
+    legacy_id: lit(c.id),
+    idea_id: ideaRef(c.idea),
+    author_id: lit(c.author ?? null),
+    body_md: lit(c.text ?? ''),                       // empty-text rows are real thread anchors — keep ''
+    legacy: jsonbLit({
+      reply_to: c.reply_to ?? undefined,
+      anon_author: c.anon_author ?? undefined,
+      anon_author_url: c.anon_author_url ?? undefined,
+      upvotes: c.upvotes ?? undefined
+    }),
+    created_at: lit(c.created_at ?? { sql: 'now()' })   // explicit NULL would abort on the NOT NULL column
+  };
+}
+
+/** The (child, parent) legacy-id pairs that need the pass-2 reply_to update. */
+export function commentReplies(rows: Row[]): { legacy_id: string; reply_legacy_id: string }[] {
+  return rows
+    .filter((r) => r.reply_to != null && r.id != null)
+    .map((r) => ({ legacy_id: r.id as string, reply_legacy_id: r.reply_to as string }));
+}
+
+/** old `idea_user_interest_relation` → `public.interest` (spec §5). */
+export function toInterest(r: Row): SqlRow {
+  return {
+    legacy_id: lit(r.id),
+    idea_id: ideaRef(r.idea),
+    profile_id: lit(r.user ?? null),
+    note_md: lit(nullifBlank(r.how)),
+    legacy: jsonbLit({ contact_if_started: r.contact_if_started ?? undefined }),
+    created_at: lit(r.created_at ?? { sql: 'now()' })
+  };
+}
+
+/** old `results` → `public.answers` as verified historical outputs (spec §5). `titles` = old idea id → title. */
+export function toAnswerFromResult(r: Row, titles: Map<string, string>): SqlRow {
+  const title = nullifBlank(r.title) ?? `Result: ${(r.idea != null && titles.get(r.idea)) || 'untitled idea'}`;
+  return {
+    legacy_id: lit(r.id),
+    idea_id: ideaRef(r.idea),
+    submitter_id: lit(r.user ?? null),
+    title: lit(title),
+    explanation_md: lit(nullifBlank(r.description)),
+    status: lit('verified'),
+    verified_at: lit(r.created_at ?? null),           // old table names no verifier; verified_by stays NULL
+    legacy: jsonbLit({
+      author: r.author ?? undefined,
+      image_link: nullifBlank(r.image_link) ?? undefined,
+      type: r.type ?? undefined,
+      link: nullifBlank(r.link) ?? undefined,
+      from_date: r.from_date ?? undefined,
+      original: r.original ?? undefined
+    }),
+    created_at: lit(r.created_at ?? { sql: 'now()' })
+  };
+}
+
+/** One `answer_artifacts` row per result with a non-blank link; null otherwise. */
+export function toAnswerArtifact(r: Row): SqlRow | null {
+  const url = nullifBlank(r.link);
+  if (!url) return null;
+  return {
+    legacy_id: lit(r.id),
+    answer_id: answerRef(r.id),
+    kind: lit('url'),
+    url: lit(url),
+    created_at: lit(r.created_at ?? { sql: 'now()' })
+  };
+}
+
+/** old `idea_user_likes` → `public.idea_votes` as upvotes; old weight kept in legacy (spec §5). */
+export function toVote(l: Row): SqlRow {
+  return {
+    legacy_id: lit(l.id),
+    idea_id: ideaRef(l.idea),
+    profile_id: lit(l.user ?? null),
+    value: '1',
+    legacy: jsonbLit({ size: l.size ?? undefined }),
+    created_at: lit(l.created_at ?? { sql: 'now()' })
+  };
+}
+
+/** Guard for `unique (idea_id, profile_id)`: keep the earliest like per (user, idea). */
+export function dedupeVotes(rows: Row[]): { kept: Row[]; dropped: number } {
+  const sorted = [...rows].sort((a, b) => String(a.created_at ?? '').localeCompare(String(b.created_at ?? '')));
+  const seen = new Set<string>();
+  const kept: Row[] = [];
+  for (const r of sorted) {
+    const key = `${r.user}|${r.idea}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push(r);
+  }
+  return { kept, dropped: rows.length - kept.length };
+}

--- a/src/lib/components/IdeaCard.svelte
+++ b/src/lib/components/IdeaCard.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import StatusBadge from './StatusBadge.svelte';
-  let { idea }: { idea: { id: string; title: string; summary_md: string | null; type: string; status: string } } = $props();
+  let { idea }: { idea: { id: string; title: string; summary_md: string | null; type: string; status: string; score?: number } } = $props();
 </script>
 <a href="/ideas/{idea.id}" class="block rounded-2xl border p-5 transition"
    style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
   <div class="mb-2 flex items-center justify-between gap-2">
     <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
-    <StatusBadge status={idea.status} />
+    <span class="flex items-center gap-2">
+      {#if typeof idea.score === 'number'}
+        <span class="text-xs font-semibold tabular-nums" style="color:var(--muted)">▲ {idea.score}</span>
+      {/if}
+      <StatusBadge status={idea.status} />
+    </span>
   </div>
   <h3 class="font-bold" style="color:var(--ink)">{idea.title}</h3>
   {#if idea.summary_md}<p class="mt-1 line-clamp-2 text-sm" style="color:var(--muted)">{idea.summary_md}</p>{/if}

--- a/src/lib/components/VoteControl.svelte
+++ b/src/lib/components/VoteControl.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  let { score, myVote, canVote, signinHref }: {
+    score: number; myVote: 1 | -1 | null; canVote: boolean; signinHref?: string;
+  } = $props();
+
+  // Optimistic local view (spec §6): apply the expected outcome immediately, reconcile when the
+  // action's load re-run delivers fresh props (the $effect clears the override on every prop change).
+  let pending = $state(false);
+  let optimistic = $state<{ score: number; myVote: 1 | -1 | null } | null>(null);
+  $effect(() => { void score; void myVote; optimistic = null; });
+  const view = $derived(optimistic ?? { score, myVote });
+
+  const submit = (value: 1 | -1) => () => {
+    const cur = view;
+    optimistic = cur.myVote === value
+      ? { score: cur.score - value, myVote: null }                        // same arrow → unvote
+      : { score: cur.score + value - (cur.myVote ?? 0), myVote: value };  // vote / switch
+    pending = true;
+    return async ({ update }: { update: () => Promise<void> }) => {
+      await update();           // re-runs the load → fresh score/myVote → $effect clears optimistic
+      pending = false;
+    };
+  };
+</script>
+<div class="flex items-center gap-1.5 rounded-xl border px-2 py-1"
+     style="border-color:var(--line); background:var(--surface)">
+  {#if !canVote && signinHref}
+    <a href={signinHref} class="px-1" aria-label="Sign in to vote" style="color:var(--muted)">▲</a>
+    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{view.score}</span>
+    <a href={signinHref} class="px-1" aria-label="Sign in to vote" style="color:var(--muted)">▼</a>
+  {:else}
+    <form method="POST" action={view.myVote === 1 ? '?/unvote' : '?/vote'} use:enhance={submit(1)}>
+      <input type="hidden" name="value" value="1" />
+      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Upvote"
+              aria-pressed={view.myVote === 1}
+              style="color:{view.myVote === 1 ? 'var(--green-deep)' : 'var(--muted)'}">▲</button>
+    </form>
+    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{view.score}</span>
+    <form method="POST" action={view.myVote === -1 ? '?/unvote' : '?/vote'} use:enhance={submit(-1)}>
+      <input type="hidden" name="value" value="-1" />
+      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Downvote"
+              aria-pressed={view.myVote === -1}
+              style="color:{view.myVote === -1 ? 'var(--neg)' : 'var(--muted)'}">▼</button>
+    </form>
+  {/if}
+</div>

--- a/src/lib/components/VoteControl.svelte
+++ b/src/lib/components/VoteControl.svelte
@@ -11,14 +11,16 @@
   $effect(() => { void score; void myVote; optimistic = null; });
   const view = $derived(optimistic ?? { score, myVote });
 
-  const submit = (value: 1 | -1) => () => {
+  const submit = (value: 1 | -1) => ({ cancel }: { cancel: () => void }) => {
+    if (pending) { cancel(); return; }
     const cur = view;
     optimistic = cur.myVote === value
       ? { score: cur.score - value, myVote: null }                        // same arrow → unvote
       : { score: cur.score + value - (cur.myVote ?? 0), myVote: value };  // vote / switch
     pending = true;
     return async ({ update }: { update: () => Promise<void> }) => {
-      await update();           // re-runs the load → fresh score/myVote → $effect clears optimistic
+      await update();           // fresh props on success; form error on failure
+      optimistic = null;        // always reconcile to props (truth), success or failure
       pending = false;
     };
   };
@@ -32,15 +34,15 @@
   {:else}
     <form method="POST" action={view.myVote === 1 ? '?/unvote' : '?/vote'} use:enhance={submit(1)}>
       <input type="hidden" name="value" value="1" />
-      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Upvote"
-              aria-pressed={view.myVote === 1}
+      <button class="px-1 transition" class:opacity-40={pending} disabled={!canVote} aria-label="Upvote"
+              aria-pressed={view.myVote === 1} aria-disabled={pending}
               style="color:{view.myVote === 1 ? 'var(--green-deep)' : 'var(--muted)'}">▲</button>
     </form>
-    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)">{view.score}</span>
+    <span class="min-w-5 text-center text-sm font-semibold tabular-nums" style="color:var(--ink)" aria-label={'Score ' + view.score}>{view.score}</span>
     <form method="POST" action={view.myVote === -1 ? '?/unvote' : '?/vote'} use:enhance={submit(-1)}>
       <input type="hidden" name="value" value="-1" />
-      <button class="px-1 transition disabled:opacity-40" disabled={!canVote || pending} aria-label="Downvote"
-              aria-pressed={view.myVote === -1}
+      <button class="px-1 transition" class:opacity-40={pending} disabled={!canVote} aria-label="Downvote"
+              aria-pressed={view.myVote === -1} aria-disabled={pending}
               style="color:{view.myVote === -1 ? 'var(--neg)' : 'var(--muted)'}">▼</button>
     </form>
   {/if}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -511,6 +511,51 @@ export type Database = {
           },
         ]
       }
+      idea_votes: {
+        Row: {
+          created_at: string
+          id: string
+          idea_id: string
+          legacy: Json
+          legacy_id: number | null
+          profile_id: string
+          value: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          idea_id: string
+          legacy?: Json
+          legacy_id?: number | null
+          profile_id: string
+          value: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          idea_id?: string
+          legacy?: Json
+          legacy_id?: number | null
+          profile_id?: string
+          value?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "idea_votes_idea_id_fkey"
+            columns: ["idea_id"]
+            isOneToOne: false
+            referencedRelation: "ideas"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "idea_votes_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ideas: {
         Row: {
           author_id: string | null
@@ -690,62 +735,25 @@ export type Database = {
           },
         ]
       }
-      pg_all_foreign_keys: {
+      idea_vote_totals: {
         Row: {
-          fk_columns: unknown[] | null
-          fk_constraint_name: unknown
-          fk_schema_name: unknown
-          fk_table_name: unknown
-          fk_table_oid: unknown
-          is_deferrable: boolean | null
-          is_deferred: boolean | null
-          match_type: string | null
-          on_delete: string | null
-          on_update: string | null
-          pk_columns: unknown[] | null
-          pk_constraint_name: unknown
-          pk_index_name: unknown
-          pk_schema_name: unknown
-          pk_table_name: unknown
-          pk_table_oid: unknown
+          down_count: number | null
+          idea_id: string | null
+          score: number | null
+          up_count: number | null
         }
-        Relationships: []
-      }
-      tap_funky: {
-        Row: {
-          args: string | null
-          is_definer: boolean | null
-          is_strict: boolean | null
-          is_visible: boolean | null
-          kind: unknown
-          langoid: unknown
-          name: unknown
-          oid: unknown
-          owner: unknown
-          returns: string | null
-          returns_set: boolean | null
-          schema: unknown
-          volatility: string | null
-        }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "idea_votes_idea_id_fkey"
+            columns: ["idea_id"]
+            isOneToOne: false
+            referencedRelation: "ideas"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Functions: {
-      _cleanup: { Args: never; Returns: boolean }
-      _contract_on: { Args: { "": string }; Returns: unknown }
-      _currtest: { Args: never; Returns: number }
-      _db_privs: { Args: never; Returns: unknown[] }
-      _extensions: { Args: never; Returns: unknown[] }
-      _get: { Args: { "": string }; Returns: number }
-      _get_latest: { Args: { "": string }; Returns: number[] }
-      _get_note: { Args: { "": string }; Returns: string }
-      _is_verbose: { Args: never; Returns: boolean }
-      _prokind: { Args: { p_oid: unknown }; Returns: unknown }
-      _query: { Args: { "": string }; Returns: string }
-      _refine_vol: { Args: { "": string }; Returns: string }
-      _table_privs: { Args: never; Returns: unknown[] }
-      _temptypes: { Args: { "": string }; Returns: string }
-      _todo: { Args: never; Returns: string }
       admin_approve_payout: {
         Args: { p_answer_id: string; p_note?: string }
         Returns: {
@@ -804,79 +812,7 @@ export type Database = {
           isSetofReturn: false
         }
       }
-      col_is_null:
-        | {
-            Args: {
-              column_name: unknown
-              description?: string
-              schema_name: unknown
-              table_name: unknown
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              column_name: unknown
-              description?: string
-              table_name: unknown
-            }
-            Returns: string
-          }
-      col_not_null:
-        | {
-            Args: {
-              column_name: unknown
-              description?: string
-              schema_name: unknown
-              table_name: unknown
-            }
-            Returns: string
-          }
-        | {
-            Args: {
-              column_name: unknown
-              description?: string
-              table_name: unknown
-            }
-            Returns: string
-          }
-      diag:
-        | {
-            Args: { msg: unknown }
-            Returns: {
-              error: true
-            } & "Could not choose the best candidate function between: public.diag(msg => text), public.diag(msg => anyelement). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
-          }
-        | {
-            Args: { msg: string }
-            Returns: {
-              error: true
-            } & "Could not choose the best candidate function between: public.diag(msg => text), public.diag(msg => anyelement). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
-          }
-      diag_test_name: { Args: { "": string }; Returns: string }
-      do_tap:
-        | { Args: never; Returns: string[] }
-        | { Args: { "": string }; Returns: string[] }
-      fail:
-        | { Args: never; Returns: string }
-        | { Args: { "": string }; Returns: string }
-      findfuncs: { Args: { "": string }; Returns: string[] }
-      finish: { Args: { exception_on_failure?: boolean }; Returns: string[] }
-      has_unique: { Args: { "": string }; Returns: string }
-      in_todo: { Args: never; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
-      is_empty: { Args: { "": string }; Returns: string }
-      isnt_empty: { Args: { "": string }; Returns: string }
-      lives_ok: { Args: { "": string }; Returns: string }
-      no_plan: { Args: never; Returns: boolean[] }
-      num_failed: { Args: never; Returns: number }
-      os_name: { Args: never; Returns: string }
-      pass:
-        | { Args: never; Returns: string }
-        | { Args: { "": string }; Returns: string }
-      pg_version: { Args: never; Returns: string }
-      pg_version_num: { Args: never; Returns: number }
-      pgtap_version: { Args: never; Returns: number }
       reject_answer: {
         Args: { p_answer_id: string; p_note?: string }
         Returns: {
@@ -968,12 +904,6 @@ export type Database = {
           isSetofReturn: false
         }
       }
-      runtests:
-        | { Args: never; Returns: string[] }
-        | { Args: { "": string }; Returns: string[] }
-      skip:
-        | { Args: { "": string }; Returns: string }
-        | { Args: { how_many: number; why: string }; Returns: string }
       start_review: {
         Args: { p_answer_id: string }
         Returns: {
@@ -1003,16 +933,6 @@ export type Database = {
           isSetofReturn: false
         }
       }
-      throws_ok: { Args: { "": string }; Returns: string }
-      todo:
-        | { Args: { how_many: number }; Returns: boolean[] }
-        | { Args: { how_many: number; why: string }; Returns: boolean[] }
-        | { Args: { why: string }; Returns: boolean[] }
-        | { Args: { how_many: number; why: string }; Returns: boolean[] }
-      todo_end: { Args: never; Returns: boolean[] }
-      todo_start:
-        | { Args: never; Returns: boolean[] }
-        | { Args: { "": string }; Returns: boolean[] }
       verify_answer: {
         Args: {
           p_answer_id: string
@@ -1052,9 +972,7 @@ export type Database = {
       [_ in never]: never
     }
     CompositeTypes: {
-      _time_trial_type: {
-        a_time: number | null
-      }
+      [_ in never]: never
     }
   }
 }

--- a/src/lib/votes.test.ts
+++ b/src/lib/votes.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { attachScores, sortTop } from './votes';
+
+describe('votes helpers', () => {
+  it('attachScores joins totals onto ideas, defaulting 0', () => {
+    const out = attachScores(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ idea_id: 'b', score: 5 }]
+    );
+    expect(out).toEqual([{ id: 'a', score: 0 }, { id: 'b', score: 5 }]);
+  });
+  it('sortTop orders by score desc, then created_at desc', () => {
+    const out = sortTop([
+      { id: 'a', score: 1, created_at: '2024-01-01' },
+      { id: 'b', score: 5, created_at: '2023-01-01' },
+      { id: 'c', score: 1, created_at: '2025-01-01' }
+    ]);
+    expect(out.map((r) => r.id)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -11,7 +11,9 @@ export function attachScores<T extends { id: string }>(
 
 /** Score desc, ties broken by created_at desc. */
 export function sortTop<T extends { score: number; created_at?: string | null }>(rows: T[]): T[] {
-  return [...rows].sort(
-    (a, b) => b.score - a.score || String(b.created_at ?? '').localeCompare(String(a.created_at ?? ''))
-  );
+  return [...rows].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const x = String(a.created_at ?? ''), y = String(b.created_at ?? '');
+    return x < y ? 1 : x > y ? -1 : 0;   // created_at desc, locale-independent
+  });
 }

--- a/src/lib/votes.ts
+++ b/src/lib/votes.ts
@@ -1,0 +1,17 @@
+export type VoteTotal = { idea_id: string; score: number };
+
+/** Join vote totals onto idea rows; ideas without votes get score 0 (the view omits them). */
+export function attachScores<T extends { id: string }>(
+  ideas: T[],
+  totals: VoteTotal[]
+): (T & { score: number })[] {
+  const byIdea = new Map(totals.map((t) => [t.idea_id, t.score]));
+  return ideas.map((i) => ({ ...i, score: byIdea.get(i.id) ?? 0 }));
+}
+
+/** Score desc, ties broken by created_at desc. */
+export function sortTop<T extends { score: number; created_at?: string | null }>(rows: T[]): T[] {
+  return [...rows].sort(
+    (a, b) => b.score - a.score || String(b.created_at ?? '').localeCompare(String(a.created_at ?? ''))
+  );
+}

--- a/src/routes/ideas/+page.server.ts
+++ b/src/routes/ideas/+page.server.ts
@@ -1,16 +1,41 @@
 import type { PageServerLoad } from './$types';
+import { attachScores, sortTop, type VoteTotal } from '$lib/votes';
 
 const PAGE = 24;
 export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
   const type = url.searchParams.get('type');       // 'hypothesis' | 'open_ended' | null
+  const sort = url.searchParams.get('sort') === 'top' ? 'top' : 'new';
   const page = Math.max(0, Number(url.searchParams.get('page') ?? 0));
-  let q = supabase
+
+  // vote totals are small (≤ #ideas rows; ~240 today, well under PostgREST's 1000-row cap — revisit
+  // both whole-set fetches if the idea count ever approaches 1000) — fetched once for the card scores
+  const { data: rawTotals } = await supabase.from('idea_vote_totals').select('idea_id, score');
+  // the view's generated types are nullable (aggregate view); normalize to non-null VoteTotal
+  const totals: VoteTotal[] = (rawTotals ?? []).flatMap((t) =>
+    t.idea_id ? [{ idea_id: t.idea_id, score: t.score ?? 0 }] : []
+  );
+
+  let base = supabase
     .from('ideas')
-    .select('id, title, summary_md, type, status', { count: 'exact' })
-    .neq('status', 'draft')
+    .select('id, title, summary_md, type, status, created_at', { count: 'exact' })
+    .neq('status', 'draft');
+  if (type === 'hypothesis' || type === 'open_ended') base = base.eq('type', type);
+
+  if (sort === 'top') {
+    // global sort by score needs the whole (small) set; slice the page in memory
+    const { data: all } = await base.order('created_at', { ascending: false });
+    const ranked = sortTop(attachScores(all ?? [], totals));
+    return {
+      ideas: ranked.slice(page * PAGE, (page + 1) * PAGE),
+      count: ranked.length, page, pageSize: PAGE, type, sort
+    };
+  }
+
+  const { data: ideas, count } = await base
     .order('created_at', { ascending: false })
     .range(page * PAGE, page * PAGE + PAGE - 1);
-  if (type === 'hypothesis' || type === 'open_ended') q = q.eq('type', type);
-  const { data: ideas, count } = await q;
-  return { ideas: ideas ?? [], count: count ?? 0, page, pageSize: PAGE, type };
+  return {
+    ideas: attachScores(ideas ?? [], totals),
+    count: count ?? 0, page, pageSize: PAGE, type, sort
+  };
 };

--- a/src/routes/ideas/+page.server.ts
+++ b/src/routes/ideas/+page.server.ts
@@ -5,7 +5,7 @@ const PAGE = 24;
 export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
   const type = url.searchParams.get('type');       // 'hypothesis' | 'open_ended' | null
   const sort = url.searchParams.get('sort') === 'top' ? 'top' : 'new';
-  const page = Math.max(0, Number(url.searchParams.get('page') ?? 0));
+  const page = Math.max(0, Math.trunc(Number(url.searchParams.get('page'))) || 0);
 
   // vote totals are small (≤ #ideas rows; ~240 today, well under PostgREST's 1000-row cap — revisit
   // both whole-set fetches if the idea count ever approaches 1000) — fetched once for the card scores

--- a/src/routes/ideas/+page.svelte
+++ b/src/routes/ideas/+page.svelte
@@ -8,6 +8,12 @@
   <a href="/ideas?type=hypothesis" style="color:{data.type === 'hypothesis' ? 'var(--green-deep)' : 'var(--muted)'}">Hypotheses</a>
   <a href="/ideas?type=open_ended" style="color:{data.type === 'open_ended' ? 'var(--green-deep)' : 'var(--muted)'}">Open-ended</a>
 </nav>
+<nav class="mb-6 -mt-4 flex gap-2 text-sm">
+  <a href="/ideas{data.type ? `?type=${data.type}` : ''}"
+     style="color:{data.sort === 'top' ? 'var(--muted)' : 'var(--green-deep)'}">Newest</a>
+  <a href="/ideas?{data.type ? `type=${data.type}&` : ''}sort=top"
+     style="color:{data.sort === 'top' ? 'var(--green-deep)' : 'var(--muted)'}">Top</a>
+</nav>
 {#if data.ideas.length === 0}
   <p style="color:var(--muted)">No ideas yet.</p>
 {:else}
@@ -17,7 +23,7 @@
 {/if}
 {#if data.count > data.pageSize}
   <div class="mt-6 flex gap-3" style="color:var(--muted)">
-    {#if data.page > 0}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}page={data.page - 1}">← Prev</a>{/if}
-    {#if (data.page + 1) * data.pageSize < data.count}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}page={data.page + 1}">Next →</a>{/if}
+    {#if data.page > 0}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}{data.sort === 'top' ? 'sort=top&' : ''}page={data.page - 1}">← Prev</a>{/if}
+    {#if (data.page + 1) * data.pageSize < data.count}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}{data.sort === 'top' ? 'sort=top&' : ''}page={data.page + 1}">Next →</a>{/if}
   </div>
 {/if}

--- a/src/routes/ideas/[id]/+page.server.ts
+++ b/src/routes/ideas/[id]/+page.server.ts
@@ -176,7 +176,9 @@ export const actions: Actions = {
     if (value !== 1 && value !== -1) return fail(400, { message: 'Invalid vote' });
     // switch = delete own row first (no UPDATE policy), then insert; a 23505 race means a vote
     // already landed — treat as ok (the page re-load shows the truth)
-    await supabase.from('idea_votes').delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    const { error: delErr } = await supabase.from('idea_votes')
+      .delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    if (delErr) return fail(400, { message: delErr.message });
     const { error: e } = await supabase.from('idea_votes').insert({
       idea_id: params.id, profile_id: user.id, value
     });

--- a/src/routes/ideas/[id]/+page.server.ts
+++ b/src/routes/ideas/[id]/+page.server.ts
@@ -80,6 +80,16 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     isAdmin = me?.is_admin === true;
   }
 
+  // votes: totals + the caller's own vote
+  const { data: voteTotals } = await supabase
+    .from('idea_vote_totals').select('score').eq('idea_id', idea.id).maybeSingle();
+  let myVote: 1 | -1 | null = null;
+  if (user) {
+    const { data: mv } = await supabase
+      .from('idea_votes').select('value').eq('idea_id', idea.id).eq('profile_id', user.id).maybeSingle();
+    myVote = (mv?.value as 1 | -1 | undefined) ?? null;
+  }
+
   return {
     idea,
     summary_html: renderMarkdown(idea.summary_md),
@@ -90,6 +100,8 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     funders,
     comments,
     interestCount: interestCount ?? 0,
+    score: voteTotals?.score ?? 0,
+    myVote,
     myInterestId,
     isAdmin,
     userId: user?.id ?? null,
@@ -153,6 +165,31 @@ export const actions: Actions = {
       if ((e as { code?: string }).code === '23505') return { ok: true };
       return fail(400, { message: e.message });
     }
+    return { ok: true };
+  },
+
+  vote: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in to vote' });
+    const fd = await request.formData();
+    const value = Number(fd.get('value'));
+    if (value !== 1 && value !== -1) return fail(400, { message: 'Invalid vote' });
+    // switch = delete own row first (no UPDATE policy), then insert; a 23505 race means a vote
+    // already landed — treat as ok (the page re-load shows the truth)
+    await supabase.from('idea_votes').delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    const { error: e } = await supabase.from('idea_votes').insert({
+      idea_id: params.id, profile_id: user.id, value
+    });
+    if (e && (e as { code?: string }).code !== '23505') return fail(400, { message: e.message });
+    return { ok: true };
+  },
+
+  unvote: async ({ params, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const { error: e } = await supabase.from('idea_votes')
+      .delete().eq('idea_id', params.id).eq('profile_id', user.id);
+    if (e) return fail(400, { message: e.message });
     return { ok: true };
   },
 

--- a/src/routes/ideas/[id]/+page.svelte
+++ b/src/routes/ideas/[id]/+page.svelte
@@ -14,7 +14,7 @@
         <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{data.idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
         <div class="flex items-center gap-2">
           <VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage}
-                       signinHref={`/login?next=/ideas/${data.idea.id}`} />
+                       signinHref={'/login?next=' + encodeURIComponent('/ideas/' + data.idea.id)} />
           <StatusBadge status={data.idea.status} />
         </div>
       </div>

--- a/src/routes/ideas/[id]/+page.svelte
+++ b/src/routes/ideas/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import StatusBadge from '$lib/components/StatusBadge.svelte';
+  import VoteControl from '$lib/components/VoteControl.svelte';
   import AnswerCard from '$lib/components/AnswerCard.svelte';
   import BountyMeter from '$lib/components/BountyMeter.svelte';
   import Money from '$lib/components/Money.svelte';
@@ -11,7 +12,11 @@
     <article class="rounded-2xl border p-6" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
       <div class="mb-2 flex items-center justify-between">
         <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{data.idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
-        <StatusBadge status={data.idea.status} />
+        <div class="flex items-center gap-2">
+          <VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage}
+                       signinHref={`/login?next=/ideas/${data.idea.id}`} />
+          <StatusBadge status={data.idea.status} />
+        </div>
       </div>
       <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.idea.title}</h1>
       {#if data.author}<p class="text-sm" style="color:var(--faint)">by <a href="/u/{data.author.handle}" style="color:var(--green-deep)">{data.author.display_name ?? data.author.handle}</a></p>{/if}

--- a/src/routes/ideas/ideas.test.ts
+++ b/src/routes/ideas/ideas.test.ts
@@ -1,18 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import { load } from './+page.server';
 
-function mkLocals(rows: unknown[]) {
-  const builder: any = {
-    select() { return this; }, neq() { return this; }, order() { return this; }, eq() { return this; },
-    range() { return Promise.resolve({ data: rows, count: rows.length }); }
+function mkLocals(rows: unknown[], totals: unknown[] = []) {
+  const make = (table: string): any => {
+    if (table === 'idea_vote_totals') return { select: () => Promise.resolve({ data: totals }) };
+    // thenable builder: serves both `…order().range()` (new) and a directly-awaited `…order()` (top)
+    const result = { data: rows, count: rows.length };
+    const builder: any = {
+      select() { return this; }, neq() { return this; }, eq() { return this; }, order() { return this; },
+      range() { return Promise.resolve(result); },
+      then(resolve: any, reject: any) { return Promise.resolve(result).then(resolve, reject); }
+    };
+    return builder;
   };
-  return { supabase: { from: () => builder } } as any;
+  return { supabase: { from: (t: string) => make(t) } } as any;
 }
 
 describe('ideas browse load', () => {
-  it('returns ideas + count', async () => {
-    const res = (await load({ url: new URL('http://x/ideas'), locals: mkLocals([{ id: '1', title: 'A' }]) } as any)) as any;
-    expect(res.ideas.length).toBe(1);
+  it('returns ideas + count with scores attached', async () => {
+    const res = (await load({
+      url: new URL('http://x/ideas'),
+      locals: mkLocals([{ id: '1', title: 'A' }], [{ idea_id: '1', score: 3 }])
+    } as any)) as any;
+    expect(res.ideas).toEqual([{ id: '1', title: 'A', score: 3 }]);
     expect(res.count).toBe(1);
+  });
+  it('sort=top ranks by score desc', async () => {
+    const res = (await load({
+      url: new URL('http://x/ideas?sort=top'),
+      locals: mkLocals(
+        [{ id: '1', created_at: '2024-01-02' }, { id: '2', created_at: '2024-01-01' }],
+        [{ idea_id: '2', score: 9 }]
+      )
+    } as any)) as any;
+    expect(res.ideas.map((i: any) => i.id)).toEqual(['2', '1']);
   });
 });

--- a/supabase/migrations/20260606134730_idea_votes.sql
+++ b/supabase/migrations/20260606134730_idea_votes.sql
@@ -7,10 +7,9 @@ create table public.idea_votes (
   value      smallint not null check (value in (-1, 1)),
   legacy     jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now(),
-  unique (idea_id, profile_id)
+  unique (idea_id, profile_id) -- doubles as the idea_id index (leading column)
 );
 alter table public.idea_votes enable row level security;
-create index idea_votes_idea_id_idx on public.idea_votes (idea_id);
 create index idea_votes_profile_id_idx on public.idea_votes (profile_id);
 
 -- SELECT: readable when the idea is visible (leverages ideas RLS) OR it is the caller's own vote
@@ -31,6 +30,7 @@ create policy "member removes own vote" on public.idea_votes for delete to authe
   using ((select auth.uid()) = profile_id);
 -- NOTE: no UPDATE policy — switching a vote is delete + re-insert (same toggle pattern as interest).
 
+-- NOTE: aggregate-only — ideas with zero votes have NO row here; clients coalesce to 0 (by design).
 -- ============ idea_vote_totals (security_invoker: respects the caller's idea visibility) ============
 create view public.idea_vote_totals
   with (security_invoker = true) as

--- a/supabase/migrations/20260606134730_idea_votes.sql
+++ b/supabase/migrations/20260606134730_idea_votes.sql
@@ -1,0 +1,44 @@
+-- ============ idea_votes (one up/down vote per member per idea; toggle = delete + re-insert) ============
+create table public.idea_votes (
+  id         uuid primary key default gen_random_uuid(),
+  legacy_id  bigint unique,
+  idea_id    uuid not null references public.ideas(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade, -- a vote without a voter is meaningless
+  value      smallint not null check (value in (-1, 1)),
+  legacy     jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (idea_id, profile_id)
+);
+alter table public.idea_votes enable row level security;
+create index idea_votes_idea_id_idx on public.idea_votes (idea_id);
+create index idea_votes_profile_id_idx on public.idea_votes (profile_id);
+
+-- SELECT: readable when the idea is visible (leverages ideas RLS) OR it is the caller's own vote
+create policy "votes readable when idea visible or own" on public.idea_votes for select
+  using (
+    (select auth.uid()) = profile_id
+    or exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- INSERT: a member casts their OWN vote on a visible idea; legacy pinned (service-role-only)
+create policy "members vote on visible ideas" on public.idea_votes for insert to authenticated
+  with check (
+    (select auth.uid()) = profile_id
+    and legacy_id is null and legacy = '{}'::jsonb
+    and exists (select 1 from public.ideas i where i.id = idea_id)
+  );
+-- DELETE: a member removes their own vote
+create policy "member removes own vote" on public.idea_votes for delete to authenticated
+  using ((select auth.uid()) = profile_id);
+-- NOTE: no UPDATE policy — switching a vote is delete + re-insert (same toggle pattern as interest).
+
+-- ============ idea_vote_totals (security_invoker: respects the caller's idea visibility) ============
+create view public.idea_vote_totals
+  with (security_invoker = true) as
+  select
+    idea_id,
+    coalesce(sum(value), 0)::bigint           as score,
+    count(*) filter (where value = 1)         as up_count,
+    count(*) filter (where value = -1)        as down_count
+  from public.idea_votes
+  group by idea_id;
+grant select on public.idea_vote_totals to anon, authenticated;   -- mirrors bounty_pot (idea_funding migration)

--- a/supabase/tests/database/idea_votes_test.sql
+++ b/supabase/tests/database/idea_votes_test.sql
@@ -1,0 +1,75 @@
+begin;
+select plan(14);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),  -- expert author
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','44444444-4444-4444-4444-444444444444','authenticated','authenticated','dave@example.com','x', now(), now(), now());
+
+insert into public.experts (id, status) values ('11111111-1111-1111-1111-111111111111','approved');
+insert into public.ideas (id, author_id, type, title, status) values
+  ('a0000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','open_ended','Open idea','open'),
+  ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','open_ended','Draft idea','draft');
+
+set local role authenticated;
+
+-- ===== bob votes (insert pinning) =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1);
+select ok((select count(*) from public.idea_votes) = 1, '1: member upvotes a visible idea');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','44444444-4444-4444-4444-444444444444',1) $$,
+  '42501', null, '2: cannot vote as another member');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222',1) $$,
+  '42501', null, '3: cannot vote on a draft idea you cannot see');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value, legacy_id)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1,7) $$,
+  '42501', null, '4: cannot set legacy_id on a live vote');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value, legacy)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',1,'{"a":1}'::jsonb) $$,
+  '42501', null, '5: cannot set a non-empty legacy on a live vote');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',0) $$,
+  '23514', null, '6: value must be -1 or 1');
+select throws_ok($$ insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222',-1) $$,
+  '23505', null, '7: one vote per member per idea (switch = delete + re-insert)');
+
+-- ===== dave downvotes; deletes are own-only =====
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000001','44444444-4444-4444-4444-444444444444',-1);
+select ok((select count(*) from public.idea_votes) = 2, '8: second member downvotes');
+delete from public.idea_votes where profile_id = '22222222-2222-2222-2222-222222222222';
+select ok((select count(*) from public.idea_votes) = 2, '9: deleting another member''s vote is a no-op');
+select results_eq(
+  $$ select score, up_count, down_count from public.idea_vote_totals where idea_id = 'a0000000-0000-0000-0000-000000000001' $$,
+  $$ values (0::bigint, 1::bigint, 1::bigint) $$,
+  '10: totals view aggregates score/up/down');
+delete from public.idea_votes where profile_id = '44444444-4444-4444-4444-444444444444';
+select ok((select count(*) from public.idea_votes where profile_id = '44444444-4444-4444-4444-444444444444') = 0,
+  '11: member removes own vote');
+
+-- ===== draft visibility (author can vote own draft; others see nothing) =====
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+insert into public.idea_votes (idea_id, profile_id, value)
+  values ('a0000000-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111',1);
+select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000-0000-0000-000000000002') = 1,
+  '12: draft author can vote their own draft');
+
+set local role anon;
+-- CRITICAL: clear the stale JWT claims — `set local role` does NOT reset request.jwt.claims, so
+-- auth.uid() would still be alice and the own-row SELECT branch would leak her draft vote into
+-- test 14. The POLICY is correct; only an uncleared fixture would make it look broken. Do NOT
+-- "fix" a red test 14 by weakening the policy or the view.
+set local request.jwt.claims = '';
+select ok((select count(*) from public.idea_votes where idea_id = 'a0000000-0000-0000-0000-000000000001') = 1,
+  '13: anon sees votes on visible ideas');
+select ok((select count(*) from public.idea_vote_totals where idea_id = 'a0000000-0000-0000-0000-000000000002') = 0,
+  '14: draft votes invisible to anon through the view (security_invoker)');
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/idea_votes_test.sql
+++ b/supabase/tests/database/idea_votes_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(14);
+select plan(15);
 
 insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
 values
@@ -43,6 +43,9 @@ set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444","r
 insert into public.idea_votes (idea_id, profile_id, value)
   values ('a0000000-0000-0000-0000-000000000001','44444444-4444-4444-4444-444444444444',-1);
 select ok((select count(*) from public.idea_votes) = 2, '8: second member downvotes');
+update public.idea_votes set value = 1 where profile_id = '44444444-4444-4444-4444-444444444444';
+select ok((select value from public.idea_votes where profile_id = '44444444-4444-4444-4444-444444444444') = -1,
+  '8b: no UPDATE policy — a client update is a silent no-op (toggle is delete + re-insert)');
 delete from public.idea_votes where profile_id = '22222222-2222-2222-2222-222222222222';
 select ok((select count(*) from public.idea_votes) = 2, '9: deleting another member''s vote is a no-op');
 select results_eq(


### PR DESCRIPTION
## Summary
- **New `idea_votes` feature**: table + RLS (one ±1 vote per member per idea; toggle = delete+re-insert; no UPDATE policy) + `idea_vote_totals` security-invoker view + 15 pgTAP tests; optimistic `▲ score ▼` VoteControl on idea pages, score chips on `/ideas` cards, and a **Newest | Top** sort.
- **ETL Restore v2** (`scripts/etl/restore-v2.ts`, reusing the v1 machinery): 83 comments (13 threaded via two-pass reply linking), 133 interests, 5 historical results → verified answers (+5 artifact links), 387 old likes → upvotes. Idea/answer FKs resolve via scalar subqueries on `legacy_id`; interest/votes use targetless `on conflict do nothing` so organic rows displace rather than abort; embedded count + 10 orphan-scan assertions are the load's only (and sufficient) FK verification under `session_replication_role = replica`.
- Hardening from two adversarial review rounds: bigint-safe legacy refs, locale-independent dedupe, strict `insertRows` column keys, pgTAP stale-claims fixture trap, optimistic-state reconciliation on action failure, keyboard-focus retention.

## Status
- ✅ vitest 67/67 · pgTAP 111/111 · svelte-check 0 errors · build clean
- ✅ **Local rehearsal green**: fresh stack + v1 + v2 artifacts → counts exact (83/13/133/5/5/387, deduped 0), 0 orphans, assertions passed, idempotent re-run = pure no-op (`INSERT 0 0`/`UPDATE 0`); `/ideas?sort=top` renders restored scores live
- ⏳ Cloud apply (migration via MCP + artifact via Management API) follows merge, owner-gated

## Test Plan
- [x] `npx vitest run` · `supabase test db` · `npm run check` · `npm run build`
- [x] Controller rehearsal incl. idempotency + live UI smoke
- [ ] Post-merge: cloud migration + data load + advisors + deployed smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)