### PR TITLE
feat: app-wide rate limiting (DEFINER self-keyed RPC, no service-role client)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-rate-limiting.md
+++ b/docs/superpowers/plans/2026-06-07-rate-limiting.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development for Tasks 1–3. Steps use checkbox (`- [ ]`) syntax. **Task 4 is CONTROLLER-ONLY** (cloud). Subagents must never touch the cloud project or edit `CLAUDE.md`/`docs/`/`.claude/`/`src_legacy_v0/`, and never `git add .`/`git add -A` at repo root (untracked `.claude/` must stay uncommitted).
 
-**Goal:** Per-endpoint rate limiting on every mutation (20 form actions across 9 routes) with **zero service-role usage** — a SECURITY INVOKER RPC self-keyed on `auth.uid()` over an RLS-pinned table, plus a per-instance in-memory limiter for the anon login actions.
+**Goal:** Per-endpoint rate limiting on every mutation (20 form actions across 9 routes) with **no service-role client** — a SECURITY DEFINER RPC self-keyed on `auth.uid()` (limits authoritative in the function) over a zero-policy table, plus a per-instance in-memory limiter for the anon login actions.
 
-**Architecture:** One migration (`rate_limits` table with own-rows-only RLS + `consume_rate_limit` invoker function, executable by `authenticated` only) + one server module `$lib/server/rate-limit.ts` (`LIMITS` constants, DB-backed `rateLimit(supabase, bucket)` that FAILS OPEN, in-memory `loginLimited(ip)`) + a two-line guard in each action. Spec: `docs/superpowers/specs/2026-06-07-rate-limiting-design.md`.
+**Architecture:** One migration (`rate_limits` table with **zero client policies** + `consume_rate_limit` SECURITY DEFINER function that self-keys on `auth.uid()` and owns the limit values, executable by `authenticated` only) + one server module `$lib/server/rate-limit.ts` (`BUCKETS` name list, DB-backed `rateLimit(supabase, bucket)` that FAILS OPEN, in-memory `loginLimited(ip)`) + a two-line guard in each action. The DEFINER function is a DB primitive, **not** a service-role client ([[no-service-role-in-app]]). Spec: `docs/superpowers/specs/2026-06-07-rate-limiting-design.md`.
 
 **Tech Stack:** Postgres 17 / pgTAP, SvelteKit 2 form actions, supabase-js v2 (typed client — types regen required), vitest.
 
@@ -19,7 +19,7 @@
 | `supabase/migrations/<ts>_rate_limits.sql` | table + 4 own-rows policies + invoker RPC + grants |
 | `supabase/tests/database/rate_limits_test.sql` | pgTAP: limit math, isolation, rollover, cleanup, anon denied |
 | `src/lib/types/database.ts` | regenerated (RPC + table types) |
-| `src/lib/server/rate-limit.ts` | `LIMITS`, `Bucket`, `rateLimit()` (fail-open), `loginLimited()` |
+| `src/lib/server/rate-limit.ts` | `BUCKETS`, `Bucket`, `RATE_LIMIT_MESSAGE`, `rateLimit()` (fail-open), `loginLimited()` |
 | `src/lib/server/rate-limit.test.ts` | vitest for both limiters |
 | 9 `+page.server.ts` route files | two-line guard per action (bucket map below) |
 
@@ -35,61 +35,70 @@
 - [ ] **Step 1: Create the migration** (`supabase migration new rate_limits`, then fill with exactly):
 
 ```sql
--- ============ rate_limits (fixed-window counters; NO service role — pure RLS) ============
--- The RPC below is SECURITY INVOKER and derives its key from auth.uid() internally, so RLS pins
--- every row to the caller: a direct PostgREST call can only increment the caller's OWN counter
--- (self-harm), never another user's, and can never lower a count the server checks.
+-- ============ rate_limits (fixed-window counters; NO service-role CLIENT) ============
+-- Writes go ONLY through the SECURITY DEFINER function below (owned by postgres, bypasses RLS),
+-- which self-keys on auth.uid() and looks up limits server-side. The table has ZERO client
+-- policies, so a direct PostgREST UPDATE/DELETE/SELECT by `authenticated` matches nothing — the
+-- three INVOKER bypass vectors (self-reset count, self-delete, caller-chosen window) are closed.
+-- A definer function is a DB primitive, NOT the forbidden service-role client (see memory).
 create table public.rate_limits (
   key          text not null,         -- 'user:<uuid>' (authed users only; anon login is in-memory app-side)
-  bucket       text not null,         -- endpoint family, e.g. 'comment'
+  bucket       text not null,
   window_start timestamptz not null,  -- aligned to the bucket's window size
   count        int  not null default 1,
   primary key (key, bucket, window_start)
 );
 alter table public.rate_limits enable row level security;
+-- ZERO policies on purpose (deny-by-default for every client role, like answers/answer_reviews).
 
--- Own-rows-only for every verb (key pinned to the caller — the whole security model):
-create policy "own rate rows select" on public.rate_limits for select to authenticated
-  using (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows insert" on public.rate_limits for insert to authenticated
-  with check (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows update" on public.rate_limits for update to authenticated
-  using (key = 'user:' || (select auth.uid())::text)
-  with check (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows delete" on public.rate_limits for delete to authenticated
-  using (key = 'user:' || (select auth.uid())::text);
-
-create function public.consume_rate_limit(p_bucket text, p_max int, p_window_secs int)
+-- Limits are AUTHORITATIVE here (server-side), not caller params — nothing for a client to spoof.
+create function public.consume_rate_limit(p_bucket text)
 returns boolean
-language plpgsql security invoker set search_path = ''
+language plpgsql security definer set search_path = ''
 as $$
 declare
-  v_key text;
-  v_window timestamptz := to_timestamp(
-    floor(extract(epoch from now()) / p_window_secs) * p_window_secs);
+  v_uid uuid := (select auth.uid());
+  v_max int;
+  v_window_secs int;
+  v_window timestamptz;
   v_count int;
 begin
-  if (select auth.uid()) is null then
+  if v_uid is null then
     return true;   -- anon callers are not tracked here (login uses the app's in-memory limiter)
   end if;
-  v_key := 'user:' || (select auth.uid())::text;
 
-  -- opportunistic cleanup of the CALLER's stale rows (RLS-scoped; keeps per-user rows ~2/bucket)
+  -- authoritative limit table; keep in sync with BUCKETS in $lib/server/rate-limit.ts
+  case p_bucket
+    when 'comment'        then v_max := 10;  v_window_secs := 300;
+    when 'comment_delete' then v_max := 30;  v_window_secs := 300;
+    when 'engage'         then v_max := 60;  v_window_secs := 300;
+    when 'pledge'         then v_max := 10;  v_window_secs := 300;
+    when 'answer'         then v_max := 5;   v_window_secs := 3600;
+    when 'idea_create'    then v_max := 10;  v_window_secs := 3600;
+    when 'review'         then v_max := 60;  v_window_secs := 300;
+    when 'profile'        then v_max := 10;  v_window_secs := 3600;
+    when 'admin'          then v_max := 120; v_window_secs := 300;
+    else raise exception 'unknown rate-limit bucket: %', p_bucket;  -- dev bug → fail-open + logged
+  end case;
+
+  v_window := to_timestamp(floor(extract(epoch from now()) / v_window_secs) * v_window_secs);
+
+  -- prune this caller's stale rows for this bucket (definer-owned; no client DELETE path exists)
   delete from public.rate_limits
-    where key = v_key and bucket = p_bucket
-      and window_start < now() - make_interval(secs => 2 * p_window_secs);
+    where key = 'user:' || v_uid::text and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * v_window_secs);
 
   insert into public.rate_limits as r (key, bucket, window_start)
-    values (v_key, p_bucket, v_window)
+    values ('user:' || v_uid::text, p_bucket, v_window)
     on conflict (key, bucket, window_start)
     do update set count = r.count + 1
     returning count into v_count;
 
-  return v_count <= p_max;
+  return v_count <= v_max;
 end $$;
 
-revoke execute on function public.consume_rate_limit(text, text, int) from public, anon;
-grant execute on function public.consume_rate_limit(text, text, int) to authenticated;
+revoke execute on function public.consume_rate_limit(text) from public, anon;
+grant execute on function public.consume_rate_limit(text) to authenticated;
 ```
 
 - [ ] **Step 2: Write the pgTAP test** `supabase/tests/database/rate_limits_test.sql` (conventions per `idea_votes_test.sql`; `handle_new_user` auto-creates profiles):
@@ -106,45 +115,55 @@ values
 set local role authenticated;
 set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
 
--- ===== limit math (max=3, 1h window) =====
-select ok(public.consume_rate_limit('t_bucket', 3, 3600), '1: first call under limit');
-select ok(public.consume_rate_limit('t_bucket', 3, 3600), '2: second call under limit');
-select ok(public.consume_rate_limit('t_bucket', 3, 3600), '3: third call AT limit still true');
-select ok(not public.consume_rate_limit('t_bucket', 3, 3600), '4: fourth call over limit → false');
+-- ===== limit math on 'answer' (max 5 / hour); 4 warm-up calls, then assert at/over limit =====
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select ok(public.consume_rate_limit('answer'), '1: 5th call AT limit still true');       -- count 5 <= 5
+select ok(not public.consume_rate_limit('answer'), '2: 6th call over limit → false');     -- count 6 > 5
 
--- ===== per-user isolation =====
+-- ===== limits are server-authoritative: an unknown bucket raises (a dev bug, not a runtime path) =====
+select throws_ok($$ select public.consume_rate_limit('nope') $$, 'P0001', null, '3: unknown bucket raises');
+
+-- ===== zero-policy lockdown: a client cannot read or mutate rate_limits directly =====
+select ok((select count(*) from public.rate_limits) = 0,
+  '4: authenticated cannot SELECT rate_limits (zero policies) though rows exist via the definer fn');
+with u as (update public.rate_limits set count = 0 where bucket = 'answer' returning 1)
+  select ok((select count(*) from u) = 0, '5: direct UPDATE count=0 matches no rows (Vector 1 closed)');
+with d as (delete from public.rate_limits where bucket = 'answer' returning 1)
+  select ok((select count(*) from d) = 0, '6: direct DELETE matches no rows (Vector 2 closed)');
+select ok(not public.consume_rate_limit('answer'),
+  '7: still over limit — the direct UPDATE/DELETE attempts reset nothing');
+
+-- ===== cross-user isolation: bob starts fresh in the same bucket =====
 set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
-select ok(public.consume_rate_limit('t_bucket', 3, 3600), '5: another user starts fresh in the same bucket');
-select ok((select count(*) from public.rate_limits where key like 'user:1111%') = 0,
-  '6: RLS hides (and protects) other users'' rows');
-update public.rate_limits set count = 0 where key like 'user:1111%';
-set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
-select ok(not public.consume_rate_limit('t_bucket', 3, 3600),
-  '7: bob''s update attempt touched nothing — alice is still over her limit');
+select ok(public.consume_rate_limit('answer'), '8: another user starts fresh');
 
--- ===== window rollover + caller-scoped cleanup (1s window so the test can outlive it) =====
--- (separate statements — never chain two volatile consume calls with AND; evaluation order is unspecified)
-select ok(public.consume_rate_limit('t_roll', 1, 1), '8: first call in the 1s window allowed');
-select ok(not public.consume_rate_limit('t_roll', 1, 1), '9: second call within the window over limit');
-select pg_sleep(2.1);
-select ok(public.consume_rate_limit('t_roll', 1, 1), '10: limit resets after the window passes');
+-- ===== window rollover: now() is FROZEN inside a txn, so age the stored row as the owner =====
+reset role;   -- back to postgres (table owner; bypasses RLS to simulate time passing)
+update public.rate_limits set window_start = window_start - interval '3 hours'
+  where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 'answer';
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+select ok(public.consume_rate_limit('answer'), '9: a new window resets the limit (aged row is stale)');
+reset role;   -- read the table as owner to verify cleanup (clients can''t SELECT it)
 select ok((select count(*) from public.rate_limits
-           where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 't_roll') = 1,
-  '11: stale t_roll rows were cleaned up (only the live window row remains)');
+           where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 'answer') = 1,
+  '10: the stale aged row was pruned — only the live window row remains');
+
+-- ===== anon cannot execute the function (revoked) =====
+set local role anon;
+set local request.jwt.claims = '';
+select throws_ok($$ select public.consume_rate_limit('comment') $$, '42501', null,
+  '11: anon execute is denied');
 
 select * from finish();
 rollback;
 ```
 
-> Why no anon-execute test: `set local role anon` + claims-reset then `throws_ok('42501')` would be
-> nice, but inside the same transaction the earlier `set local role authenticated` interactions make
-> the matrix fiddly; the REVOKE is structural in the migration and `npm run check` + a manual PostgREST
-> probe in Task 4 confirm it. If you can add it cleanly as a 12th test (reset claims to `''`,
-> `set local role anon`, `throws_ok($$select public.consume_rate_limit('x',1,1)$$, '42501', null, …)`),
-> do — bump `plan()` accordingly.
-
-- [ ] **Step 3: Run** `supabase db reset` then `supabase test db` → `rate_limits_test` green (9 or 10), all existing suites still green (111 + new).
-- [ ] **Step 4: Regenerate types** `supabase gen types typescript --local > src/lib/types/database.ts`; `npm run check` → 0 errors. Verify the regen contains `consume_rate_limit` and `rate_limits` (and no pgTAP pollution — regen runs after a fresh `db reset`, BEFORE `supabase test db` if pollution appears).
+- [ ] **Step 3: Run** `supabase db reset` then `supabase test db` → `rate_limits_test` **11/11**, all existing suites still green (111 + 11 = 122).
+- [ ] **Step 4: Regenerate types** `supabase gen types typescript --local > src/lib/types/database.ts`; `npm run check` → 0 errors. Verify the regen contains `consume_rate_limit` (now a single `p_bucket text` arg) and `rate_limits` (regen runs right after `db reset`, before `supabase test db`, so no pgTAP pollution leaks in).
 - [ ] **Step 5: Commit** `git add supabase/migrations supabase/tests/database/rate_limits_test.sql src/lib/types/database.ts && git commit -m "feat(rate-limit): rate_limits table + RLS-pinned invoker RPC + pgTAP + types"`
 
 ---
@@ -159,18 +178,21 @@ rollback;
 
 ```ts
 import { describe, it, expect, vi } from 'vitest';
-import { LIMITS, rateLimit, loginLimited, __resetLoginLimiter } from './rate-limit';
+import { BUCKETS, rateLimit, loginLimited, __resetLoginLimiter } from './rate-limit';
 
 const mkSupabase = (rpc: (...a: any[]) => any) => ({ rpc }) as any;
 
 describe('rateLimit (DB-backed, fail-open)', () => {
-  it('passes the bucket constants to the RPC and allows on true', async () => {
+  it('passes ONLY the bucket name to the RPC (limits are server-authoritative) and allows on true', async () => {
     const rpc = vi.fn().mockResolvedValue({ data: true, error: null });
     const res = await rateLimit(mkSupabase(rpc), 'comment');
-    expect(rpc).toHaveBeenCalledWith('consume_rate_limit', {
-      p_bucket: 'comment', p_max: LIMITS.comment.max, p_window_secs: LIMITS.comment.windowSecs
-    });
+    expect(rpc).toHaveBeenCalledWith('consume_rate_limit', { p_bucket: 'comment' });
     expect(res.ok).toBe(true);
+  });
+  it('exports the full bucket set for the wiring map', () => {
+    expect(BUCKETS).toContain('comment');
+    expect(BUCKETS).toContain('admin');
+    expect(BUCKETS).not.toContain('login');   // login is the in-memory limiter, not a DB bucket
   });
   it('blocks when the RPC returns false', async () => {
     const res = await rateLimit(mkSupabase(vi.fn().mockResolvedValue({ data: false, error: null })), 'pledge');
@@ -210,37 +232,33 @@ describe('loginLimited (in-memory, per-IP)', () => {
 ```ts
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-/** Lenient launch caps (spec §4 — only a script should hit these; tighten from data later). */
-export const LIMITS = {
-  comment:        { max: 10,  windowSecs: 300 },
-  comment_delete: { max: 30,  windowSecs: 300 },
-  engage:         { max: 60,  windowSecs: 300 },    // vote/unvote/interest/uninterest/follow/unfollow
-  pledge:         { max: 10,  windowSecs: 300 },    // pledge + withdraw
-  answer:         { max: 5,   windowSecs: 3600 },
-  idea_create:    { max: 10,  windowSecs: 3600 },
-  review:         { max: 60,  windowSecs: 300 },
-  profile:        { max: 10,  windowSecs: 3600 },
-  admin:          { max: 120, windowSecs: 300 }
-} as const;
-export type Bucket = keyof typeof LIMITS;
+/**
+ * Bucket NAMES only. The limit VALUES are authoritative in the SQL function
+ * `public.consume_rate_limit` (its CASE) — keep this list in sync with that CASE; a bucket here
+ * but not there raises at runtime (caught by fail-open + log), and vice-versa is a dead name.
+ * `login` is intentionally absent — it's the in-memory limiter below, not a DB bucket.
+ */
+export const BUCKETS = [
+  'comment', 'comment_delete', 'engage', 'pledge', 'answer',
+  'idea_create', 'review', 'profile', 'admin'
+] as const;
+export type Bucket = (typeof BUCKETS)[number];
 
-/** One user-visible message everywhere (keep copy identical across actions). */
+/** Shared 429 copy for the authed buckets (login uses its own message). */
 export const RATE_LIMIT_MESSAGE = 'Slow down — try again in a moment.';
 
 /**
- * DB-backed limiter for AUTHED mutations. Calls the SECURITY INVOKER RPC with the caller's own
- * client — the RPC self-keys on auth.uid() and RLS pins the rows, so no service role is needed
- * (and none may be introduced — owner principle). FAILS OPEN on RPC error: a limiter outage must
- * never take the site down; the spam risk is bounded, the availability risk is not.
+ * DB-backed limiter for AUTHED mutations. Calls the SECURITY DEFINER RPC with the caller's own
+ * `locals.supabase` client; the function (owned by postgres) self-keys on auth.uid() and looks
+ * up the limit server-side — no service-role CLIENT involved (see memory: no-service-role-in-app).
+ * FAILS OPEN on RPC error: a limiter outage must never take the site down; the spam risk is
+ * bounded, the availability risk is not.
  */
 export async function rateLimit(
   supabase: SupabaseClient<any>,
   bucket: Bucket
 ): Promise<{ ok: boolean }> {
-  const { max, windowSecs } = LIMITS[bucket];
-  const { data, error } = await supabase.rpc('consume_rate_limit', {
-    p_bucket: bucket, p_max: max, p_window_secs: windowSecs
-  });
+  const { data, error } = await supabase.rpc('consume_rate_limit', { p_bucket: bucket });
   if (error) {
     console.error(`rate-limit rpc failed (fail-open) bucket=${bucket}: ${error.message}`);
     return { ok: true };
@@ -248,9 +266,10 @@ export async function rateLimit(
   return { ok: data !== false };
 }
 
-// ── login limiter: in-memory, per-IP. The DB cannot key anon callers without trusting spoofable
-// input, so this is deliberately per-fluid-compute-instance (real cap = 10 × instances, resets on
-// cold start) — belt-and-suspenders; Supabase Auth's own email limits are the real backstop. ──
+// ── login limiter: in-memory, per-IP, BEST-EFFORT. The DB cannot key anon callers without trusting
+// spoofable input; getClientAddress() derives from a client-influenced x-forwarded-for and the map is
+// per-fluid-compute-instance (real cap ≈ 10 × instances, resets on cold start). NOT anti-spoof —
+// Supabase Auth's own email limits are the real backstop; this just blunts casual repeat-submits. ──
 const LOGIN = { max: 10, windowMs: 15 * 60_000 };
 let loginHits = new Map<string, number[]>();
 
@@ -278,7 +297,7 @@ export function __resetLoginLimiter() {
 > — use whichever satisfies `locals.supabase`'s type without casts at the call sites.
 
 - [ ] **Step 4: Run** `npx vitest run src/lib/server/rate-limit.test.ts` → PASS; `npm run check` → 0 errors.
-- [ ] **Step 5: Commit** `git add src/lib/server/rate-limit.ts src/lib/server/rate-limit.test.ts && git commit -m "feat(rate-limit): LIMITS + fail-open rateLimit helper + in-memory login limiter"`
+- [ ] **Step 5: Commit** `git add src/lib/server/rate-limit.ts src/lib/server/rate-limit.test.ts && git commit -m "feat(rate-limit): BUCKETS + fail-open rateLimit helper + in-memory login limiter"`
 
 ---
 
@@ -323,7 +342,14 @@ if (!(await rateLimit(supabase, 'comment')).ok) return fail(429, { message: RATE
 
 `logout` stays untouched (exempt). NOTE for ideas/[id] `vote`: the guard goes after the
 `if (!user)` check and before the value validation; for console actions, after the
-`requireExpert` line; for admin actions, after `requireAdmin`.
+`requireExpert` line; for admin actions, after `requireAdmin`. Actions that end in `redirect(303,…)`
+on success (`console.create`) are unaffected — the guard `return fail(429,…)`s *before* the redirect
+throw, so there's no interaction.
+
+**Intentionally NOT guarded** (confirm, don't add): the `/auth/callback` GET route exchanges the
+OAuth/magic-link code for a session — it's the Supabase-driven auth return, not a user-triggerable
+mutation, and the `login` limiter already throttles the step that *issues* those codes. No `+server.ts`
+endpoints exist. (Grep `src/routes` for `+server` / `actions` to confirm before finishing.)
 
 - [ ] **Step 2: Login actions** (`src/routes/login/+page.server.ts`) — per-IP, in-memory; the
   actions gain `getClientAddress` in their destructure:
@@ -388,23 +414,24 @@ describe('comment action rate limiting', () => {
 > (429 + message + no insert) are the contract, not the mock.
 
 - [ ] **Step 4: Run everything.** `npx vitest run` → all green (existing 67 + new); `npm run check` → 0 errors; `npm run build` → succeeds; `supabase test db` → all green (the wiring changes no SQL, but run it to be sure nothing drifted).
-- [ ] **Step 5: Manual smoke** (stack running, `npm run dev`): sign in locally is impractical headlessly — instead temporarily verify via the test above plus: `curl -X POST localhost:5173/login?/magiclink -d 'email=x@y.z'` 11 times → the 11th response body contains `Too many attempts` (anon path needs no session). Stop after verifying; no code changes.
+- [ ] **Step 5: Manual smoke** (stack running, `npm run dev`): the anon login limiter needs no session — `for i in $(seq 1 11); do curl -s -X POST 'localhost:5173/login?/magiclink' -F 'email=x@y.z' -o /dev/null -w "%{http_code} "; done` → the 11th is the limited response (the magic-link send to a junk address against the LOCAL stack is fine; do NOT do this against prod). Stop after verifying; no code changes.
 - [ ] **Step 6: Commit** `git add src/routes && git commit -m "feat(rate-limit): guard all 20 mutation actions per the spec bucket map"`
 
 ---
 
 ## Task 4 (CONTROLLER ONLY — cloud): migrate + PR
 
-- [ ] Apply the `rate_limits` migration to `gjomchhbsbtauzkpyjwa`: MCP `apply_migration` if the MCP has been re-authed, else the Management API query endpoint (PAT) with the DDL + a `supabase_migrations.schema_migrations` history row (version = the migration timestamp, name `rate_limits`) — the proven v2 path.
-- [ ] Cloud probe: as an authenticated PostgREST call, `consume_rate_limit` works and self-keys; as anon it is denied (verify the revoke). Check `rate_limits` is not readable cross-user.
-- [ ] Re-run security advisors (Management API `/advisors/security`) — expect the unchanged baseline (the new function is SECURITY INVOKER ⇒ no new WARN).
-- [ ] Push branch, `gh pr create` (summary: no-service-role rate limiting, bucket map, fail-open), owner merges; deployed smoke: 11 rapid magic-link attempts → 429.
+- [ ] Apply the `rate_limits` migration to `gjomchhbsbtauzkpyjwa`. **Prefer MCP `apply_migration`** (writes the history row itself) if the MCP has been re-authed. Else the Management API query endpoint (PAT): send the migration DDL **and** the history insert in ONE query so they commit atomically — `insert into supabase_migrations.schema_migrations(version, name, statements) values('<migration timestamp>', 'rate_limits', null)` (version is the PK that gates re-apply; name/statements are nullable). (This is the v2 fallback path; it is a Management-API insert, not MCP.)
+- [ ] Cloud probe (Management API, authenticated context not available — use SQL as postgres): confirm `select public.consume_rate_limit('comment')` works; `\df+` shows the grant is `authenticated` only; a direct `select/update/delete on public.rate_limits` as `authenticated`/`anon` returns/affects nothing (zero policies). Anon `execute` is revoked.
+- [ ] Re-run security advisors (Management API `/advisors/security`) — expect baseline **+1**: a new `authenticated_security_definer_function_executable` WARN for `consume_rate_limit` (accepted; self-authorizes via auth.uid(), touches only the caller's rows). No other new findings.
+- [ ] Push branch, `gh pr create` (summary: rate limiting via DEFINER self-keyed RPC + zero-policy table, bucket map, fail-open, in-memory login), owner merges.
+- [ ] **Deployed smoke (no email burn):** sign in, then POST one guarded authed action (e.g. a comment) 11× rapidly → the 11th returns the 429 message. (Do NOT blast magic-link emails at prod — that burns Supabase Auth's email quota against a real address.)
 - [ ] Update project memory (rate limiting done — Phase-1 security complete).
 
 ---
 
 ## Done-when
-- pgTAP `rate_limits_test` green (9–10 tests) + all suites; vitest green incl. helper + wiring tests; `npm run check` 0 errors; build clean.
-- Every action in the §5 map guarded; `logout` exempt; login per-IP in-memory.
-- No service-role client anywhere in `src/` (grep `SERVICE_ROLE` → only `.env.local`).
-- Cloud migrated, advisors at baseline, PR merged.
+- pgTAP `rate_limits_test` 11/11 + all suites (122 total); vitest green incl. helper + wiring tests; `npm run check` 0 errors; build clean.
+- Every action in the §5 map guarded; `logout` exempt; login per-IP in-memory; the three INVOKER bypass vectors are asserted-closed in pgTAP.
+- No service-role **client** anywhere in `src/` (grep `SERVICE_ROLE` → only `.env.local`); privilege lives only in the DEFINER function.
+- Cloud migrated, advisors at baseline +1 (the accepted new definer WARN), PR merged.

--- a/docs/superpowers/plans/2026-06-07-rate-limiting.md
+++ b/docs/superpowers/plans/2026-06-07-rate-limiting.md
@@ -1,0 +1,410 @@
+# App-wide Rate Limiting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development for Tasks 1–3. Steps use checkbox (`- [ ]`) syntax. **Task 4 is CONTROLLER-ONLY** (cloud). Subagents must never touch the cloud project or edit `CLAUDE.md`/`docs/`/`.claude/`/`src_legacy_v0/`, and never `git add .`/`git add -A` at repo root (untracked `.claude/` must stay uncommitted).
+
+**Goal:** Per-endpoint rate limiting on every mutation (20 form actions across 9 routes) with **zero service-role usage** — a SECURITY INVOKER RPC self-keyed on `auth.uid()` over an RLS-pinned table, plus a per-instance in-memory limiter for the anon login actions.
+
+**Architecture:** One migration (`rate_limits` table with own-rows-only RLS + `consume_rate_limit` invoker function, executable by `authenticated` only) + one server module `$lib/server/rate-limit.ts` (`LIMITS` constants, DB-backed `rateLimit(supabase, bucket)` that FAILS OPEN, in-memory `loginLimited(ip)`) + a two-line guard in each action. Spec: `docs/superpowers/specs/2026-06-07-rate-limiting-design.md`.
+
+**Tech Stack:** Postgres 17 / pgTAP, SvelteKit 2 form actions, supabase-js v2 (typed client — types regen required), vitest.
+
+**Security model (read first):** the RPC derives its key internally from `auth.uid()` — there is NO key parameter. A malicious direct PostgREST call can only increment the caller's own counter (self-harm); cross-user DoS is impossible and counts can never be lowered. Anon callers cannot be keyed safely through the DB (spoofable), so `login` uses the in-memory limiter. **No service-role client anywhere** (owner principle — do not introduce one).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/<ts>_rate_limits.sql` | table + 4 own-rows policies + invoker RPC + grants |
+| `supabase/tests/database/rate_limits_test.sql` | pgTAP: limit math, isolation, rollover, cleanup, anon denied |
+| `src/lib/types/database.ts` | regenerated (RPC + table types) |
+| `src/lib/server/rate-limit.ts` | `LIMITS`, `Bucket`, `rateLimit()` (fail-open), `loginLimited()` |
+| `src/lib/server/rate-limit.test.ts` | vitest for both limiters |
+| 9 `+page.server.ts` route files | two-line guard per action (bucket map below) |
+
+---
+
+## Task 1: `rate_limits` migration + pgTAP + types
+
+**Files:**
+- Create: `supabase/migrations/<generated>_rate_limits.sql` (via `supabase migration new rate_limits`)
+- Create: `supabase/tests/database/rate_limits_test.sql`
+- Modify: `src/lib/types/database.ts` (regenerated)
+
+- [ ] **Step 1: Create the migration** (`supabase migration new rate_limits`, then fill with exactly):
+
+```sql
+-- ============ rate_limits (fixed-window counters; NO service role — pure RLS) ============
+-- The RPC below is SECURITY INVOKER and derives its key from auth.uid() internally, so RLS pins
+-- every row to the caller: a direct PostgREST call can only increment the caller's OWN counter
+-- (self-harm), never another user's, and can never lower a count the server checks.
+create table public.rate_limits (
+  key          text not null,         -- 'user:<uuid>' (authed users only; anon login is in-memory app-side)
+  bucket       text not null,         -- endpoint family, e.g. 'comment'
+  window_start timestamptz not null,  -- aligned to the bucket's window size
+  count        int  not null default 1,
+  primary key (key, bucket, window_start)
+);
+alter table public.rate_limits enable row level security;
+
+-- Own-rows-only for every verb (key pinned to the caller — the whole security model):
+create policy "own rate rows select" on public.rate_limits for select to authenticated
+  using (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows insert" on public.rate_limits for insert to authenticated
+  with check (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows update" on public.rate_limits for update to authenticated
+  using (key = 'user:' || (select auth.uid())::text)
+  with check (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows delete" on public.rate_limits for delete to authenticated
+  using (key = 'user:' || (select auth.uid())::text);
+
+create function public.consume_rate_limit(p_bucket text, p_max int, p_window_secs int)
+returns boolean
+language plpgsql security invoker set search_path = ''
+as $$
+declare
+  v_key text;
+  v_window timestamptz := to_timestamp(
+    floor(extract(epoch from now()) / p_window_secs) * p_window_secs);
+  v_count int;
+begin
+  if (select auth.uid()) is null then
+    return true;   -- anon callers are not tracked here (login uses the app's in-memory limiter)
+  end if;
+  v_key := 'user:' || (select auth.uid())::text;
+
+  -- opportunistic cleanup of the CALLER's stale rows (RLS-scoped; keeps per-user rows ~2/bucket)
+  delete from public.rate_limits
+    where key = v_key and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * p_window_secs);
+
+  insert into public.rate_limits as r (key, bucket, window_start)
+    values (v_key, p_bucket, v_window)
+    on conflict (key, bucket, window_start)
+    do update set count = r.count + 1
+    returning count into v_count;
+
+  return v_count <= p_max;
+end $$;
+
+revoke execute on function public.consume_rate_limit(text, text, int) from public, anon;
+grant execute on function public.consume_rate_limit(text, text, int) to authenticated;
+```
+
+- [ ] **Step 2: Write the pgTAP test** `supabase/tests/database/rate_limits_test.sql` (conventions per `idea_votes_test.sql`; `handle_new_user` auto-creates profiles):
+
+```sql
+begin;
+select plan(11);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now());
+
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+
+-- ===== limit math (max=3, 1h window) =====
+select ok(public.consume_rate_limit('t_bucket', 3, 3600), '1: first call under limit');
+select ok(public.consume_rate_limit('t_bucket', 3, 3600), '2: second call under limit');
+select ok(public.consume_rate_limit('t_bucket', 3, 3600), '3: third call AT limit still true');
+select ok(not public.consume_rate_limit('t_bucket', 3, 3600), '4: fourth call over limit → false');
+
+-- ===== per-user isolation =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+select ok(public.consume_rate_limit('t_bucket', 3, 3600), '5: another user starts fresh in the same bucket');
+select ok((select count(*) from public.rate_limits where key like 'user:1111%') = 0,
+  '6: RLS hides (and protects) other users'' rows');
+update public.rate_limits set count = 0 where key like 'user:1111%';
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+select ok(not public.consume_rate_limit('t_bucket', 3, 3600),
+  '7: bob''s update attempt touched nothing — alice is still over her limit');
+
+-- ===== window rollover + caller-scoped cleanup (1s window so the test can outlive it) =====
+-- (separate statements — never chain two volatile consume calls with AND; evaluation order is unspecified)
+select ok(public.consume_rate_limit('t_roll', 1, 1), '8: first call in the 1s window allowed');
+select ok(not public.consume_rate_limit('t_roll', 1, 1), '9: second call within the window over limit');
+select pg_sleep(2.1);
+select ok(public.consume_rate_limit('t_roll', 1, 1), '10: limit resets after the window passes');
+select ok((select count(*) from public.rate_limits
+           where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 't_roll') = 1,
+  '11: stale t_roll rows were cleaned up (only the live window row remains)');
+
+select * from finish();
+rollback;
+```
+
+> Why no anon-execute test: `set local role anon` + claims-reset then `throws_ok('42501')` would be
+> nice, but inside the same transaction the earlier `set local role authenticated` interactions make
+> the matrix fiddly; the REVOKE is structural in the migration and `npm run check` + a manual PostgREST
+> probe in Task 4 confirm it. If you can add it cleanly as a 12th test (reset claims to `''`,
+> `set local role anon`, `throws_ok($$select public.consume_rate_limit('x',1,1)$$, '42501', null, …)`),
+> do — bump `plan()` accordingly.
+
+- [ ] **Step 3: Run** `supabase db reset` then `supabase test db` → `rate_limits_test` green (9 or 10), all existing suites still green (111 + new).
+- [ ] **Step 4: Regenerate types** `supabase gen types typescript --local > src/lib/types/database.ts`; `npm run check` → 0 errors. Verify the regen contains `consume_rate_limit` and `rate_limits` (and no pgTAP pollution — regen runs after a fresh `db reset`, BEFORE `supabase test db` if pollution appears).
+- [ ] **Step 5: Commit** `git add supabase/migrations supabase/tests/database/rate_limits_test.sql src/lib/types/database.ts && git commit -m "feat(rate-limit): rate_limits table + RLS-pinned invoker RPC + pgTAP + types"`
+
+---
+
+## Task 2: `$lib/server/rate-limit.ts` + vitest
+
+**Files:**
+- Create: `src/lib/server/rate-limit.ts`
+- Create: `src/lib/server/rate-limit.test.ts`
+
+- [ ] **Step 1: Write the failing test** `src/lib/server/rate-limit.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { LIMITS, rateLimit, loginLimited, __resetLoginLimiter } from './rate-limit';
+
+const mkSupabase = (rpc: (...a: any[]) => any) => ({ rpc }) as any;
+
+describe('rateLimit (DB-backed, fail-open)', () => {
+  it('passes the bucket constants to the RPC and allows on true', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: true, error: null });
+    const res = await rateLimit(mkSupabase(rpc), 'comment');
+    expect(rpc).toHaveBeenCalledWith('consume_rate_limit', {
+      p_bucket: 'comment', p_max: LIMITS.comment.max, p_window_secs: LIMITS.comment.windowSecs
+    });
+    expect(res.ok).toBe(true);
+  });
+  it('blocks when the RPC returns false', async () => {
+    const res = await rateLimit(mkSupabase(vi.fn().mockResolvedValue({ data: false, error: null })), 'pledge');
+    expect(res.ok).toBe(false);
+  });
+  it('FAILS OPEN when the RPC errors (limiter outage must never block users)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await rateLimit(
+      mkSupabase(vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } })), 'engage');
+    expect(res.ok).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('loginLimited (in-memory, per-IP)', () => {
+  it('allows up to 10 in the window, blocks the 11th, keyed per IP', () => {
+    __resetLoginLimiter();
+    const t0 = 1_000_000;
+    for (let i = 0; i < 10; i++) expect(loginLimited('1.2.3.4', t0 + i)).toBe(false);
+    expect(loginLimited('1.2.3.4', t0 + 10)).toBe(true);     // 11th blocked
+    expect(loginLimited('5.6.7.8', t0 + 10)).toBe(false);    // other IP unaffected
+  });
+  it('forgets attempts after the 15-minute window', () => {
+    __resetLoginLimiter();
+    const t0 = 1_000_000;
+    for (let i = 0; i < 11; i++) loginLimited('1.2.3.4', t0 + i);
+    expect(loginLimited('1.2.3.4', t0 + 15 * 60_000 + 100)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run src/lib/server/rate-limit.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `src/lib/server/rate-limit.ts`:
+
+```ts
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Lenient launch caps (spec §4 — only a script should hit these; tighten from data later). */
+export const LIMITS = {
+  comment:        { max: 10,  windowSecs: 300 },
+  comment_delete: { max: 30,  windowSecs: 300 },
+  engage:         { max: 60,  windowSecs: 300 },    // vote/unvote/interest/uninterest/follow/unfollow
+  pledge:         { max: 10,  windowSecs: 300 },    // pledge + withdraw
+  answer:         { max: 5,   windowSecs: 3600 },
+  idea_create:    { max: 10,  windowSecs: 3600 },
+  review:         { max: 60,  windowSecs: 300 },
+  profile:        { max: 10,  windowSecs: 3600 },
+  admin:          { max: 120, windowSecs: 300 }
+} as const;
+export type Bucket = keyof typeof LIMITS;
+
+/** One user-visible message everywhere (keep copy identical across actions). */
+export const RATE_LIMIT_MESSAGE = 'Slow down — try again in a moment.';
+
+/**
+ * DB-backed limiter for AUTHED mutations. Calls the SECURITY INVOKER RPC with the caller's own
+ * client — the RPC self-keys on auth.uid() and RLS pins the rows, so no service role is needed
+ * (and none may be introduced — owner principle). FAILS OPEN on RPC error: a limiter outage must
+ * never take the site down; the spam risk is bounded, the availability risk is not.
+ */
+export async function rateLimit(
+  supabase: SupabaseClient<any>,
+  bucket: Bucket
+): Promise<{ ok: boolean }> {
+  const { max, windowSecs } = LIMITS[bucket];
+  const { data, error } = await supabase.rpc('consume_rate_limit', {
+    p_bucket: bucket, p_max: max, p_window_secs: windowSecs
+  });
+  if (error) {
+    console.error(`rate-limit rpc failed (fail-open) bucket=${bucket}: ${error.message}`);
+    return { ok: true };
+  }
+  return { ok: data !== false };
+}
+
+// ── login limiter: in-memory, per-IP. The DB cannot key anon callers without trusting spoofable
+// input, so this is deliberately per-fluid-compute-instance (real cap = 10 × instances, resets on
+// cold start) — belt-and-suspenders; Supabase Auth's own email limits are the real backstop. ──
+const LOGIN = { max: 10, windowMs: 15 * 60_000 };
+let loginHits = new Map<string, number[]>();
+
+/** True when this IP has exceeded the login window. `now` is injectable for tests. */
+export function loginLimited(ip: string, now: number = Date.now()): boolean {
+  const cutoff = now - LOGIN.windowMs;
+  const hits = (loginHits.get(ip) ?? []).filter((t) => t > cutoff);
+  hits.push(now);
+  loginHits.set(ip, hits);
+  if (loginHits.size > 10_000) {
+    // memory backstop: drop IPs with no live hits
+    for (const [k, v] of loginHits) if (!v.some((t) => t > cutoff)) loginHits.delete(k);
+  }
+  return hits.length > LOGIN.max;
+}
+
+/** Test hook only. */
+export function __resetLoginLimiter() {
+  loginHits = new Map();
+}
+```
+
+> If the regenerated `Database` types make `supabase.rpc('consume_rate_limit', …)` fully typed,
+> prefer `SupabaseClient<Database>` (import from `$lib/types/database`) over `SupabaseClient<any>`
+> — use whichever satisfies `locals.supabase`'s type without casts at the call sites.
+
+- [ ] **Step 4: Run** `npx vitest run src/lib/server/rate-limit.test.ts` → PASS; `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add src/lib/server/rate-limit.ts src/lib/server/rate-limit.test.ts && git commit -m "feat(rate-limit): LIMITS + fail-open rateLimit helper + in-memory login limiter"`
+
+---
+
+## Task 3: wire every action
+
+**Files (modify):**
+- `src/routes/ideas/[id]/+page.server.ts` (7 actions)
+- `src/routes/ideas/[id]/answer/+page.server.ts` (1)
+- `src/routes/console/+page.server.ts` (5)
+- `src/routes/dashboard/+page.server.ts` (3)
+- `src/routes/u/[handle]/+page.server.ts` (1)
+- `src/routes/admin/experts/+page.server.ts` (1)
+- `src/routes/admin/payouts/+page.server.ts` (2)
+- `src/routes/login/+page.server.ts` (2)
+- Test: `src/routes/ideas/[id]/rate-limit-wiring.test.ts` (new)
+
+The guard is identical everywhere; it goes **immediately after the auth/role check** (so
+unauthenticated requests never consume budget) and **before any `formData()` parsing or DB write**:
+
+```ts
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
+// …inside the action, right after the `if (!user) return fail(401, …)` (or requireExpert/requireAdmin) check:
+if (!(await rateLimit(supabase, 'comment')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
+```
+
+- [ ] **Step 1: Bucket map — apply to every action** (file → action → bucket):
+
+| File | Action | Bucket |
+|---|---|---|
+| ideas/[id] | `comment` | `comment` |
+| ideas/[id] | `delete_comment` | `comment_delete` |
+| ideas/[id] | `vote`, `unvote`, `interest`, `uninterest` | `engage` |
+| ideas/[id] | `pledge` | `pledge` |
+| ideas/[id]/answer | `default` | `answer` |
+| console | `create` | `idea_create` |
+| console | `start_review`, `verify`, `request_revision`, `reject` | `review` |
+| dashboard | `follow`, `unfollow` | `engage` |
+| dashboard | `withdraw` | `pledge` |
+| u/[handle] | `update` | `profile` |
+| admin/experts | `setStatus` | `admin` |
+| admin/payouts | `approve`, `reject` | `admin` |
+
+`logout` stays untouched (exempt). NOTE for ideas/[id] `vote`: the guard goes after the
+`if (!user)` check and before the value validation; for console actions, after the
+`requireExpert` line; for admin actions, after `requireAdmin`.
+
+- [ ] **Step 2: Login actions** (`src/routes/login/+page.server.ts`) — per-IP, in-memory; the
+  actions gain `getClientAddress` in their destructure:
+
+```ts
+import { loginLimited } from '$lib/server/rate-limit';
+
+  google: async ({ url, getClientAddress, locals: { supabase } }) => {
+    if (loginLimited(getClientAddress()))
+      return fail(429, { message: 'Too many attempts — try again in a few minutes.' });
+    // …existing body unchanged
+  },
+  magiclink: async ({ request, url, getClientAddress, locals: { supabase } }) => {
+    if (loginLimited(getClientAddress()))
+      return fail(429, { message: 'Too many attempts — try again in a few minutes.' });
+    // …existing body unchanged
+  }
+```
+
+- [ ] **Step 3: Write the wiring test** `src/routes/ideas/[id]/rate-limit-wiring.test.ts` —
+  representative proof that an over-limit comment returns the 429 fail (mock the supabase client;
+  the `comment` action consults the RPC before inserting):
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { actions } from './+page.server';
+import { RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
+
+function mkEvent(rpcData: boolean) {
+  const supabase: any = {
+    rpc: vi.fn().mockResolvedValue({ data: rpcData, error: null }),
+    from: vi.fn(() => ({ insert: vi.fn().mockResolvedValue({ error: null }) }))
+  };
+  return {
+    params: { id: 'idea-1' },
+    request: { formData: async () => new Map([['body_md', 'hello']]) },
+    locals: {
+      supabase,
+      safeGetSession: async () => ({ user: { id: 'user-1' } })
+    }
+  } as any;
+}
+
+describe('comment action rate limiting', () => {
+  it('returns 429 with the shared message when over limit, before any insert', async () => {
+    const event = mkEvent(false);
+    const res: any = await (actions as any).comment(event);
+    expect(res?.status).toBe(429);
+    expect(res?.data?.message).toBe(RATE_LIMIT_MESSAGE);
+    expect(event.locals.supabase.from).not.toHaveBeenCalled();   // guard runs before the write
+  });
+  it('proceeds to the insert when under limit', async () => {
+    const event = mkEvent(true);
+    await (actions as any).comment(event);
+    expect(event.locals.supabase.from).toHaveBeenCalledWith('comments');
+  });
+});
+```
+
+> The `request.formData` mock returns a `Map` (has `.get`) — if the action's parsing needs a real
+> `FormData`, construct one instead. Adjust the mock to the action's actual shape; the assertions
+> (429 + message + no insert) are the contract, not the mock.
+
+- [ ] **Step 4: Run everything.** `npx vitest run` → all green (existing 67 + new); `npm run check` → 0 errors; `npm run build` → succeeds; `supabase test db` → all green (the wiring changes no SQL, but run it to be sure nothing drifted).
+- [ ] **Step 5: Manual smoke** (stack running, `npm run dev`): sign in locally is impractical headlessly — instead temporarily verify via the test above plus: `curl -X POST localhost:5173/login?/magiclink -d 'email=x@y.z'` 11 times → the 11th response body contains `Too many attempts` (anon path needs no session). Stop after verifying; no code changes.
+- [ ] **Step 6: Commit** `git add src/routes && git commit -m "feat(rate-limit): guard all 20 mutation actions per the spec bucket map"`
+
+---
+
+## Task 4 (CONTROLLER ONLY — cloud): migrate + PR
+
+- [ ] Apply the `rate_limits` migration to `gjomchhbsbtauzkpyjwa`: MCP `apply_migration` if the MCP has been re-authed, else the Management API query endpoint (PAT) with the DDL + a `supabase_migrations.schema_migrations` history row (version = the migration timestamp, name `rate_limits`) — the proven v2 path.
+- [ ] Cloud probe: as an authenticated PostgREST call, `consume_rate_limit` works and self-keys; as anon it is denied (verify the revoke). Check `rate_limits` is not readable cross-user.
+- [ ] Re-run security advisors (Management API `/advisors/security`) — expect the unchanged baseline (the new function is SECURITY INVOKER ⇒ no new WARN).
+- [ ] Push branch, `gh pr create` (summary: no-service-role rate limiting, bucket map, fail-open), owner merges; deployed smoke: 11 rapid magic-link attempts → 429.
+- [ ] Update project memory (rate limiting done — Phase-1 security complete).
+
+---
+
+## Done-when
+- pgTAP `rate_limits_test` green (9–10 tests) + all suites; vitest green incl. helper + wiring tests; `npm run check` 0 errors; build clean.
+- Every action in the §5 map guarded; `logout` exempt; login per-IP in-memory.
+- No service-role client anywhere in `src/` (grep `SERVICE_ROLE` → only `.env.local`).
+- Cloud migrated, advisors at baseline, PR merged.

--- a/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
@@ -16,37 +16,62 @@ length caps (comment 10k, interest note 2k).
    limits (anti link-spam/enumeration).
 3. **Lenient launch posture** — caps only a script would hit; tighten later from data.
 
-## 2. Schema (one migration: `rate_limits`)
+## 2. Schema (one migration: `rate_limits`) — NO service role, pure RLS
+
+> **Owner principle (2026-06-07): the app never uses a service-role client — RLS is the only
+> authority.** The original draft used a service-role-only SECURITY DEFINER RPC; rejected.
+
+The trick that makes client-role rate limiting safe: the function is **SECURITY INVOKER** and
+derives its key from `auth.uid()` **internally** (no key parameter), so RLS pins every row to
+the caller. A malicious direct call via PostgREST can only increment the attacker's *own*
+counter — self-harm, never a cross-user DoS. Bypass is impossible (clients can only add counts,
+never reset them; the server's verdict reads the same pinned rows).
 
 ```sql
 create table public.rate_limits (
-  key          text not null,         -- 'user:<uuid>' | 'ip:<addr>'
+  key          text not null,         -- 'user:<uuid>' (DB tracks authed users only; anon → §4)
   bucket       text not null,         -- endpoint family, e.g. 'comment'
   window_start timestamptz not null,  -- aligned to the bucket's window size
   count        int  not null default 1,
   primary key (key, bucket, window_start)
 );
 alter table public.rate_limits enable row level security;
--- ZERO policies: deny-by-default for every client role. Only the RPC below touches it.
+
+-- Own-rows-only for every verb (key is pinned to the caller — the whole security model):
+create policy "own rate rows select" on public.rate_limits for select to authenticated
+  using (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows insert" on public.rate_limits for insert to authenticated
+  with check (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows update" on public.rate_limits for update to authenticated
+  using (key = 'user:' || (select auth.uid())::text)
+  with check (key = 'user:' || (select auth.uid())::text);
+create policy "own rate rows delete" on public.rate_limits for delete to authenticated
+  using (key = 'user:' || (select auth.uid())::text);
 ```
 
 ```sql
-create function public.consume_rate_limit(
-  p_key text, p_bucket text, p_max int, p_window_secs int
-) returns boolean
-language plpgsql security definer set search_path = ''
+create function public.consume_rate_limit(p_bucket text, p_max int, p_window_secs int)
+returns boolean
+language plpgsql security invoker set search_path = ''
 as $$
 declare
+  v_key text;
   v_window timestamptz := to_timestamp(
     floor(extract(epoch from now()) / p_window_secs) * p_window_secs);
   v_count int;
 begin
-  -- opportunistic cleanup: this bucket's rows older than two windows (keeps the table tiny; no cron)
+  if (select auth.uid()) is null then
+    return true;   -- anon callers are not tracked here (login uses the in-memory limiter, §4)
+  end if;
+  v_key := 'user:' || (select auth.uid())::text;
+
+  -- opportunistic cleanup of the CALLER's stale rows (RLS-scoped; keeps per-user rows ~2/bucket)
   delete from public.rate_limits
-    where bucket = p_bucket and window_start < now() - make_interval(secs => 2 * p_window_secs);
+    where key = v_key and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * p_window_secs);
 
   insert into public.rate_limits as r (key, bucket, window_start)
-    values (p_key, p_bucket, v_window)
+    values (v_key, p_bucket, v_window)
     on conflict (key, bucket, window_start)
     do update set count = r.count + 1
     returning count into v_count;
@@ -54,36 +79,20 @@ begin
   return v_count <= p_max;
 end $$;
 
--- THE key security decision: clients must NOT be able to call this (PostgREST would let any
--- authenticated user pass someone ELSE's key and exhaust their budget — a DoS primitive).
-revoke execute on function public.consume_rate_limit(text, text, int, int) from public, anon, authenticated;
--- service_role retains execute (default PUBLIC revoked; explicit grant):
-grant execute on function public.consume_rate_limit(text, text, int, int) to service_role;
+revoke execute on function public.consume_rate_limit(text, text, int) from public, anon;
+grant execute on function public.consume_rate_limit(text, text, int) to authenticated;
 ```
 
-Notes: SECURITY DEFINER + revoked-from-clients ⇒ **no new advisor WARN** (the baseline lint
-flags *authenticated-executable* definer functions only). Fixed-window means a boundary burst
-can briefly double a limit — acceptable at lenient settings; sliding windows aren't worth the
-complexity.
+Notes: SECURITY INVOKER ⇒ **no new advisor WARN** and no RLS bypass anywhere. `p_max`/
+`p_window_secs` come from the server's constants; a direct caller passing garbage values only
+pollutes their own key (and cannot lower the count the server sees). Fixed-window means a
+boundary burst can briefly double a limit — acceptable at lenient settings.
 
-## 3. Service-role client (`$lib/server/admin.ts` — NEW, first wiring of the service key)
+## 3. No service-role client
 
-```ts
-import { createClient } from '@supabase/supabase-js';
-import { env } from '$env/dynamic/private';   // SUPABASE_SERVICE_ROLE_KEY — server-only
-import { env as pub } from '$env/dynamic/public';
-
-/** Service-role client. SERVER ONLY ($lib/server). Bypasses RLS — use for the rate-limit RPC
- *  and nothing else without a design note. No session persistence. */
-export const adminClient = createClient(pub.PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
-  auth: { persistSession: false, autoRefreshToken: false }
-});
-```
-
-- Env var name matches `.env.local`: **`SUPABASE_SERVICE_ROLE_KEY`**.
-- **Owner action:** add it to Vercel env (all environments), server-side only (no `PUBLIC_` prefix
-  ⇒ never bundled). `$env/dynamic/private` keeps the build env-independent (same rationale as
-  PR #46).
+Deliberately none. The user-scoped `locals.supabase` client calls the RPC; RLS does all
+enforcement. (The `SUPABASE_SERVICE_ROLE_KEY` in `.env.local` stays unwired; no Vercel env
+action needed.)
 
 ## 4. Helper (`$lib/server/rate-limit.ts`)
 
@@ -103,12 +112,21 @@ export const LIMITS = {
 export type Bucket = keyof typeof LIMITS;
 ```
 
-`rateLimit(event, bucket): Promise<{ ok: boolean }>`:
-- key = `user:<auth user id>` when signed in (via `safeGetSession`), else `ip:<event.getClientAddress()>`
-  (on Vercel this is the trusted `x-forwarded-for`).
-- Calls `adminClient.rpc('consume_rate_limit', …)` with the bucket's max/window.
-- **Fails OPEN**: any RPC error ⇒ `console.error` + `{ ok: true }`. A limiter outage must never
+Two limiters, matched to what each role can do safely:
+
+- **Authed buckets (everything except `login`):** `rateLimit(event, bucket): Promise<{ ok: boolean }>`
+  calls `event.locals.supabase.rpc('consume_rate_limit', { p_bucket, p_max, p_window_secs })` —
+  the user's own client; the RPC self-keys on `auth.uid()` (§2). All these actions already
+  require a session, so the anon-returns-true branch is never the deciding check.
+  **Fails OPEN**: any RPC error ⇒ `console.error` + `{ ok: true }`. A limiter outage must never
   take the site down; the durable risk (spam) is bounded, the availability risk is not.
+- **`login` bucket (anon — the DB cannot key anon callers without trusting spoofable input):**
+  a small **in-memory fixed-window map** in the same module, keyed by
+  `event.getClientAddress()` (trusted `x-forwarded-for` on Vercel), pruned on access.
+  Per-fluid-compute-instance, so the real cap is `10 × instances` and resets on cold start —
+  explicitly **belt-and-suspenders**; Supabase Auth's own server-side email limits are the real
+  backstop. No DB, no spoofable key, nothing an attacker can exhaust for someone else
+  (worst case: shared-IP neighbors share a generous bucket).
 
 Action wiring (two lines per action):
 
@@ -143,20 +161,22 @@ is admin-set via `setStatus`), so no `apply` bucket.
 ## 6. Testing
 
 - **pgTAP** (`rate_limits_test.sql`): under-limit true → over-limit false within one window;
-  window rollover resets; separate keys/buckets independent; cleanup removes stale rows;
-  **execute denied for anon + authenticated** (the DoS hole pinned shut); table unreadable/unwritable
-  by client roles (zero policies).
-- **Vitest** (`rate-limit.test.ts`): keying (user vs ip), limits table lookup, fail-open on RPC
-  error (mocked), fail-closed-on-false (429 path) in one representative action test.
+  window rollover resets; separate buckets independent; **one user's consumption cannot touch
+  another user's rows** (call as A, then as B — B starts fresh; A cannot select/update/delete
+  B's rows directly); anon `execute` denied; cleanup removes the caller's stale rows only.
+- **Vitest** (`rate-limit.test.ts`): bucket→params lookup, fail-open on RPC error (mocked),
+  fail-closed-on-false (429 path) in one representative action test; the in-memory login
+  limiter (window expiry, per-IP independence, prune).
 - Manual: 11 rapid comments locally → the 11th gets the friendly 429 message.
 
 ## 7. Risks / accepted
 
 - **Fail-open** trades abuse-resistance for availability — deliberate.
 - Fixed-window boundary bursts (≤2× briefly) — accepted at lenient caps.
-- The service-role key now lives in the running server's env — standard Supabase posture; it was
-  always going to be wired for Phase 2 money; `$lib/server` placement keeps it out of the client
-  bundle (build asserts this: importing `$env/dynamic/private` from client code is a build error).
-- Per-user keys mean a shared-account attacker self-throttles only themselves — fine; IP keying
-  covers anon. IPv6 rotation can dodge `ip:` buckets — accepted for Phase 1 (WAF is the Phase-2
-  escalation if needed).
+- **No service role anywhere** (owner principle). Consequence: the `login` limiter is per-instance
+  in-memory and therefore leaky — accepted, because Supabase Auth's own email limits backstop it
+  and the alternative (DB-keyed anon) would hand attackers a spoofable key.
+- A signed-in attacker can self-throttle only themselves; anon abuse beyond login (e.g. read
+  flooding) is out of scope — reads are cheap and cacheable; WAF is the Phase-2 escalation.
+- Direct RPC calls with garbage `p_max`/`p_window_secs` pollute only the caller's own rows and
+  can never lower the count the server's check sees.

--- a/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
@@ -1,0 +1,162 @@
+# App-wide Rate Limiting (design)
+
+**Date:** 2026-06-07 · **Status:** approved by owner (this session)
+**Closes:** spec §9 of `2026-06-04-aisafetyideas-overhaul-design.md` ("rate-limit submit/donate
+endpoints") — the last Phase-1 security gap. Current state: no throttling anywhere; only inline
+length caps (comment 10k, interest note 2k).
+
+## 1. Decisions (owner-confirmed)
+
+1. **Mechanism: Postgres-backed fixed-window counter** — exact across all Vercel fluid-compute
+   instances, version-controlled with the schema, pgTAP-testable. +1 DB round-trip per mutation
+   (mutations are rare; negligible). Rejected: in-memory token bucket (per-instance on fluid
+   compute → limits multiply by instance count, reset on cold start); Vercel WAF rules
+   (dashboard config drifts from the repo, IP-keyed only, untestable in CI).
+2. **Login endpoints included** — per-IP, belt-and-suspenders over Supabase Auth's own email
+   limits (anti link-spam/enumeration).
+3. **Lenient launch posture** — caps only a script would hit; tighten later from data.
+
+## 2. Schema (one migration: `rate_limits`)
+
+```sql
+create table public.rate_limits (
+  key          text not null,         -- 'user:<uuid>' | 'ip:<addr>'
+  bucket       text not null,         -- endpoint family, e.g. 'comment'
+  window_start timestamptz not null,  -- aligned to the bucket's window size
+  count        int  not null default 1,
+  primary key (key, bucket, window_start)
+);
+alter table public.rate_limits enable row level security;
+-- ZERO policies: deny-by-default for every client role. Only the RPC below touches it.
+```
+
+```sql
+create function public.consume_rate_limit(
+  p_key text, p_bucket text, p_max int, p_window_secs int
+) returns boolean
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  v_window timestamptz := to_timestamp(
+    floor(extract(epoch from now()) / p_window_secs) * p_window_secs);
+  v_count int;
+begin
+  -- opportunistic cleanup: this bucket's rows older than two windows (keeps the table tiny; no cron)
+  delete from public.rate_limits
+    where bucket = p_bucket and window_start < now() - make_interval(secs => 2 * p_window_secs);
+
+  insert into public.rate_limits as r (key, bucket, window_start)
+    values (p_key, p_bucket, v_window)
+    on conflict (key, bucket, window_start)
+    do update set count = r.count + 1
+    returning count into v_count;
+
+  return v_count <= p_max;
+end $$;
+
+-- THE key security decision: clients must NOT be able to call this (PostgREST would let any
+-- authenticated user pass someone ELSE's key and exhaust their budget — a DoS primitive).
+revoke execute on function public.consume_rate_limit(text, text, int, int) from public, anon, authenticated;
+-- service_role retains execute (default PUBLIC revoked; explicit grant):
+grant execute on function public.consume_rate_limit(text, text, int, int) to service_role;
+```
+
+Notes: SECURITY DEFINER + revoked-from-clients ⇒ **no new advisor WARN** (the baseline lint
+flags *authenticated-executable* definer functions only). Fixed-window means a boundary burst
+can briefly double a limit — acceptable at lenient settings; sliding windows aren't worth the
+complexity.
+
+## 3. Service-role client (`$lib/server/admin.ts` — NEW, first wiring of the service key)
+
+```ts
+import { createClient } from '@supabase/supabase-js';
+import { env } from '$env/dynamic/private';   // SUPABASE_SERVICE_ROLE_KEY — server-only
+import { env as pub } from '$env/dynamic/public';
+
+/** Service-role client. SERVER ONLY ($lib/server). Bypasses RLS — use for the rate-limit RPC
+ *  and nothing else without a design note. No session persistence. */
+export const adminClient = createClient(pub.PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { persistSession: false, autoRefreshToken: false }
+});
+```
+
+- Env var name matches `.env.local`: **`SUPABASE_SERVICE_ROLE_KEY`**.
+- **Owner action:** add it to Vercel env (all environments), server-side only (no `PUBLIC_` prefix
+  ⇒ never bundled). `$env/dynamic/private` keeps the build env-independent (same rationale as
+  PR #46).
+
+## 4. Helper (`$lib/server/rate-limit.ts`)
+
+```ts
+export const LIMITS = {
+  comment:        { max: 10,  windowSecs: 300 },
+  comment_delete: { max: 30,  windowSecs: 300 },
+  engage:         { max: 60,  windowSecs: 300 },    // vote/unvote/interest/uninterest/follow/unfollow toggles
+  pledge:         { max: 10,  windowSecs: 300 },    // pledge + withdraw
+  answer:         { max: 5,   windowSecs: 3600 },   // answer submit (artifacts ride inside the same action)
+  idea_create:    { max: 10,  windowSecs: 3600 },   // expert posts an idea (console)
+  review:         { max: 60,  windowSecs: 300 },    // author review transitions (console RPCs)
+  profile:        { max: 10,  windowSecs: 3600 },
+  admin:          { max: 120, windowSecs: 300 },
+  login:          { max: 10,  windowSecs: 900 },    // per-IP (anon at that point)
+} as const;
+export type Bucket = keyof typeof LIMITS;
+```
+
+`rateLimit(event, bucket): Promise<{ ok: boolean }>`:
+- key = `user:<auth user id>` when signed in (via `safeGetSession`), else `ip:<event.getClientAddress()>`
+  (on Vercel this is the trusted `x-forwarded-for`).
+- Calls `adminClient.rpc('consume_rate_limit', …)` with the bucket's max/window.
+- **Fails OPEN**: any RPC error ⇒ `console.error` + `{ ok: true }`. A limiter outage must never
+  take the site down; the durable risk (spam) is bounded, the availability risk is not.
+
+Action wiring (two lines per action):
+
+```ts
+if (!(await rateLimit(event, 'comment')).ok)
+  return fail(429, { message: 'Slow down — try again in a moment.' });
+```
+
+The 429 surfaces through each form's existing error display; no new UI.
+
+## 5. Bucket → action map (complete)
+
+Verified against the actual action inventory (every `export const actions` member in the repo,
+2026-06-07) — **no unthrottled mutation remains**:
+
+| Bucket | Limit | Actions (file) |
+|---|---|---|
+| `comment` | 10/5min | `comment` (ideas/[id]) |
+| `comment_delete` | 30/5min | `delete_comment` (ideas/[id]) |
+| `engage` | 60/5min | `vote`, `unvote`, `interest`, `uninterest` (ideas/[id]); `follow`, `unfollow` (dashboard) |
+| `pledge` | 10/5min | `pledge` (ideas/[id]); `withdraw` (dashboard) |
+| `answer` | 5/h | `default` answer submit, artifacts included in the same action (ideas/[id]/answer) |
+| `idea_create` | 10/h | `create` (console) |
+| `review` | 60/5min | `start_review`, `verify`, `request_revision`, `reject` (console) |
+| `profile` | 10/h | `update` (u/[handle]) |
+| `admin` | 120/5min | `setStatus` (admin/experts); `approve`, `reject` (admin/payouts) |
+| `login` | 10/15min per IP | `google`, `magiclink` (login) |
+
+Exempt: `logout` `default` (harmless, idempotent). There is no expert-apply action (expert status
+is admin-set via `setStatus`), so no `apply` bucket.
+
+## 6. Testing
+
+- **pgTAP** (`rate_limits_test.sql`): under-limit true → over-limit false within one window;
+  window rollover resets; separate keys/buckets independent; cleanup removes stale rows;
+  **execute denied for anon + authenticated** (the DoS hole pinned shut); table unreadable/unwritable
+  by client roles (zero policies).
+- **Vitest** (`rate-limit.test.ts`): keying (user vs ip), limits table lookup, fail-open on RPC
+  error (mocked), fail-closed-on-false (429 path) in one representative action test.
+- Manual: 11 rapid comments locally → the 11th gets the friendly 429 message.
+
+## 7. Risks / accepted
+
+- **Fail-open** trades abuse-resistance for availability — deliberate.
+- Fixed-window boundary bursts (≤2× briefly) — accepted at lenient caps.
+- The service-role key now lives in the running server's env — standard Supabase posture; it was
+  always going to be wired for Phase 2 money; `$lib/server` placement keeps it out of the client
+  bundle (build asserts this: importing `$env/dynamic/private` from client code is a build error).
+- Per-user keys mean a shared-account attacker self-throttles only themselves — fine; IP keying
+  covers anon. IPv6 rotation can dodge `ip:` buckets — accepted for Phase 1 (WAF is the Phase-2
+  escalation if needed).

--- a/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
@@ -106,10 +106,10 @@ export const LIMITS = {
   idea_create:    { max: 10,  windowSecs: 3600 },   // expert posts an idea (console)
   review:         { max: 60,  windowSecs: 300 },    // author review transitions (console RPCs)
   profile:        { max: 10,  windowSecs: 3600 },
-  admin:          { max: 120, windowSecs: 300 },
-  login:          { max: 10,  windowSecs: 900 },    // per-IP (anon at that point)
+  admin:          { max: 120, windowSecs: 300 }
 } as const;
 export type Bucket = keyof typeof LIMITS;
+// login (10 / 15 min per IP) lives OUTSIDE LIMITS — it's the in-memory limiter below, not the DB RPC
 ```
 
 Two limiters, matched to what each role can do safely:

--- a/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-06-07-rate-limiting-design.md
@@ -18,124 +18,137 @@ length caps (comment 10k, interest note 2k).
 
 ## 2. Schema (one migration: `rate_limits`) — NO service role, pure RLS
 
-> **Owner principle (2026-06-07): the app never uses a service-role client — RLS is the only
-> authority.** The original draft used a service-role-only SECURITY DEFINER RPC; rejected.
+> **Owner principle (2026-06-07): the app never uses a service-role *client* — see
+> [[no-service-role-in-app]].** A `SECURITY DEFINER` *database function* is **not** that: a DB-side
+> primitive owned by `postgres`, identical to the repo's 8 existing answer/payout RPCs. The
+> principle targets app-code service-role clients, not definer functions.
 
-The trick that makes client-role rate limiting safe: the function is **SECURITY INVOKER** and
-derives its key from `auth.uid()` **internally** (no key parameter), so RLS pins every row to
-the caller. A malicious direct call via PostgREST can only increment the attacker's *own*
-counter — self-harm, never a cross-user DoS. Bypass is impossible (clients can only add counts,
-never reset them; the server's verdict reads the same pinned rows).
+**Why DEFINER, not INVOKER (revised after the 6-lens plan review).** An earlier draft used
+SECURITY INVOKER + own-rows RLS policies. That is **fully bypassable**: own-rows UPDATE/DELETE
+policies let an authenticated user reset their own counter directly via PostgREST
+(`PATCH …count=0`, `DELETE …`), and a caller-supplied window param weaponizes the cleanup. The
+fix matches the repo's established pattern for sensitive tables: a **SECURITY DEFINER** function
+self-keyed on `auth.uid()` over a table with **zero client policies** (deny-all DML). Clients
+cannot touch `rate_limits` at all; the function is the only writer; and the limits are
+**looked up server-side inside the function** (no caller-passed max/window), so there is nothing
+to spoof.
 
 ```sql
 create table public.rate_limits (
-  key          text not null,         -- 'user:<uuid>' (DB tracks authed users only; anon → §4)
-  bucket       text not null,         -- endpoint family, e.g. 'comment'
+  key          text not null,         -- 'user:<uuid>' (authed users only; anon login → §4)
+  bucket       text not null,
   window_start timestamptz not null,  -- aligned to the bucket's window size
   count        int  not null default 1,
   primary key (key, bucket, window_start)
 );
 alter table public.rate_limits enable row level security;
-
--- Own-rows-only for every verb (key is pinned to the caller — the whole security model):
-create policy "own rate rows select" on public.rate_limits for select to authenticated
-  using (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows insert" on public.rate_limits for insert to authenticated
-  with check (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows update" on public.rate_limits for update to authenticated
-  using (key = 'user:' || (select auth.uid())::text)
-  with check (key = 'user:' || (select auth.uid())::text);
-create policy "own rate rows delete" on public.rate_limits for delete to authenticated
-  using (key = 'user:' || (select auth.uid())::text);
+-- ZERO policies: deny-by-default for every client role (matches answers/answer_reviews).
+-- Only the SECURITY DEFINER function below (owner = postgres, bypasses RLS) ever touches it.
 ```
 
 ```sql
-create function public.consume_rate_limit(p_bucket text, p_max int, p_window_secs int)
+-- Limits are AUTHORITATIVE here (server-side), not caller params — nothing to weaponize.
+create function public.consume_rate_limit(p_bucket text)
 returns boolean
-language plpgsql security invoker set search_path = ''
+language plpgsql security definer set search_path = ''
 as $$
 declare
-  v_key text;
-  v_window timestamptz := to_timestamp(
-    floor(extract(epoch from now()) / p_window_secs) * p_window_secs);
+  v_uid uuid := (select auth.uid());
+  v_max int;
+  v_window_secs int;
+  v_window timestamptz;
   v_count int;
 begin
-  if (select auth.uid()) is null then
+  if v_uid is null then
     return true;   -- anon callers are not tracked here (login uses the in-memory limiter, §4)
   end if;
-  v_key := 'user:' || (select auth.uid())::text;
 
-  -- opportunistic cleanup of the CALLER's stale rows (RLS-scoped; keeps per-user rows ~2/bucket)
+  case p_bucket
+    when 'comment'        then v_max := 10;  v_window_secs := 300;
+    when 'comment_delete' then v_max := 30;  v_window_secs := 300;
+    when 'engage'         then v_max := 60;  v_window_secs := 300;
+    when 'pledge'         then v_max := 10;  v_window_secs := 300;
+    when 'answer'         then v_max := 5;   v_window_secs := 3600;
+    when 'idea_create'    then v_max := 10;  v_window_secs := 3600;
+    when 'review'         then v_max := 60;  v_window_secs := 300;
+    when 'profile'        then v_max := 10;  v_window_secs := 3600;
+    when 'admin'          then v_max := 120; v_window_secs := 300;
+    else raise exception 'unknown rate-limit bucket: %', p_bucket;  -- dev bug → caught by fail-open + log
+  end case;
+
+  v_window := to_timestamp(floor(extract(epoch from now()) / v_window_secs) * v_window_secs);
+
+  -- prune this caller's stale rows for this bucket (definer-owned; no client DELETE path exists)
   delete from public.rate_limits
-    where key = v_key and bucket = p_bucket
-      and window_start < now() - make_interval(secs => 2 * p_window_secs);
+    where key = 'user:' || v_uid::text and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * v_window_secs);
 
   insert into public.rate_limits as r (key, bucket, window_start)
-    values (v_key, p_bucket, v_window)
+    values ('user:' || v_uid::text, p_bucket, v_window)
     on conflict (key, bucket, window_start)
     do update set count = r.count + 1
     returning count into v_count;
 
-  return v_count <= p_max;
+  return v_count <= v_max;
 end $$;
 
-revoke execute on function public.consume_rate_limit(text, text, int) from public, anon;
-grant execute on function public.consume_rate_limit(text, text, int) to authenticated;
+revoke execute on function public.consume_rate_limit(text) from public, anon;
+grant execute on function public.consume_rate_limit(text) to authenticated;
 ```
 
-Notes: SECURITY INVOKER ⇒ **no new advisor WARN** and no RLS bypass anywhere. `p_max`/
-`p_window_secs` come from the server's constants; a direct caller passing garbage values only
-pollutes their own key (and cannot lower the count the server sees). Fixed-window means a
-boundary burst can briefly double a limit — acceptable at lenient settings.
+Notes: adds **one** `authenticated_security_definer_function_executable` advisor WARN (9 → 10),
+accepted on the same grounds as the existing 8 (self-authorizes via `auth.uid()`, touches only the
+caller's own rows). All three INVOKER bypass vectors are closed — no client DML (zero policies), no
+caller-controlled limit/window, count never client-writable (so the INT_MAX→fail-open poison is
+impossible too). Fixed-window can briefly double a limit at a boundary — accepted at lenient caps.
 
 ## 3. No service-role client
 
-Deliberately none. The user-scoped `locals.supabase` client calls the RPC; RLS does all
-enforcement. (The `SUPABASE_SERVICE_ROLE_KEY` in `.env.local` stays unwired; no Vercel env
-action needed.)
+The user-scoped `locals.supabase` client calls the definer RPC; the *function* (not a client) holds
+the privilege. `SUPABASE_SERVICE_ROLE_KEY` stays unwired; no Vercel env action needed.
 
 ## 4. Helper (`$lib/server/rate-limit.ts`)
 
+The **limit values are authoritative in the SQL function** (§2) — not duplicated in TS. The module
+exposes only the bucket-name union (so call sites are type-checked) and the login config:
+
 ```ts
-export const LIMITS = {
-  comment:        { max: 10,  windowSecs: 300 },
-  comment_delete: { max: 30,  windowSecs: 300 },
-  engage:         { max: 60,  windowSecs: 300 },    // vote/unvote/interest/uninterest/follow/unfollow toggles
-  pledge:         { max: 10,  windowSecs: 300 },    // pledge + withdraw
-  answer:         { max: 5,   windowSecs: 3600 },   // answer submit (artifacts ride inside the same action)
-  idea_create:    { max: 10,  windowSecs: 3600 },   // expert posts an idea (console)
-  review:         { max: 60,  windowSecs: 300 },    // author review transitions (console RPCs)
-  profile:        { max: 10,  windowSecs: 3600 },
-  admin:          { max: 120, windowSecs: 300 }
-} as const;
-export type Bucket = keyof typeof LIMITS;
-// login (10 / 15 min per IP) lives OUTSIDE LIMITS — it's the in-memory limiter below, not the DB RPC
+// The DB function owns the numbers; this list must stay in sync with its CASE (a comment in each
+// points at the other). The set of buckets, not their limits, is what TS needs.
+export const BUCKETS = [
+  'comment', 'comment_delete', 'engage', 'pledge', 'answer',
+  'idea_create', 'review', 'profile', 'admin'
+] as const;
+export type Bucket = (typeof BUCKETS)[number];
+// login (10 / 15 min per IP) is the in-memory limiter below, NOT a DB bucket.
 ```
 
 Two limiters, matched to what each role can do safely:
 
-- **Authed buckets (everything except `login`):** `rateLimit(event, bucket): Promise<{ ok: boolean }>`
-  calls `event.locals.supabase.rpc('consume_rate_limit', { p_bucket, p_max, p_window_secs })` —
-  the user's own client; the RPC self-keys on `auth.uid()` (§2). All these actions already
-  require a session, so the anon-returns-true branch is never the deciding check.
-  **Fails OPEN**: any RPC error ⇒ `console.error` + `{ ok: true }`. A limiter outage must never
-  take the site down; the durable risk (spam) is bounded, the availability risk is not.
-- **`login` bucket (anon — the DB cannot key anon callers without trusting spoofable input):**
-  a small **in-memory fixed-window map** in the same module, keyed by
-  `event.getClientAddress()` (trusted `x-forwarded-for` on Vercel), pruned on access.
-  Per-fluid-compute-instance, so the real cap is `10 × instances` and resets on cold start —
-  explicitly **belt-and-suspenders**; Supabase Auth's own server-side email limits are the real
-  backstop. No DB, no spoofable key, nothing an attacker can exhaust for someone else
-  (worst case: shared-IP neighbors share a generous bucket).
+- **Authed buckets (everything except `login`):** `rateLimit(supabase, bucket): Promise<{ ok: boolean }>`
+  calls `supabase.rpc('consume_rate_limit', { p_bucket: bucket })` — the action's own
+  `locals.supabase`; the RPC self-keys on `auth.uid()` and looks up the limit server-side (§2).
+  All these actions already require a session, so the anon-returns-true branch is never the
+  deciding check. **Fails OPEN**: any RPC error ⇒ `console.error` + `{ ok: true }`. A limiter
+  outage must never take the site down; the durable risk (spam) is bounded, the availability risk
+  is not. (Passing `supabase` rather than the whole `event` keeps the helper trivially unit-testable.)
+- **`login` (anon — the DB cannot key anon callers without trusting spoofable input):** a small
+  **in-memory fixed-window map** in the same module, keyed by `event.getClientAddress()`. **Best-effort
+  only:** on Vercel that value derives from `x-forwarded-for`, which is client-*influenced*, and the
+  map is per-fluid-compute-instance (real cap ≈ `10 × instances`, resets on cold start). It is
+  **not** an anti-spoof control — **Supabase Auth's own server-side email limits are the real
+  backstop**; this just blunts casual repeat-submits. Pruned on access with a 10k-entry memory cap.
 
-Action wiring (two lines per action):
+Action wiring (two lines per authed action; login uses `loginLimited`):
 
 ```ts
-if (!(await rateLimit(event, 'comment')).ok)
-  return fail(429, { message: 'Slow down — try again in a moment.' });
+if (!(await rateLimit(supabase, 'comment')).ok)
+  return fail(429, { message: RATE_LIMIT_MESSAGE });
 ```
 
-The 429 surfaces through each form's existing error display; no new UI.
+The 429 surfaces through each form's existing error display; no new UI. `RATE_LIMIT_MESSAGE`
+("Slow down — try again in a moment.") is shared across the authed buckets; `login` uses its own
+"Too many attempts — try again in a few minutes." copy.
 
 ## 5. Bucket → action map (complete)
 
@@ -161,22 +174,31 @@ is admin-set via `setStatus`), so no `apply` bucket.
 ## 6. Testing
 
 - **pgTAP** (`rate_limits_test.sql`): under-limit true → over-limit false within one window;
-  window rollover resets; separate buckets independent; **one user's consumption cannot touch
-  another user's rows** (call as A, then as B — B starts fresh; A cannot select/update/delete
-  B's rows directly); anon `execute` denied; cleanup removes the caller's stale rows only.
-- **Vitest** (`rate-limit.test.ts`): bucket→params lookup, fail-open on RPC error (mocked),
-  fail-closed-on-false (429 path) in one representative action test; the in-memory login
-  limiter (window expiry, per-IP independence, prune).
-- Manual: 11 rapid comments locally → the 11th gets the friendly 429 message.
+  separate buckets independent; cross-user isolation (B starts fresh); **the three closed bypass
+  vectors are asserted** — a direct client `SELECT`/`UPDATE count=0`/`DELETE` on `rate_limits`
+  affects/returns **zero rows** (the zero-policy lockdown), so the next `consume` is NOT reset;
+  unknown bucket raises; anon `execute` denied. Window rollover is tested by **aging a stored row
+  as the table owner** (`now()` is frozen inside a txn, so `pg_sleep` can't drive it) then calling
+  again, asserting reset + that cleanup pruned the stale row.
+- **Vitest** (`rate-limit.test.ts`): `rateLimit` passes only `{ p_bucket }`, allows on true, blocks
+  on false, **fails open on RPC error**; the in-memory login limiter (window expiry, per-IP
+  independence, prune). One action test: over-limit `comment` → 429 with `RATE_LIMIT_MESSAGE`,
+  asserting no insert ran (guard precedes the write).
+- Manual: 11 rapid authed actions locally → the 11th gets the friendly 429.
 
 ## 7. Risks / accepted
 
 - **Fail-open** trades abuse-resistance for availability — deliberate.
 - Fixed-window boundary bursts (≤2× briefly) — accepted at lenient caps.
-- **No service role anywhere** (owner principle). Consequence: the `login` limiter is per-instance
-  in-memory and therefore leaky — accepted, because Supabase Auth's own email limits backstop it
-  and the alternative (DB-keyed anon) would hand attackers a spoofable key.
-- A signed-in attacker can self-throttle only themselves; anon abuse beyond login (e.g. read
-  flooding) is out of scope — reads are cheap and cacheable; WAF is the Phase-2 escalation.
-- Direct RPC calls with garbage `p_max`/`p_window_secs` pollute only the caller's own rows and
-  can never lower the count the server's check sees.
+- **DEFINER, not a service-role client.** The privilege lives in a `postgres`-owned function with
+  internal `auth.uid()` self-keying and zero client table access — the repo's established pattern,
+  consistent with [[no-service-role-in-app]]. Adds one accepted advisor WARN (9 → 10).
+- **`login` limiter is best-effort**, per-instance in-memory and IP-spoofable; Supabase Auth's own
+  email limits are the real backstop. DB-keying anon would hand attackers a spoofable key, so it's
+  deliberately not done.
+- A signed-in attacker can throttle only themselves; anon abuse beyond login (read flooding) is out
+  of scope — reads are cheap/cacheable; WAF is the Phase-2 escalation.
+- **Limit values live in the SQL function** (authoritative). Tuning a limit = a one-line migration;
+  rollback = revert it. The TS `BUCKETS` list must stay in sync with the function's `CASE` (paired
+  comments flag this); a bucket in one but not the other is caught by `npm run check` (TS) or the
+  unknown-bucket `raise` (SQL, surfaced via fail-open logging).

--- a/src/lib/server/rate-limit.test.ts
+++ b/src/lib/server/rate-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BUCKETS, rateLimit, loginLimited, __resetLoginLimiter } from './rate-limit';
+
+const mkSupabase = (rpc: (...a: any[]) => any) => ({ rpc }) as any;
+
+describe('rateLimit (DB-backed, fail-open)', () => {
+  it('passes ONLY the bucket name to the RPC (limits are server-authoritative) and allows on true', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: true, error: null });
+    const res = await rateLimit(mkSupabase(rpc), 'comment');
+    expect(rpc).toHaveBeenCalledWith('consume_rate_limit', { p_bucket: 'comment' });
+    expect(res.ok).toBe(true);
+  });
+  it('exports the full bucket set for the wiring map', () => {
+    expect(BUCKETS).toContain('comment');
+    expect(BUCKETS).toContain('admin');
+    expect(BUCKETS).not.toContain('login');   // login is the in-memory limiter, not a DB bucket
+  });
+  it('blocks when the RPC returns false', async () => {
+    const res = await rateLimit(mkSupabase(vi.fn().mockResolvedValue({ data: false, error: null })), 'pledge');
+    expect(res.ok).toBe(false);
+  });
+  it('FAILS OPEN when the RPC errors (limiter outage must never block users)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await rateLimit(
+      mkSupabase(vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } })), 'engage');
+    expect(res.ok).toBe(true);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('loginLimited (in-memory, per-IP)', () => {
+  it('allows up to 10 in the window, blocks the 11th, keyed per IP', () => {
+    __resetLoginLimiter();
+    const t0 = 1_000_000;
+    for (let i = 0; i < 10; i++) expect(loginLimited('1.2.3.4', t0 + i)).toBe(false);
+    expect(loginLimited('1.2.3.4', t0 + 10)).toBe(true);     // 11th blocked
+    expect(loginLimited('5.6.7.8', t0 + 10)).toBe(false);    // other IP unaffected
+  });
+  it('forgets attempts after the 15-minute window', () => {
+    __resetLoginLimiter();
+    const t0 = 1_000_000;
+    for (let i = 0; i < 11; i++) loginLimited('1.2.3.4', t0 + i);
+    expect(loginLimited('1.2.3.4', t0 + 15 * 60_000 + 100)).toBe(false);
+  });
+});

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Bucket NAMES only. The limit VALUES are authoritative in the SQL function
+ * `public.consume_rate_limit` (its CASE) — keep this list in sync with that CASE; a bucket here
+ * but not there raises at runtime (caught by fail-open + log), and vice-versa is a dead name.
+ * `login` is intentionally absent — it's the in-memory limiter below, not a DB bucket.
+ */
+export const BUCKETS = [
+  'comment', 'comment_delete', 'engage', 'pledge', 'answer',
+  'idea_create', 'review', 'profile', 'admin'
+] as const;
+export type Bucket = (typeof BUCKETS)[number];
+
+/** Shared 429 copy for the authed buckets (login uses its own message). */
+export const RATE_LIMIT_MESSAGE = 'Slow down — try again in a moment.';
+
+/**
+ * DB-backed limiter for AUTHED mutations. Calls the SECURITY DEFINER RPC with the caller's own
+ * `locals.supabase` client; the function (owned by postgres) self-keys on auth.uid() and looks
+ * up the limit server-side — no service-role CLIENT involved. FAILS OPEN on RPC error: a limiter
+ * outage must never take the site down; the spam risk is bounded, the availability risk is not.
+ */
+export async function rateLimit(
+  supabase: SupabaseClient<any>,
+  bucket: Bucket
+): Promise<{ ok: boolean }> {
+  const { data, error } = await supabase.rpc('consume_rate_limit', { p_bucket: bucket });
+  if (error) {
+    console.error(`rate-limit rpc failed (fail-open) bucket=${bucket}: ${error.message}`);
+    return { ok: true };
+  }
+  return { ok: data !== false };
+}
+
+// ── login limiter: in-memory, per-IP, BEST-EFFORT. The DB cannot key anon callers without trusting
+// spoofable input; getClientAddress() derives from a client-influenced x-forwarded-for and the map is
+// per-fluid-compute-instance (real cap ≈ 10 × instances, resets on cold start). NOT anti-spoof —
+// Supabase Auth's own email limits are the real backstop; this just blunts casual repeat-submits. ──
+const LOGIN = { max: 10, windowMs: 15 * 60_000 };
+let loginHits = new Map<string, number[]>();
+
+/** True when this IP has exceeded the login window. `now` is injectable for tests. */
+export function loginLimited(ip: string, now: number = Date.now()): boolean {
+  const cutoff = now - LOGIN.windowMs;
+  const hits = (loginHits.get(ip) ?? []).filter((t) => t > cutoff);
+  hits.push(now);
+  loginHits.set(ip, hits);
+  if (loginHits.size > 10_000) {
+    for (const [k, v] of loginHits) if (!v.some((t) => t > cutoff)) loginHits.delete(k);
+  }
+  return hits.length > LOGIN.max;
+}
+
+/** Test hook only. */
+export function __resetLoginLimiter() {
+  loginHits = new Map();
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -717,6 +717,27 @@ export type Database = {
         }
         Relationships: []
       }
+      rate_limits: {
+        Row: {
+          bucket: string
+          count: number
+          key: string
+          window_start: string
+        }
+        Insert: {
+          bucket: string
+          count?: number
+          key: string
+          window_start: string
+        }
+        Update: {
+          bucket?: string
+          count?: number
+          key?: string
+          window_start?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       bounty_pot: {
@@ -812,6 +833,7 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      consume_rate_limit: { Args: { p_bucket: string }; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
       reject_answer: {
         Args: { p_answer_id: string; p_note?: string }

--- a/src/routes/admin/experts/+page.server.ts
+++ b/src/routes/admin/experts/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import type { Database } from '$lib/types/database';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 type ExpertUpdate = Database['public']['Tables']['experts']['Update'];
 
@@ -24,6 +25,7 @@ export const actions: Actions = {
   setStatus: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireAdmin(supabase, user.id))) return fail(403, { message: 'Admins only' });
+    if (!(await rateLimit(supabase, 'admin')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const id = String(fd.get('id'));
     const status = String(fd.get('status'));

--- a/src/routes/admin/payouts/+page.server.ts
+++ b/src/routes/admin/payouts/+page.server.ts
@@ -1,5 +1,6 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 async function requireAdmin(supabase: any, userId: string | undefined) {
   if (!userId) return false;
@@ -38,6 +39,7 @@ export const actions: Actions = {
   approve: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireAdmin(supabase, user.id))) return fail(403, { message: 'Admins only' });
+    if (!(await rateLimit(supabase, 'admin')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     // `undefined` (not null) for the optional note keeps full RPC param-name type-checking (see console route).
     const { error: e } = await supabase.rpc('admin_approve_payout', {
@@ -49,6 +51,7 @@ export const actions: Actions = {
   reject: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireAdmin(supabase, user.id))) return fail(403, { message: 'Admins only' });
+    if (!(await rateLimit(supabase, 'admin')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.rpc('admin_reject_payout', {
       p_answer_id: String(fd.get('answer_id')), p_note: String(fd.get('note') ?? '') || undefined

--- a/src/routes/console/+page.server.ts
+++ b/src/routes/console/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { renderMarkdown } from '$lib/server/markdown';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 async function requireExpert(supabase: any, userId: string | undefined) {
   if (!userId) return false;
@@ -47,6 +48,7 @@ export const actions: Actions = {
   create: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireExpert(supabase, user.id))) return fail(403, { message: 'Approved experts only' });
+    if (!(await rateLimit(supabase, 'idea_create')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const title = String(fd.get('title') ?? '').trim();
     if (!title) return fail(400, { message: 'Title required' });
@@ -64,6 +66,7 @@ export const actions: Actions = {
   start_review: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireExpert(supabase, user.id))) return fail(403, { message: 'Approved experts only' });
+    if (!(await rateLimit(supabase, 'review')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.rpc('start_review', { p_answer_id: String(fd.get('answer_id')) });
     if (e) return fail(400, { message: e.message });
@@ -73,6 +76,7 @@ export const actions: Actions = {
   verify: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireExpert(supabase, user.id))) return fail(403, { message: 'Approved experts only' });
+    if (!(await rateLimit(supabase, 'review')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const dollars = Number(fd.get('payout') ?? '');
     // Pass `undefined` (not null) for omitted optional RPC params: supabase-js types defaulted params as
@@ -94,6 +98,7 @@ export const actions: Actions = {
   request_revision: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireExpert(supabase, user.id))) return fail(403, { message: 'Approved experts only' });
+    if (!(await rateLimit(supabase, 'review')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.rpc('request_revision_answer', {
       p_answer_id: String(fd.get('answer_id')), p_note: String(fd.get('note') ?? '') || undefined
@@ -105,6 +110,7 @@ export const actions: Actions = {
   reject: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user || !(await requireExpert(supabase, user.id))) return fail(403, { message: 'Approved experts only' });
+    if (!(await rateLimit(supabase, 'review')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.rpc('reject_answer', {
       p_answer_id: String(fd.get('answer_id')), p_note: String(fd.get('note') ?? '') || undefined

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
@@ -62,6 +63,7 @@ export const actions: Actions = {
   follow: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.from('follows')
       .insert({ follower_id: user.id, expert_id: String(fd.get('expert_id')) });
@@ -71,6 +73,7 @@ export const actions: Actions = {
   unfollow: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase.from('follows')
       .delete().eq('follower_id', user.id).eq('expert_id', String(fd.get('expert_id')));
@@ -80,6 +83,7 @@ export const actions: Actions = {
   withdraw: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'pledge')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     // RLS allows deleting only the caller's own still-committed pledge; .select() surfaces a no-op (someone
     // else's pledge, or an already-escrowed one) as a failure instead of a misleading success.

--- a/src/routes/ideas/[id]/+page.server.ts
+++ b/src/routes/ideas/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { renderMarkdown } from '$lib/server/markdown';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
@@ -115,6 +116,7 @@ export const actions: Actions = {
   pledge: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in to fund this idea' });
+    if (!(await rateLimit(supabase, 'pledge')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const dollars = Number(fd.get('amount') ?? '');
     if (!Number.isFinite(dollars) || dollars <= 0) return fail(400, { message: 'Enter an amount greater than 0' });
@@ -128,6 +130,7 @@ export const actions: Actions = {
   comment: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in to comment' });
+    if (!(await rateLimit(supabase, 'comment')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const body_md = String(fd.get('body_md') ?? '').trim();
     if (!body_md) return fail(400, { message: 'Write something first' });
@@ -143,6 +146,7 @@ export const actions: Actions = {
   delete_comment: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'comment_delete')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     // RLS allows deleting only your own comment (or admin); .select() surfaces a no-op
     const { data: del, error: e } = await supabase.from('comments')
@@ -155,6 +159,7 @@ export const actions: Actions = {
   interest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in to express interest' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const note_md = String(fd.get('note_md') ?? '').trim().slice(0, 2000) || null;
     const { error: e } = await supabase.from('interest').insert({
@@ -171,6 +176,7 @@ export const actions: Actions = {
   vote: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in to vote' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const value = Number(fd.get('value'));
     if (value !== 1 && value !== -1) return fail(400, { message: 'Invalid vote' });
@@ -189,6 +195,7 @@ export const actions: Actions = {
   unvote: async ({ params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const { error: e } = await supabase.from('idea_votes')
       .delete().eq('idea_id', params.id).eq('profile_id', user.id);
     if (e) return fail(400, { message: e.message });
@@ -198,6 +205,7 @@ export const actions: Actions = {
   uninterest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
+    if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const { data: del, error: e } = await supabase.from('interest')
       .delete().eq('idea_id', params.id).eq('profile_id', user.id).select('id');
     if (e) return fail(400, { message: e.message });

--- a/src/routes/ideas/[id]/answer/+page.server.ts
+++ b/src/routes/ideas/[id]/answer/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { inferKind } from '$lib/artifacts';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
@@ -16,6 +17,7 @@ export const actions: Actions = {
   default: async ({ request, params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in to submit an answer' });
+    if (!(await rateLimit(supabase, 'answer')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const title = String(fd.get('title') ?? '').trim();
     const explanation_md = String(fd.get('explanation_md') ?? '').trim();

--- a/src/routes/ideas/[id]/rate-limit-wiring.test.ts
+++ b/src/routes/ideas/[id]/rate-limit-wiring.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { actions } from './+page.server';
+import { RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
+
+function mkEvent(rpcData: boolean) {
+  const supabase: any = {
+    rpc: vi.fn().mockResolvedValue({ data: rpcData, error: null }),
+    from: vi.fn(() => ({ insert: vi.fn().mockResolvedValue({ error: null }) }))
+  };
+  const fd = new FormData();
+  fd.set('body_md', 'hello');
+  return {
+    params: { id: 'idea-1' },
+    request: { formData: async () => fd },
+    locals: { supabase, safeGetSession: async () => ({ user: { id: 'user-1' } }) }
+  } as any;
+}
+
+describe('comment action rate limiting', () => {
+  it('returns 429 with the shared message when over limit, before any insert', async () => {
+    const event = mkEvent(false);
+    const res: any = await (actions as any).comment(event);
+    expect(res?.status).toBe(429);
+    expect(res?.data?.message).toBe(RATE_LIMIT_MESSAGE);
+    expect(event.locals.supabase.from).not.toHaveBeenCalled();   // guard precedes the write
+  });
+  it('proceeds to the insert when under limit', async () => {
+    const event = mkEvent(true);
+    await (actions as any).comment(event);
+    expect(event.locals.supabase.from).toHaveBeenCalledWith('comments');
+  });
+});

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,5 +1,6 @@
 import { redirect, fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
+import { loginLimited } from '$lib/server/rate-limit';
 
 // same-origin absolute paths only (block "//evil.com" and full URLs), matching /auth/callback
 function safeNext(raw: string | null): string {
@@ -9,7 +10,9 @@ function safeNext(raw: string | null): string {
 export const load: PageServerLoad = async ({ url }) => ({ next: safeNext(url.searchParams.get('next')) });
 
 export const actions: Actions = {
-  google: async ({ url, locals: { supabase } }) => {
+  google: async ({ url, getClientAddress, locals: { supabase } }) => {
+    if (loginLimited(getClientAddress()))
+      return fail(429, { message: 'Too many attempts — try again in a few minutes.' });
     const next = safeNext(url.searchParams.get('next'));
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
@@ -18,7 +21,9 @@ export const actions: Actions = {
     if (error) return fail(400, { message: error.message });
     redirect(303, data.url);
   },
-  magiclink: async ({ request, url, locals: { supabase } }) => {
+  magiclink: async ({ request, url, getClientAddress, locals: { supabase } }) => {
+    if (loginLimited(getClientAddress()))
+      return fail(429, { message: 'Too many attempts — try again in a few minutes.' });
     const next = safeNext(url.searchParams.get('next'));
     const email = String((await request.formData()).get('email') ?? '');
     if (!email) return fail(400, { message: 'Email required' });

--- a/src/routes/u/[handle]/+page.server.ts
+++ b/src/routes/u/[handle]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { renderMarkdown } from '$lib/server/markdown';
+import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase } }) => {
   const { data: profile } = await supabase
@@ -16,6 +17,7 @@ export const actions: Actions = {
   update: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in required' });
+    if (!(await rateLimit(supabase, 'profile')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const { error: e } = await supabase
       .from('profiles')

--- a/supabase/migrations/20260607102806_rate_limits.sql
+++ b/supabase/migrations/20260607102806_rate_limits.sql
@@ -1,0 +1,64 @@
+-- ============ rate_limits (fixed-window counters; NO service-role CLIENT) ============
+-- Writes go ONLY through the SECURITY DEFINER function below (owned by postgres, bypasses RLS),
+-- which self-keys on auth.uid() and looks up limits server-side. The table has ZERO client
+-- policies, so a direct PostgREST UPDATE/DELETE/SELECT by `authenticated` matches nothing — the
+-- three INVOKER bypass vectors (self-reset count, self-delete, caller-chosen window) are closed.
+-- A definer function is a DB primitive, NOT the forbidden service-role client.
+create table public.rate_limits (
+  key          text not null,         -- 'user:<uuid>' (authed users only; anon login is in-memory app-side)
+  bucket       text not null,
+  window_start timestamptz not null,  -- aligned to the bucket's window size
+  count        int  not null default 1,
+  primary key (key, bucket, window_start)
+);
+alter table public.rate_limits enable row level security;
+-- ZERO policies on purpose (deny-by-default for every client role, like answers/answer_reviews).
+
+-- Limits are AUTHORITATIVE here (server-side), not caller params — nothing for a client to spoof.
+create function public.consume_rate_limit(p_bucket text)
+returns boolean
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  v_uid uuid := (select auth.uid());
+  v_max int;
+  v_window_secs int;
+  v_window timestamptz;
+  v_count int;
+begin
+  if v_uid is null then
+    return true;   -- anon callers are not tracked here (login uses the app's in-memory limiter)
+  end if;
+
+  -- authoritative limit table; keep in sync with BUCKETS in $lib/server/rate-limit.ts
+  case p_bucket
+    when 'comment'        then v_max := 10;  v_window_secs := 300;
+    when 'comment_delete' then v_max := 30;  v_window_secs := 300;
+    when 'engage'         then v_max := 60;  v_window_secs := 300;
+    when 'pledge'         then v_max := 10;  v_window_secs := 300;
+    when 'answer'         then v_max := 5;   v_window_secs := 3600;
+    when 'idea_create'    then v_max := 10;  v_window_secs := 3600;
+    when 'review'         then v_max := 60;  v_window_secs := 300;
+    when 'profile'        then v_max := 10;  v_window_secs := 3600;
+    when 'admin'          then v_max := 120; v_window_secs := 300;
+    else raise exception 'unknown rate-limit bucket: %', p_bucket;  -- dev bug → fail-open + logged
+  end case;
+
+  v_window := to_timestamp(floor(extract(epoch from now()) / v_window_secs) * v_window_secs);
+
+  -- prune this caller's stale rows for this bucket (definer-owned; no client DELETE path exists)
+  delete from public.rate_limits
+    where key = 'user:' || v_uid::text and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * v_window_secs);
+
+  insert into public.rate_limits as r (key, bucket, window_start)
+    values ('user:' || v_uid::text, p_bucket, v_window)
+    on conflict (key, bucket, window_start)
+    do update set count = r.count + 1
+    returning count into v_count;
+
+  return v_count <= v_max;
+end $$;
+
+revoke execute on function public.consume_rate_limit(text) from public, anon;
+grant execute on function public.consume_rate_limit(text) to authenticated;

--- a/supabase/tests/database/rate_limits_test.sql
+++ b/supabase/tests/database/rate_limits_test.sql
@@ -1,0 +1,56 @@
+begin;
+select plan(11);
+
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','11111111-1111-1111-1111-111111111111','authenticated','authenticated','alice@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','22222222-2222-2222-2222-222222222222','authenticated','authenticated','bob@example.com','x', now(), now(), now());
+
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+
+-- ===== limit math on 'answer' (max 5 / hour); 4 warm-up calls, then assert at/over limit =====
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select public.consume_rate_limit('answer');
+select ok(public.consume_rate_limit('answer'), '1: 5th call AT limit still true');
+select ok(not public.consume_rate_limit('answer'), '2: 6th call over limit → false');
+
+-- ===== limits are server-authoritative: an unknown bucket raises (a dev bug, not a runtime path) =====
+select throws_ok($$ select public.consume_rate_limit('nope') $$, 'P0001', null, '3: unknown bucket raises');
+
+-- ===== zero-policy lockdown: a client cannot read or mutate rate_limits directly =====
+select ok((select count(*) from public.rate_limits) = 0,
+  '4: authenticated cannot SELECT rate_limits (zero policies) though rows exist via the definer fn');
+with u as (update public.rate_limits set count = 0 where bucket = 'answer' returning 1)
+  select ok((select count(*) from u) = 0, '5: direct UPDATE count=0 matches no rows (Vector 1 closed)');
+with d as (delete from public.rate_limits where bucket = 'answer' returning 1)
+  select ok((select count(*) from d) = 0, '6: direct DELETE matches no rows (Vector 2 closed)');
+select ok(not public.consume_rate_limit('answer'),
+  '7: still over limit — the direct UPDATE/DELETE attempts reset nothing');
+
+-- ===== cross-user isolation: bob starts fresh in the same bucket =====
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
+select ok(public.consume_rate_limit('answer'), '8: another user starts fresh');
+
+-- ===== window rollover: now() is FROZEN inside a txn, so age the stored row as the owner =====
+reset role;
+update public.rate_limits set window_start = window_start - interval '3 hours'
+  where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 'answer';
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
+select ok(public.consume_rate_limit('answer'), '9: a new window resets the limit (aged row is stale)');
+reset role;
+select ok((select count(*) from public.rate_limits
+           where key = 'user:11111111-1111-1111-1111-111111111111' and bucket = 'answer') = 1,
+  '10: the stale aged row was pruned — only the live window row remains');
+
+-- ===== anon cannot execute the function (revoked) =====
+set local role anon;
+set local request.jwt.claims = '';
+select throws_ok($$ select public.consume_rate_limit('comment') $$, '42501', null,
+  '11: anon execute is denied');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Per-endpoint rate limiting on every mutation — the last Phase-1 security gap (spec §9).

- **`rate_limits` table + `consume_rate_limit(p_bucket)` SECURITY DEFINER RPC.** The table has **zero client policies** (deny-all); the function is the only writer, self-keys on `auth.uid()`, and holds the limit values **server-side** (no caller-passed max/window). A definer function is a DB primitive, **not** a service-role client — consistent with the owner's no-service-role-client principle and the repo's 8 existing answer/payout RPCs.
- **`$lib/server/rate-limit.ts`**: `rateLimit(supabase, bucket)` (fails **open** on RPC error — a limiter outage never blocks users) + an in-memory per-IP `loginLimited()` for the anon login actions (best-effort; Supabase Auth's email limits are the real backstop).
- **All 20 authed actions guarded** (after auth, before any write) per a verified bucket map + the 2 login actions. `logout`/`auth/callback` exempt by design.
- Lenient launch caps (e.g. 10 comments / 30 votes-toggles / 5 answers per window) — only a script should hit them.

## Why DEFINER, not the originally-specced INVOKER
A 6-lens adversarial plan review found the INVOKER + own-rows-RLS draft **fully bypassable** (a signed-in user could `PATCH count=0`, `DELETE` their row, or weaponize a caller-supplied window). The DEFINER + zero-policy + server-authoritative-limits design closes all three vectors; pgTAP asserts each is closed.

## Status
- ✅ pgTAP 11/11 new (122 total, full suite green on a clean DB) · vitest 75/75 · svelte-check 0 · build clean
- ✅ No service-role client anywhere (`grep SERVICE_ROLE src/` → nothing)
- ⏳ Cloud migration + advisors follow merge (adds 1 accepted definer-WARN)

## Test Plan
- [x] `supabase test db` · `npx vitest run` · `npm run check` · `npm run build`
- [x] Local smoke: 11 rapid login attempts → limiter trips at the 11th
- [ ] Post-merge: cloud migration, advisors at baseline+1, deployed authed-action smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)