### PR TITLE
feat: verify→payout signature animation (CLAUDE.md §5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: supabase/setup-cli@v1
-        with: { version: latest }
+        with: { version: 2.75.0 }   # pin: `latest` resolves via the GitHub API → rate-limit failures on CI
       - run: supabase start          # boots local stack + applies migrations (Docker on the runner)
       - run: supabase test db        # pgTAP RLS tests
       - run: supabase db lint         # static schema lint

--- a/docs/superpowers/plans/2026-06-07-verify-payout-animation.md
+++ b/docs/superpowers/plans/2026-06-07-verify-payout-animation.md
@@ -1,43 +1,81 @@
 # Verify→Payout Signature Animation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. No cloud/DB/RPC changes — this is presentational + an enhance conversion. Constraints: never edit CLAUDE.md/docs//.claude//src_legacy_v0/; never `git add .`/`git add -A` (explicit paths only).
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. No cloud/DB/RPC changes — presentational + an enhance conversion. Constraints: never edit CLAUDE.md/docs//.claude//src_legacy_v0/; never `git add .`/`git add -A` (explicit paths only).
 
-**Goal:** Play CLAUDE.md's verify→payout signature moment — a seal draws its check + fills `--green` with a small pop, then the recorded payout counts up with one green glow — on console verify; a lighter seal on admin approve; a restrained settle+dim on reject/revision; everything jumps to final under `prefers-reduced-motion`.
+**Goal:** Play CLAUDE.md's verify→payout signature moment — a seal draws its check + fills `--green` with a small pop, then the recorded payout counts up with one green glow — **only after the server confirms** the verify; a lighter seal on admin approve; a restrained settle on reject (dim) / revision (amber); everything jumps to final under `prefers-reduced-motion`.
 
-**Architecture:** Two presentational primitives (`VerifySeal`, `CountUp`), a pure formatter + a reduced-motion store, two CSS keyframes, and a framework-agnostic `use:enhance` orchestration helper (`makeOutcomeEnhancer`) wired into the console + admin/payouts review forms (converting them from full-reload to animate-then-refetch). Spec: `docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md`.
+**Architecture:** Two presentational primitives (`VerifySeal`, `CountUp`, each with an injectable `reduced` prop), a pure formatter + a reduced-motion store, two CSS keyframes, and a framework-agnostic `use:enhance` orchestration helper (`makeOutcomeEnhancer`) that shows the success visual **in the result callback on success only**. Wired into the console + admin/payouts review forms. Spec: `docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md`.
 
-**Tech Stack:** Svelte 5 runes, `svelte/motion` `tweened` + `svelte/easing` `cubicOut`, Tailwind v4, vitest + `@testing-library/svelte` (jsdom — note: jsdom has no `matchMedia`, so the reduced-motion store defaults to `false` in tests, deterministically).
+**Tech Stack:** Svelte 5 runes, `svelte/motion` `tweened` + `svelte/easing` `cubicOut`, Tailwind v4, vitest + `@testing-library/svelte` (jsdom). **Component render tests require config not yet present** — Task 1 adds `resolve.conditions:['browser']` + a `matchMedia` setup stub (without which `svelte/motion` throws at import under jsdom). The `reduced` prop (not the store) is what tests drive, so both motion branches are deterministically testable.
 
 ---
 
 ## Key decisions
-- **DRY the money format:** extract `formatCents` to `$lib/money.ts`; `Money.svelte` and `CountUp.svelte` both use it → one deterministic unit to test.
-- **Reduced motion is a store** (`prefersReducedMotion`) read once at component init (preference rarely flips mid-session); SSR-safe default `false`.
-- **Orchestration is extracted** to `$lib/review-motion.ts` (`makeOutcomeEnhancer`) so the two-phase logic (cancel-if-pending → begin → hold-then-update, `fail()` skips the hold) is unit-tested without mounting a page.
-- **Seal is CSS-driven** (stroke-dashoffset transition + a `seal-pop` keyframe), not a JS spring — simpler, and the global reduced-motion block already neutralizes it.
+- **Success-gated visual (the money-honesty fix):** the green seal/CountUp/glow mount **only when `result.type==='success'`**, never optimistically — a rate-limited/failed verify must never flash "Verified · $X". The before-submit phase only marks the row in-flight (hides controls, no green).
+- **`reduced` is an injectable prop** on `CountUp`/`VerifySeal` (default = `get(prefersReducedMotion)`), so vitest drives both branches without depending on jsdom matchMedia.
+- **DRY money:** `formatCents` in `$lib/money.ts`, used by `Money` + `CountUp`.
+- **Orchestration extracted** to `$lib/review-motion.ts` for unit testing the phase logic.
+- **Seal/glow are CSS-driven**; the global reduced-motion block neutralizes them. On the admin **table**, animate cells (`<td>`)/opacity — never `transform`/`box-shadow` on `<tr>` (unreliable).
 
 ## File structure
 
 | File | Responsibility |
 |---|---|
+| `vite.config.ts` (modify) | `resolve.conditions:['browser']` + `setupFiles` for component tests |
+| `vitest.setup.ts` (new) | stub `window.matchMedia` (else `svelte/motion` throws at import) |
 | `src/lib/money.ts` (new) | `formatCents(cents, currency)` pure formatter |
 | `src/lib/motion.ts` (modify) | add `prefersReducedMotion` readable store |
 | `src/lib/components/Money.svelte` (modify) | use `formatCents` (no behavior change) |
-| `src/lib/components/CountUp.svelte` (new) | tweened 0→cents animated amount |
-| `src/lib/components/VerifySeal.svelte` (new) | SVG check-draw + green-pop / reject ✕ |
-| `src/app.css` (modify) | `@keyframes payout-glow`, `reject-settle` + classes |
-| `src/lib/review-motion.ts` (new) | `makeOutcomeEnhancer` + `HOLD_MS` |
-| `src/routes/console/+page.svelte` (modify) | wire verify (full) / reject / request_revision |
-| `src/routes/admin/payouts/+page.svelte` (modify) | wire approve (lighter) / reject |
-| `*.test.ts` | vitest for money, CountUp, VerifySeal, review-motion |
+| `src/lib/components/CountUp.svelte` (new) | tweened 0→cents, width-reserved, `reduced` prop |
+| `src/lib/components/VerifySeal.svelte` (new) | SVG check-draw + green-pop / reject ✕, `reduced` prop |
+| `src/app.css` (modify) | `payout-glow`, `reject-settle` keyframes + `row-dim`/`row-warn` |
+| `src/lib/review-motion.ts` (new) | `makeOutcomeEnhancer` + `HOLD_MS` (success-gated) |
+| `src/routes/console/+page.svelte` (modify) | verify (full) / reject / request_revision |
+| `src/routes/admin/payouts/+page.svelte` (modify) | approve (lighter) / reject |
+| `*.test.ts` | money, CountUp, VerifySeal, review-motion |
 
 ---
 
-## Task 1: Foundation — `formatCents`, reduced-motion store
+## Task 1: Test config + foundation (`formatCents`, reduced-motion store)
 
-**Files:** Create `src/lib/money.ts`, `src/lib/money.test.ts`; modify `src/lib/motion.ts`, `src/lib/components/Money.svelte`.
+**Files:** Modify `vite.config.ts`; create `vitest.setup.ts`, `src/lib/money.ts`, `src/lib/money.test.ts`; modify `src/lib/motion.ts`, `src/lib/components/Money.svelte`.
 
-- [ ] **Step 1: Write the failing test** `src/lib/money.test.ts`:
+- [ ] **Step 1: Enable component render tests.** Replace `vite.config.ts` with:
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tailwindcss(), sveltekit()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    // resolve Svelte's browser build so @testing-library/svelte render()/mount() works under jsdom
+    conditions: ['browser'],
+    include: ['src/**/*.{test,spec}.{js,ts}', 'scripts/**/*.{test,spec}.{js,ts}']
+  }
+});
+```
+
+Create `vitest.setup.ts` (without this, `svelte/motion` constructs a `MediaQuery` at import and throws `window.matchMedia is not a function`):
+
+```ts
+// jsdom has no matchMedia; svelte/motion touches it at module load. Stub a no-op (reduced = false).
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  // @ts-expect-error – minimal stub for tests
+  window.matchMedia = (query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener() {}, removeEventListener() {},
+    addListener() {}, removeListener() {}, dispatchEvent() { return false; }
+  });
+}
+```
+
+- [ ] **Step 2: Confirm the config works** — `npx vitest run` → the existing suites still pass (the `conditions`/setup change must not break route-logic tests). Expected: all current tests green.
+
+- [ ] **Step 3: Write the failing test** `src/lib/money.test.ts`:
 
 ```ts
 import { describe, it, expect } from 'vitest';
@@ -59,9 +97,9 @@ describe('formatCents', () => {
 });
 ```
 
-- [ ] **Step 2: Run** `npx vitest run src/lib/money.test.ts` → FAIL (module missing).
+- [ ] **Step 4: Run** `npx vitest run src/lib/money.test.ts` → FAIL (module missing).
 
-- [ ] **Step 3: Implement** `src/lib/money.ts`:
+- [ ] **Step 5: Implement** `src/lib/money.ts`:
 
 ```ts
 /** Format integer cents as a localized currency string; null/undefined → em-dash. */
@@ -72,7 +110,7 @@ export function formatCents(cents: number | null | undefined, currency = 'USD'):
 }
 ```
 
-- [ ] **Step 4: Refactor `Money.svelte`** to use it (no behavior change):
+- [ ] **Step 6: Refactor `Money.svelte`** (no behavior change):
 
 ```svelte
 <script lang="ts">
@@ -83,7 +121,7 @@ export function formatCents(cents: number | null | undefined, currency = 'USD'):
 <span style="font-variant-numeric: tabular-nums">{fmt}</span>
 ```
 
-- [ ] **Step 5: Add the reduced-motion store** to `src/lib/motion.ts` (append):
+- [ ] **Step 7: Add the reduced-motion store** to `src/lib/motion.ts` (append):
 
 ```ts
 import { readable } from 'svelte/store';
@@ -99,12 +137,12 @@ export const prefersReducedMotion = readable(false, (set) => {
 });
 ```
 
-- [ ] **Step 6: Run** `npx vitest run src/lib/money.test.ts` → PASS; `npm run check` → 0 errors.
-- [ ] **Step 7: Commit** `git add src/lib/money.ts src/lib/money.test.ts src/lib/motion.ts src/lib/components/Money.svelte && git commit -m "feat(motion): formatCents helper + prefersReducedMotion store; Money uses formatCents"`
+- [ ] **Step 8: Run** `npx vitest run src/lib/money.test.ts` → PASS; `npm run check` → 0 errors.
+- [ ] **Step 9: Commit** `git add vite.config.ts vitest.setup.ts src/lib/money.ts src/lib/money.test.ts src/lib/motion.ts src/lib/components/Money.svelte && git commit -m "test+feat: enable component render tests; formatCents + prefersReducedMotion; Money uses formatCents"`
 
 ---
 
-## Task 2: `CountUp.svelte`
+## Task 2: `CountUp.svelte` (width-reserved, reduced-prop)
 
 **Files:** Create `src/lib/components/CountUp.svelte`, `src/lib/components/CountUp.test.ts`.
 
@@ -116,19 +154,26 @@ import { render, waitFor } from '@testing-library/svelte';
 import CountUp from './CountUp.svelte';
 
 describe('CountUp', () => {
-  it('eventually displays the formatted target amount', async () => {
-    const { container } = render(CountUp, { props: { cents: 3712 } });
-    // jsdom has no matchMedia → store is false → it animates; it must land on the target
-    await waitFor(() => expect(container.textContent).toBe('$37.12'), { timeout: 1500 });
+  it('reduced=true renders the final amount immediately (no count)', () => {
+    const { container } = render(CountUp, { props: { cents: 3712, reduced: true } });
+    expect(container.textContent).toContain('$37.12');
   });
-  it('uses tabular-nums so width does not reflow', () => {
-    const { container } = render(CountUp, { props: { cents: 100 } });
-    expect(container.querySelector('span')?.getAttribute('style')).toContain('tabular-nums');
+  it('reduced=false starts below the target and animates up to it', async () => {
+    const { container } = render(CountUp, { props: { cents: 3712, reduced: false } });
+    // the visible (non-sizer) value starts at $0.00 and lands on $37.12
+    const value = () => container.querySelector('[data-countup-value]')?.textContent ?? '';
+    expect(value()).toBe('$0.00');
+    await waitFor(() => expect(value()).toBe('$37.12'), { timeout: 1500 });
+  });
+  it('reserves the final width with an aria-hidden sizer to avoid reflow', () => {
+    const { container } = render(CountUp, { props: { cents: 100000, reduced: true } });
+    const sizer = container.querySelector('[aria-hidden="true"]');
+    expect(sizer?.textContent).toBe('$1,000.00');   // sizer always shows the FINAL string
   });
 });
 ```
 
-- [ ] **Step 2: Run** `npx vitest run src/lib/components/CountUp.test.ts` → FAIL (module missing).
+- [ ] **Step 2: Run** → FAIL (module missing).
 
 - [ ] **Step 3: Implement** `src/lib/components/CountUp.svelte`:
 
@@ -140,25 +185,31 @@ describe('CountUp', () => {
   import { dur, prefersReducedMotion } from '$lib/motion';
   import { formatCents } from '$lib/money';
 
-  let { cents, currency = 'USD' }: { cents: number; currency?: string } = $props();
-  const reduced = get(prefersReducedMotion);
-  // start at the target under reduced motion (no count), else count up from 0
+  let { cents, currency = 'USD', reduced = get(prefersReducedMotion) }: {
+    cents: number; currency?: string; reduced?: boolean;
+  } = $props();
+
   const value = tweened(reduced ? cents : 0, {
     duration: reduced ? 0 : dur.slow * 1000,
     easing: cubicOut
   });
   $effect(() => { value.set(cents); });
   const display = $derived(formatCents(Math.round($value), currency));
+  const finalStr = $derived(formatCents(cents, currency));
 </script>
-<span style="font-variant-numeric: tabular-nums">{display}</span>
+<!-- relative box: an aria-hidden sizer reserves the FINAL width so the counting value never reflows -->
+<span style="position:relative; display:inline-block; font-variant-numeric:tabular-nums">
+  <span aria-hidden="true" style="visibility:hidden">{finalStr}</span>
+  <span data-countup-value style="position:absolute; left:0; top:0">{display}</span>
+</span>
 ```
 
-- [ ] **Step 4: Run** `npx vitest run src/lib/components/CountUp.test.ts` → PASS (the animated value lands on `$37.12`). `npm run check` → 0 errors.
-- [ ] **Step 5: Commit** `git add src/lib/components/CountUp.svelte src/lib/components/CountUp.test.ts && git commit -m "feat(motion): CountUp — tweened amount that lands on the target (reduced-motion jumps)"`
+- [ ] **Step 4: Run** → PASS (`reduced:true` immediate; `reduced:false` animates 0→target; sizer shows final). `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add src/lib/components/CountUp.svelte src/lib/components/CountUp.test.ts && git commit -m "feat(motion): CountUp — width-reserved tweened amount, reduced prop"`
 
 ---
 
-## Task 3: `VerifySeal.svelte`
+## Task 3: `VerifySeal.svelte` (reduced-prop)
 
 **Files:** Create `src/lib/components/VerifySeal.svelte`, `src/lib/components/VerifySeal.test.ts`.
 
@@ -172,10 +223,13 @@ import VerifySeal from './VerifySeal.svelte';
 describe('VerifySeal', () => {
   it('renders the check fully drawn in the static (play=false) state', () => {
     const { container } = render(VerifySeal, { props: { play: false, tone: 'verified' } });
-    const path = container.querySelector('path');
-    expect(path?.getAttribute('style')).toContain('stroke-dashoffset:0');
-    // verified circle is green-filled
+    // jsdom CSSOM serializes inline style with a space after the colon
+    expect(container.querySelector('path')?.getAttribute('style')).toContain('stroke-dashoffset: 0');
     expect(container.querySelector('circle')?.getAttribute('fill')).toBe('var(--green)');
+  });
+  it('reduced=true also renders drawn immediately even with play=true', () => {
+    const { container } = render(VerifySeal, { props: { play: true, reduced: true, tone: 'verified' } });
+    expect(container.querySelector('path')?.getAttribute('style')).toContain('stroke-dashoffset: 0');
   });
   it('renders a neg ✕ for tone=rejected, never green', () => {
     const { container } = render(VerifySeal, { props: { play: false, tone: 'rejected' } });
@@ -186,7 +240,7 @@ describe('VerifySeal', () => {
 });
 ```
 
-- [ ] **Step 2: Run** `npx vitest run src/lib/components/VerifySeal.test.ts` → FAIL (module missing).
+- [ ] **Step 2: Run** → FAIL (module missing).
 
 - [ ] **Step 3: Implement** `src/lib/components/VerifySeal.svelte`:
 
@@ -195,17 +249,15 @@ describe('VerifySeal', () => {
   import { get } from 'svelte/store';
   import { prefersReducedMotion } from '$lib/motion';
 
-  let { play = false, tone = 'verified', size = 28 }: {
-    play?: boolean; tone?: 'verified' | 'rejected'; size?: number;
+  let { play = false, tone = 'verified', size = 20, reduced = get(prefersReducedMotion) }: {
+    play?: boolean; tone?: 'verified' | 'rejected'; size?: number; reduced?: boolean;
   } = $props();
 
-  const reduced = get(prefersReducedMotion);
   const LEN = 20; // approx length of the check polyline for the draw
-
-  // drawn immediately when static or reduced; otherwise start undrawn then flip on next frame to transition
+  // drawn immediately when static or reduced; otherwise start undrawn then flip next frame to transition
   let drawn = $state(!play || reduced);
   $effect(() => {
-    if (play && !reduced) {
+    if (play && !reduced && typeof requestAnimationFrame === 'function') {
       drawn = false;
       requestAnimationFrame(() => { drawn = true; });
     } else {
@@ -214,7 +266,8 @@ describe('VerifySeal', () => {
   });
 </script>
 
-<svg width={size} height={size} viewBox="0 0 24 24" class:pop={play && !reduced && tone === 'verified'}
+<svg width={size} height={size} viewBox="0 0 24 24"
+     class:pop={play && !reduced && tone === 'verified'}
      aria-hidden="true" style="display:inline-block; vertical-align:middle">
   {#if tone === 'verified'}
     <circle cx="12" cy="12" r="11" fill="var(--green)" />
@@ -235,18 +288,16 @@ describe('VerifySeal', () => {
 </style>
 ```
 
-> Note: the rejected ✕ path also carries `stroke-dashoffset:0` so the verified-state test's selector (`path` has offset 0) and the rejected test (no green) are both unambiguous. The `.pop` keyframe is auto-neutralized by the global `prefers-reduced-motion` block in app.css.
-
-- [ ] **Step 4: Run** `npx vitest run src/lib/components/VerifySeal.test.ts` → PASS; `npm run check` → 0 errors.
-- [ ] **Step 5: Commit** `git add src/lib/components/VerifySeal.svelte src/lib/components/VerifySeal.test.ts && git commit -m "feat(motion): VerifySeal — check-draw + green pop / reject ✕"`
+- [ ] **Step 4: Run** → PASS; `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add src/lib/components/VerifySeal.svelte src/lib/components/VerifySeal.test.ts && git commit -m "feat(motion): VerifySeal — check-draw + green pop / reject ✕, reduced prop"`
 
 ---
 
-## Task 4: Keyframes + orchestration helper
+## Task 4: Keyframes + success-gated orchestration helper
 
 **Files:** Modify `src/app.css`; create `src/lib/review-motion.ts`, `src/lib/review-motion.test.ts`.
 
-- [ ] **Step 1: Add keyframes** to `src/app.css` (append at end — the global reduced-motion block already covers them):
+- [ ] **Step 1: Add keyframes** to `src/app.css` (append; the global reduced-motion block already neutralizes animations):
 
 ```css
 /* ── verify→payout signature motion (CLAUDE.md §5) ── */
@@ -261,10 +312,11 @@ describe('VerifySeal', () => {
   0% { transform: translateX(0); } 35% { transform: translateX(-5px); }
   70% { transform: translateX(3px); } 100% { transform: translateX(0); }
 }
-.row-dim { opacity: .5; transition: opacity var(--dur-base) var(--ease-snappy); }
+.row-dim  { opacity: .5; transition: opacity var(--dur-base) var(--ease-snappy); }            /* reject → muted */
+.row-warn { box-shadow: inset 3px 0 0 0 var(--warn); transition: box-shadow var(--dur-base); } /* revision → amber */
 ```
 
-(Confirm `--ease-out-soft` and `--ease-snappy` exist in app.css `:root`; CLAUDE.md §3 defines them — if a token is absent, add it from CLAUDE.md §3 verbatim.)
+(`--ease-out-soft`, `--ease-snappy`, `--dur-*`, `--warn` all already exist in app.css `:root`.)
 
 - [ ] **Step 2: Write the failing test** `src/lib/review-motion.test.ts`:
 
@@ -272,13 +324,14 @@ describe('VerifySeal', () => {
 import { describe, it, expect, vi } from 'vitest';
 import { makeOutcomeEnhancer, HOLD_MS } from './review-motion';
 
-function run(opts: Partial<Parameters<typeof makeOutcomeEnhancer>[0]> = {}) {
+function harness(opts: Partial<Parameters<typeof makeOutcomeEnhancer>[0]> = {}) {
   const calls: string[] = [];
   const hold = vi.fn(() => { calls.push('hold'); return Promise.resolve(); });
   const enhancer = makeOutcomeEnhancer({
     kind: 'verifying', reduced: false,
     isPending: () => false,
-    begin: () => calls.push('begin'),
+    markPending: () => calls.push('markPending'),
+    showSucceeded: () => calls.push('showSucceeded'),
     finish: () => calls.push('finish'),
     hold,
     ...opts
@@ -287,73 +340,80 @@ function run(opts: Partial<Parameters<typeof makeOutcomeEnhancer>[0]> = {}) {
 }
 
 describe('makeOutcomeEnhancer', () => {
-  it('cancels (and does not begin) when already pending', () => {
+  it('cancels (no markPending) when already pending', () => {
     const cancel = vi.fn();
-    const { enhancer, calls } = run({ isPending: () => true });
-    const cb = enhancer({ cancel } as any);
+    const { enhancer, calls } = harness({ isPending: () => true });
+    expect(enhancer({ cancel } as any)).toBeUndefined();
     expect(cancel).toHaveBeenCalled();
-    expect(cb).toBeUndefined();
-    expect(calls).not.toContain('begin');
+    expect(calls).toEqual([]);
   });
-  it('on success: begin → hold(HOLD_MS) → update → finish, in order', async () => {
-    const { enhancer, calls, hold } = run();
-    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
-    const result = enhancer({ cancel: vi.fn() } as any)!;
-    await result({ result: { type: 'success' }, update } as any);
-    expect(hold).toHaveBeenCalledWith(HOLD_MS.verifying);
-    expect(calls).toEqual(['begin', 'hold', 'update', 'finish']);
-  });
-  it('reduced motion skips the hold', async () => {
-    const { enhancer, calls } = run({ reduced: true });
+  it('SUCCESS: markPending (before) → showSucceeded → hold → update → finish', async () => {
+    const { enhancer, calls, hold } = harness();
     const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
     await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'success' }, update } as any);
-    expect(calls).toEqual(['begin', 'update', 'finish']);
+    expect(hold).toHaveBeenCalledWith(HOLD_MS.verifying);
+    expect(calls).toEqual(['markPending', 'showSucceeded', 'hold', 'update', 'finish']);
   });
-  it('failure result skips the hold but still updates + finishes', async () => {
-    const { enhancer, calls } = run();
+  it('FAILURE: never shows the success visual, no hold — just update + finish', async () => {
+    const { enhancer, calls, hold } = harness();
     const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
     await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'failure' }, update } as any);
-    expect(calls).toEqual(['begin', 'update', 'finish']);
+    expect(hold).not.toHaveBeenCalled();
+    expect(calls).toEqual(['markPending', 'update', 'finish']);   // NO showSucceeded
   });
-  it('runs prepare(input) before begin, in the before-submit phase', () => {
+  it('reduced motion: success shows the visual but skips the hold', async () => {
+    const { enhancer, calls, hold } = harness({ reduced: true });
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'success' }, update } as any);
+    expect(hold).not.toHaveBeenCalled();
+    expect(calls).toEqual(['markPending', 'showSucceeded', 'update', 'finish']);
+  });
+  it('runs prepare(input) before markPending', () => {
     const calls: string[] = [];
     const enhancer = makeOutcomeEnhancer({
       kind: 'verifying', reduced: false, isPending: () => false,
-      prepare: (input: any) => calls.push('prepare:' + input.formData.get('payout')),
-      begin: () => calls.push('begin'), finish: () => {}, hold: () => Promise.resolve()
+      prepare: (i: any) => calls.push('prepare:' + i.formData.get('payout')),
+      markPending: () => calls.push('markPending'),
+      showSucceeded: () => {}, finish: () => {}, hold: () => Promise.resolve()
     });
     enhancer({ cancel: vi.fn(), formData: new Map([['payout', '5']]) } as any);
-    expect(calls).toEqual(['prepare:5', 'begin']);
+    expect(calls).toEqual(['prepare:5', 'markPending']);
   });
 });
 ```
 
-- [ ] **Step 3: Run** `npx vitest run src/lib/review-motion.test.ts` → FAIL (module missing).
+- [ ] **Step 3: Run** → FAIL (module missing).
 
 - [ ] **Step 4: Implement** `src/lib/review-motion.ts`:
 
 ```ts
 import type { SubmitFunction } from '@sveltejs/kit';
 
-export type OutcomeKind = 'verifying' | 'rejecting' | 'revising';
+export type OutcomeKind = 'verifying' | 'approving' | 'rejecting' | 'revising';
 
-/** Sequence durations (ms): the full moment reads ~700ms; dismissals are quicker (CLAUDE.md §2.3). */
-export const HOLD_MS: Record<OutcomeKind, number> = { verifying: 700, rejecting: 260, revising: 260 };
+/** Sequence durations (ms): full verify reads ~700ms; the lighter admin approve ~400ms;
+ *  dismissals quicker (CLAUDE.md §2.3). The hold runs AFTER the success visual mounts. */
+export const HOLD_MS: Record<OutcomeKind, number> = {
+  verifying: 700, approving: 400, rejecting: 260, revising: 260
+};
 
 /**
  * Build a `use:enhance` SubmitFunction that plays the review-outcome moment, then refetches.
- * Two phases: (before-submit) cancel if already pending, else begin() — mounts the seal/glow now,
- * overlapping the server round-trip; (result) hold for the sequence on SUCCESS (skipped under
- * reduced motion or on a fail() result), then update() to refetch, then finish().
+ * SUCCESS-GATED: the before-submit phase only marks the row in-flight (markPending — NO green seal,
+ * so a rejected/failed request never flashes a fake "Verified"). The success visual (showSucceeded)
+ * mounts ONLY in the result callback when result.type === 'success', then holds the full sequence
+ * (skipped under reduced motion), then update() refetches, then finish().
+ * On a fail() result: no success visual, no hold — just update() + finish() (the form's
+ * error message surfaces via the page's `form` prop after invalidateAll).
  */
 export function makeOutcomeEnhancer(opts: {
   kind: OutcomeKind;
   reduced: boolean;
   isPending: () => boolean;
-  begin: () => void;
-  finish: () => void;
-  /** Before-submit hook with the SubmitFunction input (e.g. read formData to capture the payout). */
-  prepare?: (input: Parameters<SubmitFunction>[0]) => void;
+  markPending: () => void;            // neutral in-flight marker (hide controls); NO success visual
+  showSucceeded: () => void;          // mount seal/CountUp/glow or settle (success only)
+  finish: () => void;                 // clear in-flight + visual
+  prepare?: (input: Parameters<SubmitFunction>[0]) => void;  // e.g. capture the typed payout
   hold?: (ms: number) => Promise<void>;
 }): SubmitFunction {
   const hold = opts.hold ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
@@ -363,9 +423,12 @@ export function makeOutcomeEnhancer(opts: {
       return;
     }
     opts.prepare?.(input);
-    opts.begin();
+    opts.markPending();
     return async ({ result, update }) => {
-      if (result.type === 'success' && !opts.reduced) await hold(HOLD_MS[opts.kind]);
+      if (result.type === 'success') {
+        opts.showSucceeded();
+        if (!opts.reduced) await hold(HOLD_MS[opts.kind]);
+      }
       await update();
       opts.finish();
     };
@@ -373,27 +436,28 @@ export function makeOutcomeEnhancer(opts: {
 }
 ```
 
-- [ ] **Step 5: Run** `npx vitest run src/lib/review-motion.test.ts` → PASS; `npm run check` → 0 errors.
-- [ ] **Step 6: Commit** `git add src/app.css src/lib/review-motion.ts src/lib/review-motion.test.ts && git commit -m "feat(motion): payout-glow + reject-settle keyframes + makeOutcomeEnhancer orchestration"`
+- [ ] **Step 5: Run** → PASS; `npm run check` → 0 errors.
+- [ ] **Step 6: Commit** `git add src/app.css src/lib/review-motion.ts src/lib/review-motion.test.ts && git commit -m "feat(motion): keyframes + success-gated makeOutcomeEnhancer"`
 
 ---
 
 ## Task 5: Wire the console review queue
 
-**Files:** Modify `src/routes/console/+page.svelte`.
+**Files:** Modify `src/routes/console/+page.svelte`. Two-flag per-row state: `inflight` (neutral, set in `markPending`) hides controls during the round-trip; `shown` (set in `showSucceeded`) drives the visual on success only. The create form stays a plain POST.
 
-Convert the per-row `verify` / `request_revision` / `reject` forms to `use:enhance` driving the
-moment. Keep the create form a plain POST (out of scope). The full verify moment shows the seal +
-`CountUp` (to the entered payout) + `payout-glow`; revision/reject show the settle + dim.
+> **Behavior note (corrected):** after `update()`, a **verified** or **rejected** row leaves the
+> queue (those statuses aren't in the load filter `submitted/under_review/revision_requested`), so
+> the moment is its send-off. A **request_revision** row **stays** (`revision_requested` is in the
+> filter) and re-shows its controls with a "Revision requested" badge — the amber settle reads as
+> in-place feedback, not a removal.
 
-- [ ] **Step 1: Replace the `<script>` and the review-queue `{#each}`** in `src/routes/console/+page.svelte`. New script block:
+- [ ] **Step 1: Replace the `<script>` block** in `src/routes/console/+page.svelte`:
 
 ```svelte
 <script lang="ts">
   import { enhance } from '$app/forms';
   import { get } from 'svelte/store';
   import StatusBadge from '$lib/components/StatusBadge.svelte';
-  import Money from '$lib/components/Money.svelte';
   import Markdown from '$lib/components/Markdown.svelte';
   import VerifySeal from '$lib/components/VerifySeal.svelte';
   import CountUp from '$lib/components/CountUp.svelte';
@@ -403,48 +467,52 @@ moment. Keep the create form a plain POST (out of scope). The full verify moment
   let { data, form } = $props();
   const reduced = get(prefersReducedMotion);
 
-  // per-row moment state, keyed by answer id
-  let outcome = $state<Record<string, OutcomeKind | undefined>>({});
+  let inflight = $state<Record<string, boolean>>({});                 // round-trip marker (hide controls)
+  let shown = $state<Record<string, OutcomeKind | undefined>>({});    // success visual only
   let verifiedCents = $state<Record<string, number>>({});
-  const pending = (id: string) => outcome[id] != null;
+  let announce = $state('');                                          // aria-live text
 
-  function enhancer(id: string, kind: OutcomeKind) {
+  function enhancer(id: string, kind: OutcomeKind, label: string) {
     return makeOutcomeEnhancer({
       kind, reduced,
-      isPending: () => pending(id),
-      // for verify: capture the typed payout (dollars→cents) from the submit's formData so CountUp
-      // counts to exactly what was sent (runs in the before-submit phase, before begin hides the form)
+      isPending: () => inflight[id] === true,
       prepare: kind === 'verifying'
         ? (input) => {
             const dollars = Number(input.formData.get('payout'));
             if (Number.isFinite(dollars)) verifiedCents = { ...verifiedCents, [id]: Math.round(dollars * 100) };
           }
         : undefined,
-      begin: () => { outcome = { ...outcome, [id]: kind }; },
-      finish: () => { const o = { ...outcome }; delete o[id]; outcome = o; }
+      markPending: () => { inflight = { ...inflight, [id]: true }; },
+      showSucceeded: () => { shown = { ...shown, [id]: kind }; announce = label; },
+      finish: () => {
+        const i = { ...inflight }; delete i[id]; inflight = i;
+        const s = { ...shown }; delete s[id]; shown = s;
+      }
     });
   }
 </script>
 ```
 
-- [ ] **Step 2: Replace the review-queue row markup** (the `{#each data.queue as a (a.id)}` block) with the version below — the row dims/settles via classes, the verify form swaps to the seal+CountUp while `outcome[a.id] === 'verifying'`:
+- [ ] **Step 2: Replace the review-queue `{#each}` block** with:
 
 ```svelte
-  <div class="mb-8 flex flex-col gap-3">
+  <div class="mb-8 flex flex-col gap-3" aria-live="polite">
+    <span class="sr-only">{announce}</span>
     {#each data.queue as a (a.id)}
       <div class="rounded-2xl border p-5"
-           class:reject-settle={outcome[a.id] === 'rejecting' || outcome[a.id] === 'revising'}
-           class:row-dim={outcome[a.id] === 'rejecting'}
-           class:payout-glow={outcome[a.id] === 'verifying'}
+           class:payout-glow={shown[a.id] === 'verifying'}
+           class:reject-settle={shown[a.id] === 'rejecting' || shown[a.id] === 'revising'}
+           class:row-dim={shown[a.id] === 'rejecting'}
+           class:row-warn={shown[a.id] === 'revising'}
            style="border-color:var(--line); background:var(--surface)">
         <div class="mb-1 flex items-center justify-between gap-2">
           <div>
             <a href="/ideas/{a.idea_id}" class="font-bold" style="color:var(--ink)">{a.title}</a>
             <span class="ml-2 text-xs" style="color:var(--faint)">on “{a.ideas?.title}” · by {a.submitter?.display_name ?? a.submitter?.handle}</span>
           </div>
-          {#if outcome[a.id] === 'verifying'}
-            <span class="flex items-center gap-2 text-sm font-medium" style="color:var(--green-deep)">
-              <VerifySeal play tone="verified" /> Verified · <CountUp cents={verifiedCents[a.id] ?? 0} />
+          {#if shown[a.id] === 'verifying'}
+            <span class="flex items-center gap-1.5 text-sm font-medium whitespace-nowrap" style="color:var(--green-deep)">
+              <VerifySeal play tone="verified" {reduced} /> Verified · <CountUp cents={verifiedCents[a.id] ?? 0} {reduced} />
             </span>
           {:else}
             <StatusBadge status={a.status} />
@@ -459,9 +527,9 @@ moment. Keep the create form a plain POST (out of scope). The full verify moment
           </ul>
         {/if}
 
-        {#if !pending(a.id)}
+        {#if !inflight[a.id]}
           <form method="POST" action="?/verify" class="flex flex-wrap items-end gap-2 border-t pt-3"
-                style="border-color:var(--line)" use:enhance={enhancer(a.id, 'verifying')}>
+                style="border-color:var(--line)" use:enhance={enhancer(a.id, 'verifying', 'Answer verified.')}>
             <input type="hidden" name="answer_id" value={a.id} />
             <label class="text-xs" style="color:var(--faint)">Intended payout ($)
               <input name="payout" type="number" min="0.01" step="0.01" placeholder="0.00" required
@@ -479,12 +547,13 @@ moment. Keep the create form a plain POST (out of scope). The full verify moment
           </form>
 
           <div class="mt-2 flex gap-4">
-            <form method="POST" action="?/request_revision" class="flex flex-1 gap-2" use:enhance={enhancer(a.id, 'revising')}>
+            <form method="POST" action="?/request_revision" class="flex flex-1 gap-2"
+                  use:enhance={enhancer(a.id, 'revising', 'Revision requested.')}>
               <input type="hidden" name="answer_id" value={a.id} />
               <input name="note" placeholder="What to revise" class="flex-1 rounded-xl border px-2 py-1 text-sm" style="border-color:var(--line)" />
               <button class="text-sm" style="color:var(--warn)">Request revision</button>
             </form>
-            <form method="POST" action="?/reject" use:enhance={enhancer(a.id, 'rejecting')}>
+            <form method="POST" action="?/reject" use:enhance={enhancer(a.id, 'rejecting', 'Answer rejected.')}>
               <input type="hidden" name="answer_id" value={a.id} />
               <button class="text-sm" style="color:var(--neg)">Reject</button>
             </form>
@@ -495,22 +564,17 @@ moment. Keep the create form a plain POST (out of scope). The full verify moment
   </div>
 ```
 
-> The `{#if !pending(a.id)}` hides the controls while the moment plays (prevents re-submit; the
-> seal/CountUp occupy the header). After `update()` the refetch drops the row from `data.queue`
-> entirely (status moved off `submitted`/`under_review`), so the moment is the row's send-off.
+(If `.sr-only` isn't already a global utility, add it to `app.css`: `.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}`.)
 
-- [ ] **Step 3: Verify** `npm run check` → 0 errors. `npm run build` → succeeds. `npx vitest run` → all green (no test broke).
-- [ ] **Step 4: Manual smoke** (`npm run dev` on a free port): not headless-feasible to sign in as an expert; instead confirm the page compiles and renders (curl the console route returns 200/redirect) and rely on the unit tests for behavior. Note the observation.
-- [ ] **Step 5: Commit** `git add src/routes/console/+page.svelte && git commit -m "feat(console): verify→payout moment + reject/revision settle via use:enhance"`
+- [ ] **Step 3: Verify** `npm run check` → 0 errors; `npm run build` → succeeds; `npx vitest run` → all green.
+- [ ] **Step 4: Manual smoke** (`npm run dev`): expert sign-in isn't headless-feasible — confirm the route compiles/renders (curl returns 200 or the auth redirect) and rely on the unit suites for behavior. Note the observation.
+- [ ] **Step 5: Commit** `git add src/routes/console/+page.svelte src/app.css && git commit -m "feat(console): success-gated verify moment + reject(dim)/revision(amber) settle"`
 
 ---
 
-## Task 6: Wire the admin/payouts gate (lighter seal)
+## Task 6: Wire the admin/payouts gate (lighter seal, table-safe)
 
-**Files:** Modify `src/routes/admin/payouts/+page.svelte`.
-
-Approve = lighter moment (seal pop + glow, **no re-count** — the amount is unchanged; keep the
-static `Money`). Reject = settle + dim.
+**Files:** Modify `src/routes/admin/payouts/+page.svelte`. Approve = `approving` kind (~400ms seal pop + glow, **no count-up** — amount unchanged). Reject = dim only. **No `transform`/`box-shadow` on `<tr>`** — glow goes on the action `<td>`, reject uses `row-dim` (opacity, which is reliable on rows).
 
 - [ ] **Step 1: Replace the `<script>`**:
 
@@ -525,42 +589,52 @@ static `Money`). Reject = settle + dim.
 
   let { data, form } = $props();
   const reduced = get(prefersReducedMotion);
-  let outcome = $state<Record<string, OutcomeKind | undefined>>({});
-  const pending = (id: string) => outcome[id] != null;
-  function enhancer(id: string, kind: OutcomeKind) {
+  let inflight = $state<Record<string, boolean>>({});
+  let shown = $state<Record<string, OutcomeKind | undefined>>({});
+  let announce = $state('');
+
+  function enhancer(id: string, kind: OutcomeKind, label: string) {
     return makeOutcomeEnhancer({
       kind, reduced,
-      isPending: () => pending(id),
-      begin: () => { outcome = { ...outcome, [id]: kind }; },
-      finish: () => { const o = { ...outcome }; delete o[id]; outcome = o; }
+      isPending: () => inflight[id] === true,
+      markPending: () => { inflight = { ...inflight, [id]: true }; },
+      showSucceeded: () => { shown = { ...shown, [id]: kind }; announce = label; },
+      finish: () => {
+        const i = { ...inflight }; delete i[id]; inflight = i;
+        const s = { ...shown }; delete s[id]; shown = s;
+      }
     });
   }
 </script>
 ```
 
-- [ ] **Step 2: Replace the `<tbody>` rows** so the action cell swaps to the seal while approving, and the row settles/dims on reject:
+- [ ] **Step 2: Replace the `<tbody>`** (and add an aria-live region just before the `<table>`):
 
 ```svelte
+  <span class="sr-only" aria-live="polite">{announce}</span>
+  <table class="w-full text-sm">
+    <thead><tr style="color:var(--faint)">
+      <th class="text-left">Answer</th><th class="text-left">Idea</th><th class="text-left">Submitter</th>
+      <th class="text-right">Intended</th><th></th>
+    </tr></thead>
+    <tbody>
       {#each data.pending as a (a.id)}
-        <tr style="border-top:1px solid var(--line)"
-            class:reject-settle={outcome[a.id] === 'rejecting'}
-            class:row-dim={outcome[a.id] === 'rejecting'}
-            class:payout-glow={outcome[a.id] === 'verifying'}>
+        <tr style="border-top:1px solid var(--line)" class:row-dim={shown[a.id] === 'rejecting'}>
           <td class="py-2" style="color:var(--ink)"><a href="/ideas/{a.idea_id}" style="color:var(--green-deep)">{a.title}</a></td>
           <td style="color:var(--muted)">{a.ideas?.title}</td>
           <td style="color:var(--muted)">{a.submitter?.display_name ?? a.submitter?.handle}</td>
           <td class="text-right" style="color:var(--ink)"><Money cents={a.payout_amount_cents} currency={a.payout_currency} /></td>
-          <td class="py-2 text-right">
-            {#if outcome[a.id] === 'verifying'}
+          <td class="py-2 text-right" class:payout-glow={shown[a.id] === 'approving'}>
+            {#if shown[a.id] === 'approving'}
               <span class="inline-flex items-center gap-1 text-sm font-medium" style="color:var(--green-deep)">
-                <VerifySeal play tone="verified" size={20} /> Approved
+                <VerifySeal play tone="verified" {reduced} /> Approved
               </span>
-            {:else if !pending(a.id)}
-              <form method="POST" action="?/approve" class="inline" use:enhance={enhancer(a.id, 'verifying')}>
+            {:else if !inflight[a.id]}
+              <form method="POST" action="?/approve" class="inline" use:enhance={enhancer(a.id, 'approving', 'Payout approved.')}>
                 <input type="hidden" name="answer_id" value={a.id} />
                 <button class="mr-3" style="color:var(--green-deep)">Approve</button>
               </form>
-              <form method="POST" action="?/reject" class="inline" use:enhance={enhancer(a.id, 'rejecting')}>
+              <form method="POST" action="?/reject" class="inline" use:enhance={enhancer(a.id, 'rejecting', 'Payout rejected.')}>
                 <input type="hidden" name="answer_id" value={a.id} />
                 <button style="color:var(--neg)">Reject</button>
               </form>
@@ -568,23 +642,22 @@ static `Money`). Reject = settle + dim.
           </td>
         </tr>
       {/each}
+    </tbody>
+  </table>
 ```
 
-(`verifying` is reused as the approve kind — same `HOLD_MS.verifying` pacing for the lighter seal; no CountUp here.)
-
 - [ ] **Step 3: Verify** `npm run check` → 0 errors; `npm run build` → succeeds; `npx vitest run` → all green.
-- [ ] **Step 4: Commit** `git add src/routes/admin/payouts/+page.svelte && git commit -m "feat(payouts): lighter approve seal + reject settle via use:enhance"`
+- [ ] **Step 4: Commit** `git add src/routes/admin/payouts/+page.svelte && git commit -m "feat(payouts): lighter approve seal (table-safe glow) + reject dim"`
 
 ---
 
 ## Task 7: Final verification
-
 - [ ] `npx vitest run` (whole repo) green; `npm run check` 0 errors; `npm run build` succeeds; `supabase test db` unchanged-green (no SQL touched).
-- [ ] Manual (`npm run dev`): with OS reduced-motion OFF, a verify plays seal+count-up+glow and the row leaves; with reduced-motion ON, states jump (no motion), row still leaves. (If signing in as an expert/admin locally is impractical, note it and rely on the unit suites covering the moment's logic.)
-- [ ] Dispatch the final holistic review; then finish the branch (PR).
+- [ ] Manual (`npm run dev`, if expert/admin sign-in is feasible): verify plays seal+count-up+glow only on success; a rate-limited/failed verify shows the error with **no** green flash; OS reduced-motion ON → states jump. Otherwise note and rely on the unit suites.
+- [ ] Dispatch the final holistic review; finish the branch (PR).
 
 ## Done-when
-- `formatCents`, `prefersReducedMotion`, `CountUp`, `VerifySeal`, `makeOutcomeEnhancer` all unit-tested and green; `Money` refactored with no behavior change.
-- Console verify shows the full moment (seal → green pop → payout count-up → glow); admin approve shows the lighter seal; reject/revision settle+dim; all jump to final under reduced motion.
-- Forms are `use:enhance` (progressive-enhancement fallback still submits); `fail()` skips the success animation.
+- `formatCents`, `prefersReducedMotion`, `CountUp` (width-reserved, reduced-prop), `VerifySeal` (reduced-prop), `makeOutcomeEnhancer` (success-gated) all unit-tested green; `Money` refactored, no behavior change; component render tests run (vite browser condition + matchMedia stub).
+- Console verify shows the full moment **only on success**; admin approve the lighter ~400ms seal; reject dims, revision shows the amber settle (and stays in-queue). A `fail()` shows no success visual.
+- Everything jumps to final under reduced motion (driven by the `reduced` prop, unit-tested both ways); an aria-live region announces each outcome.
 - No RPC/DB/cloud changes; `npm run check`/`vitest`/`build`/`supabase test db` all green.

--- a/docs/superpowers/plans/2026-06-07-verify-payout-animation.md
+++ b/docs/superpowers/plans/2026-06-07-verify-payout-animation.md
@@ -1,0 +1,590 @@
+# Verify→Payout Signature Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. No cloud/DB/RPC changes — this is presentational + an enhance conversion. Constraints: never edit CLAUDE.md/docs//.claude//src_legacy_v0/; never `git add .`/`git add -A` (explicit paths only).
+
+**Goal:** Play CLAUDE.md's verify→payout signature moment — a seal draws its check + fills `--green` with a small pop, then the recorded payout counts up with one green glow — on console verify; a lighter seal on admin approve; a restrained settle+dim on reject/revision; everything jumps to final under `prefers-reduced-motion`.
+
+**Architecture:** Two presentational primitives (`VerifySeal`, `CountUp`), a pure formatter + a reduced-motion store, two CSS keyframes, and a framework-agnostic `use:enhance` orchestration helper (`makeOutcomeEnhancer`) wired into the console + admin/payouts review forms (converting them from full-reload to animate-then-refetch). Spec: `docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md`.
+
+**Tech Stack:** Svelte 5 runes, `svelte/motion` `tweened` + `svelte/easing` `cubicOut`, Tailwind v4, vitest + `@testing-library/svelte` (jsdom — note: jsdom has no `matchMedia`, so the reduced-motion store defaults to `false` in tests, deterministically).
+
+---
+
+## Key decisions
+- **DRY the money format:** extract `formatCents` to `$lib/money.ts`; `Money.svelte` and `CountUp.svelte` both use it → one deterministic unit to test.
+- **Reduced motion is a store** (`prefersReducedMotion`) read once at component init (preference rarely flips mid-session); SSR-safe default `false`.
+- **Orchestration is extracted** to `$lib/review-motion.ts` (`makeOutcomeEnhancer`) so the two-phase logic (cancel-if-pending → begin → hold-then-update, `fail()` skips the hold) is unit-tested without mounting a page.
+- **Seal is CSS-driven** (stroke-dashoffset transition + a `seal-pop` keyframe), not a JS spring — simpler, and the global reduced-motion block already neutralizes it.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `src/lib/money.ts` (new) | `formatCents(cents, currency)` pure formatter |
+| `src/lib/motion.ts` (modify) | add `prefersReducedMotion` readable store |
+| `src/lib/components/Money.svelte` (modify) | use `formatCents` (no behavior change) |
+| `src/lib/components/CountUp.svelte` (new) | tweened 0→cents animated amount |
+| `src/lib/components/VerifySeal.svelte` (new) | SVG check-draw + green-pop / reject ✕ |
+| `src/app.css` (modify) | `@keyframes payout-glow`, `reject-settle` + classes |
+| `src/lib/review-motion.ts` (new) | `makeOutcomeEnhancer` + `HOLD_MS` |
+| `src/routes/console/+page.svelte` (modify) | wire verify (full) / reject / request_revision |
+| `src/routes/admin/payouts/+page.svelte` (modify) | wire approve (lighter) / reject |
+| `*.test.ts` | vitest for money, CountUp, VerifySeal, review-motion |
+
+---
+
+## Task 1: Foundation — `formatCents`, reduced-motion store
+
+**Files:** Create `src/lib/money.ts`, `src/lib/money.test.ts`; modify `src/lib/motion.ts`, `src/lib/components/Money.svelte`.
+
+- [ ] **Step 1: Write the failing test** `src/lib/money.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatCents } from './money';
+
+describe('formatCents', () => {
+  it('formats cents as USD currency', () => {
+    expect(formatCents(3712)).toBe('$37.12');
+    expect(formatCents(0)).toBe('$0.00');
+    expect(formatCents(100000)).toBe('$1,000.00');
+  });
+  it('renders an em-dash for null/undefined', () => {
+    expect(formatCents(null)).toBe('—');
+    expect(formatCents(undefined)).toBe('—');
+  });
+  it('honors a currency argument', () => {
+    expect(formatCents(500, 'EUR')).toBe('€5.00');
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run src/lib/money.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `src/lib/money.ts`:
+
+```ts
+/** Format integer cents as a localized currency string; null/undefined → em-dash. */
+export function formatCents(cents: number | null | undefined, currency = 'USD'): string {
+  return cents == null
+    ? '—'
+    : new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100);
+}
+```
+
+- [ ] **Step 4: Refactor `Money.svelte`** to use it (no behavior change):
+
+```svelte
+<script lang="ts">
+  import { formatCents } from '$lib/money';
+  let { cents, currency = 'USD' }: { cents: number | null | undefined; currency?: string } = $props();
+  const fmt = $derived(formatCents(cents, currency));
+</script>
+<span style="font-variant-numeric: tabular-nums">{fmt}</span>
+```
+
+- [ ] **Step 5: Add the reduced-motion store** to `src/lib/motion.ts` (append):
+
+```ts
+import { readable } from 'svelte/store';
+
+/** True when the user asked for reduced motion. SSR-safe default false; updates on change. */
+export const prefersReducedMotion = readable(false, (set) => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  set(mq.matches);
+  const on = () => set(mq.matches);
+  mq.addEventListener('change', on);
+  return () => mq.removeEventListener('change', on);
+});
+```
+
+- [ ] **Step 6: Run** `npx vitest run src/lib/money.test.ts` → PASS; `npm run check` → 0 errors.
+- [ ] **Step 7: Commit** `git add src/lib/money.ts src/lib/money.test.ts src/lib/motion.ts src/lib/components/Money.svelte && git commit -m "feat(motion): formatCents helper + prefersReducedMotion store; Money uses formatCents"`
+
+---
+
+## Task 2: `CountUp.svelte`
+
+**Files:** Create `src/lib/components/CountUp.svelte`, `src/lib/components/CountUp.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `src/lib/components/CountUp.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte';
+import CountUp from './CountUp.svelte';
+
+describe('CountUp', () => {
+  it('eventually displays the formatted target amount', async () => {
+    const { container } = render(CountUp, { props: { cents: 3712 } });
+    // jsdom has no matchMedia → store is false → it animates; it must land on the target
+    await waitFor(() => expect(container.textContent).toBe('$37.12'), { timeout: 1500 });
+  });
+  it('uses tabular-nums so width does not reflow', () => {
+    const { container } = render(CountUp, { props: { cents: 100 } });
+    expect(container.querySelector('span')?.getAttribute('style')).toContain('tabular-nums');
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run src/lib/components/CountUp.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `src/lib/components/CountUp.svelte`:
+
+```svelte
+<script lang="ts">
+  import { tweened } from 'svelte/motion';
+  import { cubicOut } from 'svelte/easing';
+  import { get } from 'svelte/store';
+  import { dur, prefersReducedMotion } from '$lib/motion';
+  import { formatCents } from '$lib/money';
+
+  let { cents, currency = 'USD' }: { cents: number; currency?: string } = $props();
+  const reduced = get(prefersReducedMotion);
+  // start at the target under reduced motion (no count), else count up from 0
+  const value = tweened(reduced ? cents : 0, {
+    duration: reduced ? 0 : dur.slow * 1000,
+    easing: cubicOut
+  });
+  $effect(() => { value.set(cents); });
+  const display = $derived(formatCents(Math.round($value), currency));
+</script>
+<span style="font-variant-numeric: tabular-nums">{display}</span>
+```
+
+- [ ] **Step 4: Run** `npx vitest run src/lib/components/CountUp.test.ts` → PASS (the animated value lands on `$37.12`). `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add src/lib/components/CountUp.svelte src/lib/components/CountUp.test.ts && git commit -m "feat(motion): CountUp — tweened amount that lands on the target (reduced-motion jumps)"`
+
+---
+
+## Task 3: `VerifySeal.svelte`
+
+**Files:** Create `src/lib/components/VerifySeal.svelte`, `src/lib/components/VerifySeal.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `src/lib/components/VerifySeal.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import VerifySeal from './VerifySeal.svelte';
+
+describe('VerifySeal', () => {
+  it('renders the check fully drawn in the static (play=false) state', () => {
+    const { container } = render(VerifySeal, { props: { play: false, tone: 'verified' } });
+    const path = container.querySelector('path');
+    expect(path?.getAttribute('style')).toContain('stroke-dashoffset:0');
+    // verified circle is green-filled
+    expect(container.querySelector('circle')?.getAttribute('fill')).toBe('var(--green)');
+  });
+  it('renders a neg ✕ for tone=rejected, never green', () => {
+    const { container } = render(VerifySeal, { props: { play: false, tone: 'rejected' } });
+    expect(container.querySelector('circle')?.getAttribute('fill')).toBe('none');
+    expect(container.innerHTML).not.toContain('var(--green)');
+    expect(container.innerHTML).toContain('var(--neg)');
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest run src/lib/components/VerifySeal.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** `src/lib/components/VerifySeal.svelte`:
+
+```svelte
+<script lang="ts">
+  import { get } from 'svelte/store';
+  import { prefersReducedMotion } from '$lib/motion';
+
+  let { play = false, tone = 'verified', size = 28 }: {
+    play?: boolean; tone?: 'verified' | 'rejected'; size?: number;
+  } = $props();
+
+  const reduced = get(prefersReducedMotion);
+  const LEN = 20; // approx length of the check polyline for the draw
+
+  // drawn immediately when static or reduced; otherwise start undrawn then flip on next frame to transition
+  let drawn = $state(!play || reduced);
+  $effect(() => {
+    if (play && !reduced) {
+      drawn = false;
+      requestAnimationFrame(() => { drawn = true; });
+    } else {
+      drawn = true;
+    }
+  });
+</script>
+
+<svg width={size} height={size} viewBox="0 0 24 24" class:pop={play && !reduced && tone === 'verified'}
+     aria-hidden="true" style="display:inline-block; vertical-align:middle">
+  {#if tone === 'verified'}
+    <circle cx="12" cy="12" r="11" fill="var(--green)" />
+    <path d="M7 12.5l3.3 3.3L17 9" fill="none" stroke="var(--ink)" stroke-width="2.2"
+          stroke-linecap="round" stroke-linejoin="round"
+          style="stroke-dasharray:{LEN}; stroke-dashoffset:{drawn ? 0 : LEN};
+                 transition:stroke-dashoffset var(--dur-base) var(--ease-snappy)" />
+  {:else}
+    <circle cx="12" cy="12" r="11" fill="none" stroke="var(--neg)" stroke-width="2" />
+    <path d="M8.5 8.5l7 7M15.5 8.5l-7 7" fill="none" stroke="var(--neg)" stroke-width="2.2"
+          stroke-linecap="round" style="stroke-dashoffset:0" />
+  {/if}
+</svg>
+
+<style>
+  .pop { transform-origin: center; animation: seal-pop var(--dur-base) var(--ease-snappy); }
+  @keyframes seal-pop { 0% { transform: scale(1); } 45% { transform: scale(1.12); } 100% { transform: scale(1); } }
+</style>
+```
+
+> Note: the rejected ✕ path also carries `stroke-dashoffset:0` so the verified-state test's selector (`path` has offset 0) and the rejected test (no green) are both unambiguous. The `.pop` keyframe is auto-neutralized by the global `prefers-reduced-motion` block in app.css.
+
+- [ ] **Step 4: Run** `npx vitest run src/lib/components/VerifySeal.test.ts` → PASS; `npm run check` → 0 errors.
+- [ ] **Step 5: Commit** `git add src/lib/components/VerifySeal.svelte src/lib/components/VerifySeal.test.ts && git commit -m "feat(motion): VerifySeal — check-draw + green pop / reject ✕"`
+
+---
+
+## Task 4: Keyframes + orchestration helper
+
+**Files:** Modify `src/app.css`; create `src/lib/review-motion.ts`, `src/lib/review-motion.test.ts`.
+
+- [ ] **Step 1: Add keyframes** to `src/app.css` (append at end — the global reduced-motion block already covers them):
+
+```css
+/* ── verify→payout signature motion (CLAUDE.md §5) ── */
+.payout-glow { animation: payout-glow var(--dur-slow) var(--ease-out-soft); }
+@keyframes payout-glow {
+  0%   { box-shadow: 0 0 0 0 rgba(68, 255, 152, 0); }
+  40%  { box-shadow: 0 0 0 4px rgba(68, 255, 152, .30); }
+  100% { box-shadow: 0 0 0 0 rgba(68, 255, 152, 0); }
+}
+.reject-settle { animation: reject-settle var(--dur-base) var(--ease-snappy); }
+@keyframes reject-settle {
+  0% { transform: translateX(0); } 35% { transform: translateX(-5px); }
+  70% { transform: translateX(3px); } 100% { transform: translateX(0); }
+}
+.row-dim { opacity: .5; transition: opacity var(--dur-base) var(--ease-snappy); }
+```
+
+(Confirm `--ease-out-soft` and `--ease-snappy` exist in app.css `:root`; CLAUDE.md §3 defines them — if a token is absent, add it from CLAUDE.md §3 verbatim.)
+
+- [ ] **Step 2: Write the failing test** `src/lib/review-motion.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { makeOutcomeEnhancer, HOLD_MS } from './review-motion';
+
+function run(opts: Partial<Parameters<typeof makeOutcomeEnhancer>[0]> = {}) {
+  const calls: string[] = [];
+  const hold = vi.fn(() => { calls.push('hold'); return Promise.resolve(); });
+  const enhancer = makeOutcomeEnhancer({
+    kind: 'verifying', reduced: false,
+    isPending: () => false,
+    begin: () => calls.push('begin'),
+    finish: () => calls.push('finish'),
+    hold,
+    ...opts
+  });
+  return { enhancer, calls, hold };
+}
+
+describe('makeOutcomeEnhancer', () => {
+  it('cancels (and does not begin) when already pending', () => {
+    const cancel = vi.fn();
+    const { enhancer, calls } = run({ isPending: () => true });
+    const cb = enhancer({ cancel } as any);
+    expect(cancel).toHaveBeenCalled();
+    expect(cb).toBeUndefined();
+    expect(calls).not.toContain('begin');
+  });
+  it('on success: begin → hold(HOLD_MS) → update → finish, in order', async () => {
+    const { enhancer, calls, hold } = run();
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    const result = enhancer({ cancel: vi.fn() } as any)!;
+    await result({ result: { type: 'success' }, update } as any);
+    expect(hold).toHaveBeenCalledWith(HOLD_MS.verifying);
+    expect(calls).toEqual(['begin', 'hold', 'update', 'finish']);
+  });
+  it('reduced motion skips the hold', async () => {
+    const { enhancer, calls } = run({ reduced: true });
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'success' }, update } as any);
+    expect(calls).toEqual(['begin', 'update', 'finish']);
+  });
+  it('failure result skips the hold but still updates + finishes', async () => {
+    const { enhancer, calls } = run();
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'failure' }, update } as any);
+    expect(calls).toEqual(['begin', 'update', 'finish']);
+  });
+  it('runs prepare(input) before begin, in the before-submit phase', () => {
+    const calls: string[] = [];
+    const enhancer = makeOutcomeEnhancer({
+      kind: 'verifying', reduced: false, isPending: () => false,
+      prepare: (input: any) => calls.push('prepare:' + input.formData.get('payout')),
+      begin: () => calls.push('begin'), finish: () => {}, hold: () => Promise.resolve()
+    });
+    enhancer({ cancel: vi.fn(), formData: new Map([['payout', '5']]) } as any);
+    expect(calls).toEqual(['prepare:5', 'begin']);
+  });
+});
+```
+
+- [ ] **Step 3: Run** `npx vitest run src/lib/review-motion.test.ts` → FAIL (module missing).
+
+- [ ] **Step 4: Implement** `src/lib/review-motion.ts`:
+
+```ts
+import type { SubmitFunction } from '@sveltejs/kit';
+
+export type OutcomeKind = 'verifying' | 'rejecting' | 'revising';
+
+/** Sequence durations (ms): the full moment reads ~700ms; dismissals are quicker (CLAUDE.md §2.3). */
+export const HOLD_MS: Record<OutcomeKind, number> = { verifying: 700, rejecting: 260, revising: 260 };
+
+/**
+ * Build a `use:enhance` SubmitFunction that plays the review-outcome moment, then refetches.
+ * Two phases: (before-submit) cancel if already pending, else begin() — mounts the seal/glow now,
+ * overlapping the server round-trip; (result) hold for the sequence on SUCCESS (skipped under
+ * reduced motion or on a fail() result), then update() to refetch, then finish().
+ */
+export function makeOutcomeEnhancer(opts: {
+  kind: OutcomeKind;
+  reduced: boolean;
+  isPending: () => boolean;
+  begin: () => void;
+  finish: () => void;
+  /** Before-submit hook with the SubmitFunction input (e.g. read formData to capture the payout). */
+  prepare?: (input: Parameters<SubmitFunction>[0]) => void;
+  hold?: (ms: number) => Promise<void>;
+}): SubmitFunction {
+  const hold = opts.hold ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  return (input) => {
+    if (opts.isPending()) {
+      input.cancel();
+      return;
+    }
+    opts.prepare?.(input);
+    opts.begin();
+    return async ({ result, update }) => {
+      if (result.type === 'success' && !opts.reduced) await hold(HOLD_MS[opts.kind]);
+      await update();
+      opts.finish();
+    };
+  };
+}
+```
+
+- [ ] **Step 5: Run** `npx vitest run src/lib/review-motion.test.ts` → PASS; `npm run check` → 0 errors.
+- [ ] **Step 6: Commit** `git add src/app.css src/lib/review-motion.ts src/lib/review-motion.test.ts && git commit -m "feat(motion): payout-glow + reject-settle keyframes + makeOutcomeEnhancer orchestration"`
+
+---
+
+## Task 5: Wire the console review queue
+
+**Files:** Modify `src/routes/console/+page.svelte`.
+
+Convert the per-row `verify` / `request_revision` / `reject` forms to `use:enhance` driving the
+moment. Keep the create form a plain POST (out of scope). The full verify moment shows the seal +
+`CountUp` (to the entered payout) + `payout-glow`; revision/reject show the settle + dim.
+
+- [ ] **Step 1: Replace the `<script>` and the review-queue `{#each}`** in `src/routes/console/+page.svelte`. New script block:
+
+```svelte
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { get } from 'svelte/store';
+  import StatusBadge from '$lib/components/StatusBadge.svelte';
+  import Money from '$lib/components/Money.svelte';
+  import Markdown from '$lib/components/Markdown.svelte';
+  import VerifySeal from '$lib/components/VerifySeal.svelte';
+  import CountUp from '$lib/components/CountUp.svelte';
+  import { makeOutcomeEnhancer, type OutcomeKind } from '$lib/review-motion';
+  import { prefersReducedMotion } from '$lib/motion';
+
+  let { data, form } = $props();
+  const reduced = get(prefersReducedMotion);
+
+  // per-row moment state, keyed by answer id
+  let outcome = $state<Record<string, OutcomeKind | undefined>>({});
+  let verifiedCents = $state<Record<string, number>>({});
+  const pending = (id: string) => outcome[id] != null;
+
+  function enhancer(id: string, kind: OutcomeKind) {
+    return makeOutcomeEnhancer({
+      kind, reduced,
+      isPending: () => pending(id),
+      // for verify: capture the typed payout (dollars→cents) from the submit's formData so CountUp
+      // counts to exactly what was sent (runs in the before-submit phase, before begin hides the form)
+      prepare: kind === 'verifying'
+        ? (input) => {
+            const dollars = Number(input.formData.get('payout'));
+            if (Number.isFinite(dollars)) verifiedCents = { ...verifiedCents, [id]: Math.round(dollars * 100) };
+          }
+        : undefined,
+      begin: () => { outcome = { ...outcome, [id]: kind }; },
+      finish: () => { const o = { ...outcome }; delete o[id]; outcome = o; }
+    });
+  }
+</script>
+```
+
+- [ ] **Step 2: Replace the review-queue row markup** (the `{#each data.queue as a (a.id)}` block) with the version below — the row dims/settles via classes, the verify form swaps to the seal+CountUp while `outcome[a.id] === 'verifying'`:
+
+```svelte
+  <div class="mb-8 flex flex-col gap-3">
+    {#each data.queue as a (a.id)}
+      <div class="rounded-2xl border p-5"
+           class:reject-settle={outcome[a.id] === 'rejecting' || outcome[a.id] === 'revising'}
+           class:row-dim={outcome[a.id] === 'rejecting'}
+           class:payout-glow={outcome[a.id] === 'verifying'}
+           style="border-color:var(--line); background:var(--surface)">
+        <div class="mb-1 flex items-center justify-between gap-2">
+          <div>
+            <a href="/ideas/{a.idea_id}" class="font-bold" style="color:var(--ink)">{a.title}</a>
+            <span class="ml-2 text-xs" style="color:var(--faint)">on “{a.ideas?.title}” · by {a.submitter?.display_name ?? a.submitter?.handle}</span>
+          </div>
+          {#if outcome[a.id] === 'verifying'}
+            <span class="flex items-center gap-2 text-sm font-medium" style="color:var(--green-deep)">
+              <VerifySeal play tone="verified" /> Verified · <CountUp cents={verifiedCents[a.id] ?? 0} />
+            </span>
+          {:else}
+            <StatusBadge status={a.status} />
+          {/if}
+        </div>
+        <Markdown html={a.explanation_html} class="mb-2" />
+        {#if a.answer_artifacts?.length}
+          <ul class="mb-3 flex flex-col gap-1 text-sm">
+            {#each a.answer_artifacts as art (art.id)}
+              <li><a href={art.url} target="_blank" rel="noopener" style="color:var(--green-deep)">{art.label ?? art.kind} ↗</a></li>
+            {/each}
+          </ul>
+        {/if}
+
+        {#if !pending(a.id)}
+          <form method="POST" action="?/verify" class="flex flex-wrap items-end gap-2 border-t pt-3"
+                style="border-color:var(--line)" use:enhance={enhancer(a.id, 'verifying')}>
+            <input type="hidden" name="answer_id" value={a.id} />
+            <label class="text-xs" style="color:var(--faint)">Intended payout ($)
+              <input name="payout" type="number" min="0.01" step="0.01" placeholder="0.00" required
+                     class="block w-28 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
+            </label>
+            {#if a.ideas?.type === 'hypothesis'}
+              <label class="text-xs" style="color:var(--faint)">Resolution
+                <select name="resolution" class="block rounded-xl border px-2 py-1" style="border-color:var(--line)">
+                  <option value="yes">Yes</option><option value="no">No</option><option value="ambiguous">Ambiguous</option>
+                </select>
+              </label>
+            {/if}
+            <input name="note" placeholder="Note (optional)" class="flex-1 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
+            <button class="rounded-xl px-3 py-1 text-sm font-medium" style="background:var(--ink); color:#fff">Verify</button>
+          </form>
+
+          <div class="mt-2 flex gap-4">
+            <form method="POST" action="?/request_revision" class="flex flex-1 gap-2" use:enhance={enhancer(a.id, 'revising')}>
+              <input type="hidden" name="answer_id" value={a.id} />
+              <input name="note" placeholder="What to revise" class="flex-1 rounded-xl border px-2 py-1 text-sm" style="border-color:var(--line)" />
+              <button class="text-sm" style="color:var(--warn)">Request revision</button>
+            </form>
+            <form method="POST" action="?/reject" use:enhance={enhancer(a.id, 'rejecting')}>
+              <input type="hidden" name="answer_id" value={a.id} />
+              <button class="text-sm" style="color:var(--neg)">Reject</button>
+            </form>
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+```
+
+> The `{#if !pending(a.id)}` hides the controls while the moment plays (prevents re-submit; the
+> seal/CountUp occupy the header). After `update()` the refetch drops the row from `data.queue`
+> entirely (status moved off `submitted`/`under_review`), so the moment is the row's send-off.
+
+- [ ] **Step 3: Verify** `npm run check` → 0 errors. `npm run build` → succeeds. `npx vitest run` → all green (no test broke).
+- [ ] **Step 4: Manual smoke** (`npm run dev` on a free port): not headless-feasible to sign in as an expert; instead confirm the page compiles and renders (curl the console route returns 200/redirect) and rely on the unit tests for behavior. Note the observation.
+- [ ] **Step 5: Commit** `git add src/routes/console/+page.svelte && git commit -m "feat(console): verify→payout moment + reject/revision settle via use:enhance"`
+
+---
+
+## Task 6: Wire the admin/payouts gate (lighter seal)
+
+**Files:** Modify `src/routes/admin/payouts/+page.svelte`.
+
+Approve = lighter moment (seal pop + glow, **no re-count** — the amount is unchanged; keep the
+static `Money`). Reject = settle + dim.
+
+- [ ] **Step 1: Replace the `<script>`**:
+
+```svelte
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { get } from 'svelte/store';
+  import Money from '$lib/components/Money.svelte';
+  import VerifySeal from '$lib/components/VerifySeal.svelte';
+  import { makeOutcomeEnhancer, type OutcomeKind } from '$lib/review-motion';
+  import { prefersReducedMotion } from '$lib/motion';
+
+  let { data, form } = $props();
+  const reduced = get(prefersReducedMotion);
+  let outcome = $state<Record<string, OutcomeKind | undefined>>({});
+  const pending = (id: string) => outcome[id] != null;
+  function enhancer(id: string, kind: OutcomeKind) {
+    return makeOutcomeEnhancer({
+      kind, reduced,
+      isPending: () => pending(id),
+      begin: () => { outcome = { ...outcome, [id]: kind }; },
+      finish: () => { const o = { ...outcome }; delete o[id]; outcome = o; }
+    });
+  }
+</script>
+```
+
+- [ ] **Step 2: Replace the `<tbody>` rows** so the action cell swaps to the seal while approving, and the row settles/dims on reject:
+
+```svelte
+      {#each data.pending as a (a.id)}
+        <tr style="border-top:1px solid var(--line)"
+            class:reject-settle={outcome[a.id] === 'rejecting'}
+            class:row-dim={outcome[a.id] === 'rejecting'}
+            class:payout-glow={outcome[a.id] === 'verifying'}>
+          <td class="py-2" style="color:var(--ink)"><a href="/ideas/{a.idea_id}" style="color:var(--green-deep)">{a.title}</a></td>
+          <td style="color:var(--muted)">{a.ideas?.title}</td>
+          <td style="color:var(--muted)">{a.submitter?.display_name ?? a.submitter?.handle}</td>
+          <td class="text-right" style="color:var(--ink)"><Money cents={a.payout_amount_cents} currency={a.payout_currency} /></td>
+          <td class="py-2 text-right">
+            {#if outcome[a.id] === 'verifying'}
+              <span class="inline-flex items-center gap-1 text-sm font-medium" style="color:var(--green-deep)">
+                <VerifySeal play tone="verified" size={20} /> Approved
+              </span>
+            {:else if !pending(a.id)}
+              <form method="POST" action="?/approve" class="inline" use:enhance={enhancer(a.id, 'verifying')}>
+                <input type="hidden" name="answer_id" value={a.id} />
+                <button class="mr-3" style="color:var(--green-deep)">Approve</button>
+              </form>
+              <form method="POST" action="?/reject" class="inline" use:enhance={enhancer(a.id, 'rejecting')}>
+                <input type="hidden" name="answer_id" value={a.id} />
+                <button style="color:var(--neg)">Reject</button>
+              </form>
+            {/if}
+          </td>
+        </tr>
+      {/each}
+```
+
+(`verifying` is reused as the approve kind — same `HOLD_MS.verifying` pacing for the lighter seal; no CountUp here.)
+
+- [ ] **Step 3: Verify** `npm run check` → 0 errors; `npm run build` → succeeds; `npx vitest run` → all green.
+- [ ] **Step 4: Commit** `git add src/routes/admin/payouts/+page.svelte && git commit -m "feat(payouts): lighter approve seal + reject settle via use:enhance"`
+
+---
+
+## Task 7: Final verification
+
+- [ ] `npx vitest run` (whole repo) green; `npm run check` 0 errors; `npm run build` succeeds; `supabase test db` unchanged-green (no SQL touched).
+- [ ] Manual (`npm run dev`): with OS reduced-motion OFF, a verify plays seal+count-up+glow and the row leaves; with reduced-motion ON, states jump (no motion), row still leaves. (If signing in as an expert/admin locally is impractical, note it and rely on the unit suites covering the moment's logic.)
+- [ ] Dispatch the final holistic review; then finish the branch (PR).
+
+## Done-when
+- `formatCents`, `prefersReducedMotion`, `CountUp`, `VerifySeal`, `makeOutcomeEnhancer` all unit-tested and green; `Money` refactored with no behavior change.
+- Console verify shows the full moment (seal → green pop → payout count-up → glow); admin approve shows the lighter seal; reject/revision settle+dim; all jump to final under reduced motion.
+- Forms are `use:enhance` (progressive-enhancement fallback still submits); `fail()` skips the success animation.
+- No RPC/DB/cloud changes; `npm run check`/`vitest`/`build`/`supabase test db` all green.

--- a/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
+++ b/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
@@ -1,0 +1,122 @@
+# Verify→Payout Signature Animation (design)
+
+**Date:** 2026-06-07 · **Status:** approved by owner (this session)
+**Implements:** CLAUDE.md §5 ("★ Verify & payout moment") + §2 motion principles. The product-defining
+brand moment — the one place the green accent goes "loud," restrained and earned, never confetti.
+
+## 1. Goal
+
+When an author verifies an answer (and when an admin approves the charitable gate), play a quiet,
+deliberate affirmation: a seal draws its check and fills `--green` with a small pop, then the
+recorded payout amount counts up with a single green glow on the recipient row. Rejection and
+revision get restrained negative motion (a soft horizontal settle + dim). Everything honors
+`prefers-reduced-motion` by jumping to final state.
+
+**Money is OFF in Phase 1.** The amount is the recorded `answers.payout_amount_cents` (an *intended*
+payout, not a transfer). The label stays "Intended payout" — the animation never implies money moved.
+
+## 2. Owner decisions (this session)
+
+1. **Console `verify` = full moment** (seal + count-up + glow, where the amount is entered);
+   **admin/payouts `approve` = lighter** (same seal pop + glow, **no re-count** — the amount is
+   unchanged at the gate). One component set, two intensities.
+2. **Reject + request_revision animate too** (soft settle + dim / amber settle) — the full
+   review-outcome vocabulary in one pass.
+3. ~700ms full-moment timing; dismissals quicker than entrances.
+
+## 3. Architecture
+
+Small composable primitives + `use:enhance` orchestration (not one monolith — the seal and
+count-up are independently testable and reusable for future metrics per CLAUDE.md §5). Purely
+presentational + the enhance conversion: **no RPC/DB changes**.
+
+### 3.1 `src/lib/components/VerifySeal.svelte`
+SVG seal. A circle fills `--green` with `scale(1 → 1.12 → 1)` (the `smooth` spring from
+`$lib/motion`) while a checkmark draws via `stroke-dashoffset` (offset → 0). Props:
+- `play: boolean` — false renders the final drawn state statically (also the reduced-motion path).
+- `tone: 'verified' | 'rejected'` — `verified` = green fill + check; `rejected` = `--neg` ring + a
+  muted ✕, no green, no pop (a quiet mark).
+- `size?: number` (default 28).
+Reduced-motion (a `prefersReducedMotion` store, §3.5) → no spring/draw; render done-state instantly.
+
+### 3.2 `src/lib/components/CountUp.svelte`
+Animated numeric via `svelte/motion` `tweened` over `dur.slow` (360ms), ease-out
+(`cubicOut`). Props `cents: number`, `currency = 'USD'`. Formats each frame with the **same**
+`Intl.NumberFormat(... style:'currency')` call as `Money.svelte`; `font-variant-numeric:
+tabular-nums` so width never reflows mid-count. Counts `0 → cents`. Reduced-motion → set to `cents`
+immediately (no tween). `Money.svelte` is unchanged (static sibling; CountUp is the animated one).
+
+### 3.3 Keyframes (append to `src/app.css`, inside/covered by the existing reduced-motion block)
+- `@keyframes payout-glow` — `box-shadow` from `0 0 0 0 transparent` → `0 0 0 4px rgba(68,255,152,.30)`
+  → back to transparent, one shot (`--dur-slow`). Applied via a `.payout-glow` class toggled on the row.
+- `@keyframes reject-settle` — `translateX(0 → -5px → 3px → 0)`, one shot (`--dur-base`). `.reject-settle` class.
+- Both are transform/opacity/box-shadow only; the existing `@media (prefers-reduced-motion: reduce)`
+  global rule (app.css:36) already forces `animation-duration:.01ms`, so they self-neutralize.
+
+### 3.4 Orchestration — `use:enhance` on the outcome forms
+Convert these plain `method="POST"` forms to `use:enhance` so the row stays mounted to animate,
+then refetch:
+- `src/routes/console/+page.svelte`: `verify`, `reject`, `request_revision` forms.
+- `src/routes/admin/payouts/+page.svelte`: `approve`, `reject` forms.
+
+Per-row state via a rune keyed by answer id: `outcome: 'verifying' | 'rejecting' | 'revising' | null`
+and a `pending` guard (same idiom as `VoteControl`). The enhance handler has two phases:
+
+**Before-submit phase** (runs as the POST is dispatched, so the animation and the server round-trip
+overlap):
+1. On re-entry while `pending` → `cancel()` (no double-fire).
+2. Set `pending = true` and the matching `outcome` — this mounts `VerifySeal` (+ `CountUp` for verify)
+   and toggles the row class (`payout-glow` / `reject-settle`); the moment begins playing now.
+
+**Result callback** (after the server responds):
+3. **Hold first, refetch after** (the ordering that keeps the row mounted through the moment): `await`
+   the remaining sequence time so the total reads ~700ms verify / ~260ms reject from step 2 (a
+   promise-timeout the handler owns; **skipped entirely under reduced motion**).
+4. *Then* `await update()` — runs `invalidateAll()`; the refetched data removes the row from the
+   queue (status is no longer `submitted`/`under_review`) / dims it. Clear `pending`.
+
+(If the action returned `fail()` — e.g. rate-limited or an RPC error — skip the hold, surface the
+message, clear `pending`, and `update()`; no success animation plays.)
+
+**Full verify timeline (~700ms):** seal draw + pop `0–360ms` → at ~60% (`~220ms`) the
+"Intended payout" line swaps to `<CountUp>` (counts to the entered amount, `360ms`) + one
+`payout-glow` pulse → settle. **Admin approve:** seal pop + glow only (`~400ms`), amount shown
+statically via `Money` (unchanged at the gate). **Reject:** `reject-settle` + row opacity to
+`--muted` over `dur.base`; **request_revision:** same settle in `--warn`. Dismissals are quicker
+than the entrance (CLAUDE.md §2.3).
+
+### 3.5 Reduced motion
+`src/lib/motion.ts` gains a `prefersReducedMotion` readable store (matchMedia
+`(prefers-reduced-motion: reduce)`, SSR-safe default `false`, updates on change). `VerifySeal`,
+`CountUp`, and the orchestration read it to jump to final state (no spring/tween/hold). The CSS
+keyframes are already neutralized globally. Final states (seal drawn, amount shown, row dimmed) are
+always reached.
+
+## 4. Surfaces & data
+- Recipient row = the queue card in `console` (verify/reject/revision) and the pending card in
+  `admin/payouts` (approve/reject).
+- The amount = the value the author types into the existing `payout` input (verify) → already passed
+  to `verify_answer` as `p_payout_amount_cents`. The animation reads the same submitted value for
+  the count-up (from the form data) so it counts to exactly what was recorded; on the post-update
+  refetch the static `Money` shows the persisted value.
+- No new server fields; the actions and RPCs are untouched.
+
+## 5. Testing
+- **Vitest** `CountUp.test.ts`: tweens from 0 toward target (intermediate < target mid-flight,
+  equals target at rest); reduced-motion (store mocked true) renders the final formatted value
+  immediately; formatting matches `Money` (`$X.XX`).
+- **Vitest** `VerifySeal.test.ts`: `play=false` (and reduced-motion) renders the done-state markup
+  (full check, no pending dashoffset); `tone='rejected'` renders the ✕/`--neg`, never `--green`.
+- **Vitest** wiring (`console` and/or `payouts`): the enhance callback sets the right `outcome`,
+  guards re-entry while `pending`, and calls `update()`; reduced-motion path skips the hold.
+- **Manual / Playwright (optional):** verify in the console → seal + count-up + glow; toggle OS
+  reduced-motion → states jump, no motion. (Money-off: the label reads "Intended payout".)
+
+## 6. Risks / accepted
+- Converting forms to `use:enhance` changes them from full-reload to client-updated — strictly
+  better UX; the no-JS fallback still submits (progressive enhancement) and just won't animate.
+- The ~700ms hold briefly delays the row leaving the queue — intentional (the moment must read);
+  bounded and skipped under reduced motion.
+- `tweened`/`matchMedia` are client-only; components must guard SSR (store defaults false, tween
+  set in `onMount`/effect) so SSR renders the final static state.
+- No sound, no particles, no confetti, no sorting/RPC/DB changes (YAGNI + CLAUDE.md "Don't").

--- a/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
+++ b/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
@@ -36,7 +36,7 @@ SVG seal. A circle fills `--green` with `scale(1 → 1.12 → 1)` (the `smooth` 
 - `play: boolean` — false renders the final drawn state statically (also the reduced-motion path).
 - `tone: 'verified' | 'rejected'` — `verified` = green fill + check; `rejected` = `--neg` ring + a
   muted ✕, no green, no pop (a quiet mark).
-- `size?: number` (default 28).
+- `size?: number` (default 20 — fits the console header + admin table inline without bumping row height).
 Reduced-motion (a `prefersReducedMotion` store, §3.5) → no spring/draw; render done-state instantly.
 
 ### 3.2 `src/lib/components/CountUp.svelte`

--- a/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
+++ b/docs/superpowers/specs/2026-06-07-verify-payout-animation-design.md
@@ -41,10 +41,12 @@ Reduced-motion (a `prefersReducedMotion` store, §3.5) → no spring/draw; rende
 
 ### 3.2 `src/lib/components/CountUp.svelte`
 Animated numeric via `svelte/motion` `tweened` over `dur.slow` (360ms), ease-out
-(`cubicOut`). Props `cents: number`, `currency = 'USD'`. Formats each frame with the **same**
-`Intl.NumberFormat(... style:'currency')` call as `Money.svelte`; `font-variant-numeric:
-tabular-nums` so width never reflows mid-count. Counts `0 → cents`. Reduced-motion → set to `cents`
-immediately (no tween). `Money.svelte` is unchanged (static sibling; CountUp is the animated one).
+(`cubicOut`). Props `cents: number`, `currency = 'USD'`, `reduced?` (default = the store value,
+injectable for tests). Formats each frame with `formatCents` (the shared helper). **Width is
+reserved** by an `aria-hidden` sizer rendering the *final* formatted string under the
+absolutely-positioned counting value — `tabular-nums` alone does not reserve space for digits/commas
+not yet present, so the count would otherwise widen and shove the seal left. Counts `0 → cents`;
+reduced → set to `cents` immediately. `Money.svelte` is unchanged (static sibling; CountUp animated).
 
 ### 3.3 Keyframes (append to `src/app.css`, inside/covered by the existing reduced-motion block)
 - `@keyframes payout-glow` — `box-shadow` from `0 0 0 0 transparent` → `0 0 0 4px rgba(68,255,152,.30)`
@@ -62,21 +64,27 @@ then refetch:
 Per-row state via a rune keyed by answer id: `outcome: 'verifying' | 'rejecting' | 'revising' | null`
 and a `pending` guard (same idiom as `VoteControl`). The enhance handler has two phases:
 
-**Before-submit phase** (runs as the POST is dispatched, so the animation and the server round-trip
-overlap):
-1. On re-entry while `pending` → `cancel()` (no double-fire).
-2. Set `pending = true` and the matching `outcome` — this mounts `VerifySeal` (+ `CountUp` for verify)
-   and toggles the row class (`payout-glow` / `reject-settle`); the moment begins playing now.
+**SUCCESS-GATED** (revised after the 6-lens plan review — the original "optimistic" mounting would
+flash a fake "Verified · $X" on a failed/rate-limited verify, wrong for a money moment):
+
+**Before-submit phase** (as the POST dispatches):
+1. On re-entry while in-flight → `cancel()` (no double-fire).
+2. `prepare(input)` captures the typed payout from `input.formData`.
+3. `markPending()` — a **neutral** in-flight marker that hides the row's controls. **No green seal,
+   no count-up** yet (nothing that implies success).
 
 **Result callback** (after the server responds):
-3. **Hold first, refetch after** (the ordering that keeps the row mounted through the moment): `await`
-   the remaining sequence time so the total reads ~700ms verify / ~260ms reject from step 2 (a
-   promise-timeout the handler owns; **skipped entirely under reduced motion**).
-4. *Then* `await update()` — runs `invalidateAll()`; the refetched data removes the row from the
-   queue (status is no longer `submitted`/`under_review`) / dims it. Clear `pending`.
+4. **Only if `result.type === 'success'`:** `showSucceeded()` mounts `VerifySeal` (+ `CountUp` for
+   verify) and toggles `payout-glow` / settle; then hold the full sequence (~700ms verify / ~400ms
+   admin approve / ~260ms reject/revision) so the moment reads — **skipped under reduced motion**.
+5. `await update()` (`invalidateAll()`): verified/rejected rows leave the queue (status off the
+   load filter); a **revision** row stays (`revision_requested` is still in the filter) and re-shows
+   its controls with an updated badge — the amber settle reads as in-place feedback, not removal.
+6. `finish()` clears the in-flight + visual state.
 
-(If the action returned `fail()` — e.g. rate-limited or an RPC error — skip the hold, surface the
-message, clear `pending`, and `update()`; no success animation plays.)
+(On a `fail()` result — rate-limit / RPC error — `showSucceeded()` never runs and there's no hold:
+just `update()` + `finish()`; the error surfaces via the page's `form` prop. **No success visual
+ever appears for a verification the server rejected.**)
 
 **Full verify timeline (~700ms):** seal draw + pop `0–360ms` → at ~60% (`~220ms`) the
 "Intended payout" line swaps to `<CountUp>` (counts to the entered amount, `360ms`) + one
@@ -87,10 +95,18 @@ than the entrance (CLAUDE.md §2.3).
 
 ### 3.5 Reduced motion
 `src/lib/motion.ts` gains a `prefersReducedMotion` readable store (matchMedia
-`(prefers-reduced-motion: reduce)`, SSR-safe default `false`, updates on change). `VerifySeal`,
-`CountUp`, and the orchestration read it to jump to final state (no spring/tween/hold). The CSS
-keyframes are already neutralized globally. Final states (seal drawn, amount shown, row dimmed) are
-always reached.
+`(prefers-reduced-motion: reduce)`, SSR-safe default `false`, updates on change). `VerifySeal` and
+`CountUp` take a `reduced` **prop** that defaults to the store but is **injectable** — so vitest
+drives both branches deterministically (jsdom has no real matchMedia). The orchestration reads the
+store to skip the hold. CSS keyframes are neutralized globally. Final states (seal drawn, amount
+shown, row dimmed) are always reached. *Accepted:* the page reads `reduced` once at init, so a
+mid-session OS toggle won't retro-apply — negligible.
+
+### 3.6 Test infrastructure (new — these don't exist yet)
+Component render tests are the repo's first. `vite.config.ts` must add `test.conditions:['browser']`
+(else `@testing-library/svelte` `render()` hits Svelte's SSR build and throws) and a `setupFiles`
+that stubs `window.matchMedia` (else `svelte/motion` throws at *import* under jsdom). Without both,
+every component test errors before asserting.
 
 ## 4. Surfaces & data
 - Recipient row = the queue card in `console` (verify/reject/revision) and the pending card in
@@ -102,15 +118,19 @@ always reached.
 - No new server fields; the actions and RPCs are untouched.
 
 ## 5. Testing
-- **Vitest** `CountUp.test.ts`: tweens from 0 toward target (intermediate < target mid-flight,
-  equals target at rest); reduced-motion (store mocked true) renders the final formatted value
-  immediately; formatting matches `Money` (`$X.XX`).
-- **Vitest** `VerifySeal.test.ts`: `play=false` (and reduced-motion) renders the done-state markup
-  (full check, no pending dashoffset); `tone='rejected'` renders the ✕/`--neg`, never `--green`.
-- **Vitest** wiring (`console` and/or `payouts`): the enhance callback sets the right `outcome`,
-  guards re-entry while `pending`, and calls `update()`; reduced-motion path skips the hold.
-- **Manual / Playwright (optional):** verify in the console → seal + count-up + glow; toggle OS
-  reduced-motion → states jump, no motion. (Money-off: the label reads "Intended payout".)
+- **Vitest** `CountUp.test.ts`: `reduced:true` → final value immediately; `reduced:false` → the
+  visible value starts at `$0.00` and animates to the target; an `aria-hidden` sizer always shows
+  the final string (width reserve). Formatting via `formatCents`.
+- **Vitest** `VerifySeal.test.ts`: `play=false` (and `reduced:true`) render the done-state (style
+  contains `stroke-dashoffset: 0` — note jsdom's space after the colon); `tone='rejected'` → the
+  ✕/`--neg`, never `--green`.
+- **Vitest** `review-motion.test.ts`: cancel-if-pending (no `markPending`); **success** →
+  `markPending → showSucceeded → hold → update → finish`; **failure** → `markPending → update →
+  finish` (**no `showSucceeded`, no hold** — the money-honesty guarantee); reduced success skips
+  the hold; `prepare` runs before `markPending`.
+- **Vitest** `money.test.ts`: `formatCents` cases.
+- **Manual (optional):** verify → seal+count-up+glow on success only; a rate-limited verify shows
+  the error with no green flash; OS reduced-motion → states jump. (Money-off: "Intended payout".)
 
 ## 6. Risks / accepted
 - Converting forms to `use:enhance` changes them from full-reload to client-updated — strictly

--- a/src/app.css
+++ b/src/app.css
@@ -39,3 +39,19 @@ html { font-family: var(--font-display); color: var(--body); background: var(--c
     transition-duration:.01ms !important; scroll-behavior:auto !important;
   }
 }
+
+/* ── verify→payout signature motion (CLAUDE.md §5) ── */
+.payout-glow { animation: payout-glow var(--dur-slow) var(--ease-out-soft); }
+@keyframes payout-glow {
+  0%   { box-shadow: 0 0 0 0 rgba(68, 255, 152, 0); }
+  40%  { box-shadow: 0 0 0 4px rgba(68, 255, 152, .30); }
+  100% { box-shadow: 0 0 0 0 rgba(68, 255, 152, 0); }
+}
+.reject-settle { animation: reject-settle var(--dur-base) var(--ease-snappy); }
+@keyframes reject-settle {
+  0% { transform: translateX(0); } 35% { transform: translateX(-5px); }
+  70% { transform: translateX(3px); } 100% { transform: translateX(0); }
+}
+.row-dim  { opacity: .5; transition: opacity var(--dur-base) var(--ease-snappy); }
+.row-warn { box-shadow: inset 3px 0 0 0 var(--warn); transition: box-shadow var(--dur-base); }
+.sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }

--- a/src/lib/components/CountUp.svelte
+++ b/src/lib/components/CountUp.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { tweened } from 'svelte/motion';
+  import { cubicOut } from 'svelte/easing';
+  import { get } from 'svelte/store';
+  import { dur, prefersReducedMotion } from '$lib/motion';
+  import { formatCents } from '$lib/money';
+
+  let { cents, currency = 'USD', reduced = get(prefersReducedMotion) }: {
+    cents: number; currency?: string; reduced?: boolean;
+  } = $props();
+
+  // Intentional one-time capture: the tween's start value + duration are fixed at construction;
+  // post-mount changes to `cents` are handled reactively by the $effect below.
+  // svelte-ignore state_referenced_locally
+  const value = tweened(reduced ? cents : 0, {
+    duration: reduced ? 0 : dur.slow * 1000,
+    easing: cubicOut
+  });
+  $effect(() => { value.set(cents); });
+  const display = $derived(formatCents(Math.round($value), currency));
+  const finalStr = $derived(formatCents(cents, currency));
+</script>
+<span style="position:relative; display:inline-block; font-variant-numeric:tabular-nums">
+  <span aria-hidden="true" style="visibility:hidden">{finalStr}</span>
+  <span data-countup-value style="position:absolute; left:0; top:0">{display}</span>
+</span>

--- a/src/lib/components/CountUp.test.ts
+++ b/src/lib/components/CountUp.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte';
+import CountUp from './CountUp.svelte';
+
+describe('CountUp', () => {
+  it('reduced=true renders the final amount immediately (no count)', () => {
+    const { container } = render(CountUp, { props: { cents: 3712, reduced: true } });
+    expect(container.textContent).toContain('$37.12');
+  });
+  it('reduced=false starts below the target and animates up to it', async () => {
+    const { container } = render(CountUp, { props: { cents: 3712, reduced: false } });
+    const value = () => container.querySelector('[data-countup-value]')?.textContent ?? '';
+    expect(value()).toBe('$0.00');
+    await waitFor(() => expect(value()).toBe('$37.12'), { timeout: 1500 });
+  });
+  it('reserves the final width with an aria-hidden sizer to avoid reflow', () => {
+    const { container } = render(CountUp, { props: { cents: 100000, reduced: true } });
+    const sizer = container.querySelector('[aria-hidden="true"]');
+    expect(sizer?.textContent).toBe('$1,000.00');
+  });
+});

--- a/src/lib/components/Money.svelte
+++ b/src/lib/components/Money.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+  import { formatCents } from '$lib/money';
   let { cents, currency = 'USD' }: { cents: number | null | undefined; currency?: string } = $props();
-  const fmt = $derived(
-    cents == null ? '—' : new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100)
-  );
+  const fmt = $derived(formatCents(cents, currency));
 </script>
 <span style="font-variant-numeric: tabular-nums">{fmt}</span>

--- a/src/lib/components/VerifySeal.svelte
+++ b/src/lib/components/VerifySeal.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { get } from 'svelte/store';
+  import { prefersReducedMotion } from '$lib/motion';
+
+  let { play = false, tone = 'verified', size = 20, reduced = get(prefersReducedMotion) }: {
+    play?: boolean; tone?: 'verified' | 'rejected'; size?: number; reduced?: boolean;
+  } = $props();
+
+  const LEN = 20; // approx length of the check polyline for the draw
+  // drawn immediately when static or reduced; otherwise start undrawn then flip next frame to transition
+  // svelte-ignore state_referenced_locally
+  let drawn = $state(!play || reduced);
+  $effect(() => {
+    if (play && !reduced && typeof requestAnimationFrame === 'function') {
+      drawn = false;
+      requestAnimationFrame(() => { drawn = true; });
+    } else {
+      drawn = true;
+    }
+  });
+</script>
+
+<svg width={size} height={size} viewBox="0 0 24 24"
+     class:pop={play && !reduced && tone === 'verified'}
+     aria-hidden="true" style="display:inline-block; vertical-align:middle">
+  {#if tone === 'verified'}
+    <circle cx="12" cy="12" r="11" fill="var(--green)" />
+    <path d="M7 12.5l3.3 3.3L17 9" fill="none" stroke="var(--ink)" stroke-width="2.2"
+          stroke-linecap="round" stroke-linejoin="round"
+          style="stroke-dasharray:{LEN}; stroke-dashoffset:{drawn ? 0 : LEN};
+                 transition:stroke-dashoffset var(--dur-base) var(--ease-snappy)" />
+  {:else}
+    <circle cx="12" cy="12" r="11" fill="none" stroke="var(--neg)" stroke-width="2" />
+    <path d="M8.5 8.5l7 7M15.5 8.5l-7 7" fill="none" stroke="var(--neg)" stroke-width="2.2"
+          stroke-linecap="round" style="stroke-dashoffset:0" />
+  {/if}
+</svg>
+
+<style>
+  .pop { transform-origin: center; animation: seal-pop var(--dur-base) var(--ease-snappy); }
+  @keyframes seal-pop { 0% { transform: scale(1); } 45% { transform: scale(1.12); } 100% { transform: scale(1); } }
+</style>

--- a/src/lib/components/VerifySeal.test.ts
+++ b/src/lib/components/VerifySeal.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import VerifySeal from './VerifySeal.svelte';
+
+describe('VerifySeal', () => {
+  it('renders the check fully drawn in the static (play=false) state', () => {
+    const { container } = render(VerifySeal, { props: { play: false, tone: 'verified' } });
+    expect(container.querySelector('path')?.getAttribute('style')).toContain('stroke-dashoffset: 0');
+    expect(container.querySelector('circle')?.getAttribute('fill')).toBe('var(--green)');
+  });
+  it('reduced=true also renders drawn immediately even with play=true', () => {
+    const { container } = render(VerifySeal, { props: { play: true, reduced: true, tone: 'verified' } });
+    expect(container.querySelector('path')?.getAttribute('style')).toContain('stroke-dashoffset: 0');
+  });
+  it('renders a neg ✕ for tone=rejected, never green', () => {
+    const { container } = render(VerifySeal, { props: { play: false, tone: 'rejected' } });
+    expect(container.querySelector('circle')?.getAttribute('fill')).toBe('none');
+    expect(container.innerHTML).not.toContain('var(--green)');
+    expect(container.innerHTML).toContain('var(--neg)');
+  });
+});

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { formatCents } from './money';
+
+describe('formatCents', () => {
+  it('formats cents as USD currency', () => {
+    expect(formatCents(3712)).toBe('$37.12');
+    expect(formatCents(0)).toBe('$0.00');
+    expect(formatCents(100000)).toBe('$1,000.00');
+  });
+  it('renders an em-dash for null/undefined', () => {
+    expect(formatCents(null)).toBe('—');
+    expect(formatCents(undefined)).toBe('—');
+  });
+  it('honors a currency argument', () => {
+    expect(formatCents(500, 'EUR')).toBe('€5.00');
+  });
+});

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,6 @@
+/** Format integer cents as a localized currency string; null/undefined → em-dash. */
+export function formatCents(cents: number | null | undefined, currency = 'USD'): string {
+  return cents == null
+    ? '—'
+    : new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100);
+}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -4,3 +4,15 @@ export const spring = {
   gentle: { stiffness: 160, damping: 26, mass: 1 }
 } as const;
 export const dur = { instant: .08, fast: .14, base: .22, slow: .36, slower: .52 } as const;
+
+import { readable } from 'svelte/store';
+
+/** True when the user asked for reduced motion. SSR-safe default false; updates on change. */
+export const prefersReducedMotion = readable(false, (set) => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  set(mq.matches);
+  const on = () => set(mq.matches);
+  mq.addEventListener('change', on);
+  return () => mq.removeEventListener('change', on);
+});

--- a/src/lib/review-motion.test.ts
+++ b/src/lib/review-motion.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeOutcomeEnhancer, HOLD_MS } from './review-motion';
+
+function harness(opts: Partial<Parameters<typeof makeOutcomeEnhancer>[0]> = {}) {
+  const calls: string[] = [];
+  const hold = vi.fn(() => { calls.push('hold'); return Promise.resolve(); });
+  const enhancer = makeOutcomeEnhancer({
+    kind: 'verifying', reduced: false,
+    isPending: () => false,
+    markPending: () => calls.push('markPending'),
+    showSucceeded: () => calls.push('showSucceeded'),
+    finish: () => calls.push('finish'),
+    hold,
+    ...opts
+  });
+  return { enhancer, calls, hold };
+}
+
+describe('makeOutcomeEnhancer', () => {
+  it('cancels (no markPending) when already pending', () => {
+    const cancel = vi.fn();
+    const { enhancer, calls } = harness({ isPending: () => true });
+    expect(enhancer({ cancel } as any)).toBeUndefined();
+    expect(cancel).toHaveBeenCalled();
+    expect(calls).toEqual([]);
+  });
+  it('SUCCESS: markPending (before) → showSucceeded → hold → update → finish', async () => {
+    const { enhancer, calls, hold } = harness();
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'success' }, update } as any);
+    expect(hold).toHaveBeenCalledWith(HOLD_MS.verifying);
+    expect(calls).toEqual(['markPending', 'showSucceeded', 'hold', 'update', 'finish']);
+  });
+  it('FAILURE: never shows the success visual, no hold — just update + finish', async () => {
+    const { enhancer, calls, hold } = harness();
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'failure' }, update } as any);
+    expect(hold).not.toHaveBeenCalled();
+    expect(calls).toEqual(['markPending', 'update', 'finish']);
+  });
+  it('reduced motion: success shows the visual but skips the hold', async () => {
+    const { enhancer, calls, hold } = harness({ reduced: true });
+    const update = vi.fn(() => { calls.push('update'); return Promise.resolve(); });
+    await enhancer({ cancel: vi.fn() } as any)!({ result: { type: 'success' }, update } as any);
+    expect(hold).not.toHaveBeenCalled();
+    expect(calls).toEqual(['markPending', 'showSucceeded', 'update', 'finish']);
+  });
+  it('runs prepare(input) before markPending', () => {
+    const calls: string[] = [];
+    const enhancer = makeOutcomeEnhancer({
+      kind: 'verifying', reduced: false, isPending: () => false,
+      prepare: (i: any) => calls.push('prepare:' + i.formData.get('payout')),
+      markPending: () => calls.push('markPending'),
+      showSucceeded: () => {}, finish: () => {}, hold: () => Promise.resolve()
+    });
+    enhancer({ cancel: vi.fn(), formData: new Map([['payout', '5']]) } as any);
+    expect(calls).toEqual(['prepare:5', 'markPending']);
+  });
+});

--- a/src/lib/review-motion.ts
+++ b/src/lib/review-motion.ts
@@ -1,0 +1,50 @@
+import type { SubmitFunction, ActionResult } from '@sveltejs/kit';
+
+export type OutcomeKind = 'verifying' | 'approving' | 'rejecting' | 'revising';
+
+/** Sequence durations (ms): full verify ~700; lighter admin approve ~400; dismissals quicker. */
+export const HOLD_MS: Record<OutcomeKind, number> = {
+  verifying: 700, approving: 400, rejecting: 260, revising: 260
+};
+
+/** The after-submit callback type — always returned (never void) for non-pending submits. */
+type AfterSubmit = (opts: {
+  result: ActionResult;
+  update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
+}) => Promise<void>;
+
+/**
+ * Build a `use:enhance` SubmitFunction that plays the review-outcome moment, then refetches.
+ * SUCCESS-GATED: the before-submit phase only marks the row in-flight (markPending — NO green seal,
+ * so a rejected/failed request never flashes a fake "Verified"). The success visual (showSucceeded)
+ * mounts ONLY when result.type === 'success', then holds the full sequence (skipped under reduced
+ * motion), then update() refetches, then finish(). On fail(): no visual, no hold — update + finish.
+ */
+export function makeOutcomeEnhancer(opts: {
+  kind: OutcomeKind;
+  reduced: boolean;
+  isPending: () => boolean;
+  markPending: () => void;
+  showSucceeded: () => void;
+  finish: () => void;
+  prepare?: (input: Parameters<SubmitFunction>[0]) => void;
+  hold?: (ms: number) => Promise<void>;
+}): (input: Parameters<SubmitFunction>[0]) => AfterSubmit | undefined {
+  const hold = opts.hold ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
+  return (input) => {
+    if (opts.isPending()) {
+      input.cancel();
+      return;
+    }
+    opts.prepare?.(input);
+    opts.markPending();
+    return async ({ result, update }) => {
+      if (result.type === 'success') {
+        opts.showSucceeded();
+        if (!opts.reduced) await hold(HOLD_MS[opts.kind]);
+      }
+      await update();
+      opts.finish();
+    };
+  };
+}

--- a/src/routes/admin/payouts/+page.svelte
+++ b/src/routes/admin/payouts/+page.svelte
@@ -1,6 +1,29 @@
 <script lang="ts">
+  import { enhance } from '$app/forms';
+  import { get } from 'svelte/store';
   import Money from '$lib/components/Money.svelte';
+  import VerifySeal from '$lib/components/VerifySeal.svelte';
+  import { makeOutcomeEnhancer, type OutcomeKind } from '$lib/review-motion';
+  import { prefersReducedMotion } from '$lib/motion';
+
   let { data, form } = $props();
+  const reduced = get(prefersReducedMotion);
+  let inflight = $state<Record<string, boolean>>({});
+  let shown = $state<Record<string, OutcomeKind | undefined>>({});
+  let announce = $state('');
+
+  function enhancer(id: string, kind: OutcomeKind, label: string) {
+    return makeOutcomeEnhancer({
+      kind, reduced,
+      isPending: () => inflight[id] === true,
+      markPending: () => { inflight = { ...inflight, [id]: true }; },
+      showSucceeded: () => { shown = { ...shown, [id]: kind }; announce = label; },
+      finish: () => {
+        const i = { ...inflight }; delete i[id]; inflight = i;
+        const s = { ...shown }; delete s[id]; shown = s;
+      }
+    });
+  }
 </script>
 <h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Charitable-purpose gate</h1>
 <p class="mb-4 text-sm" style="color:var(--muted)">Verified answers awaiting admin approval. Approving records the intended payout (no funds move in Phase 1).</p>
@@ -9,6 +32,7 @@
 {#if data.pending.length === 0}
   <p style="color:var(--muted)">Nothing awaiting approval.</p>
 {:else}
+  <span class="sr-only" aria-live="polite">{announce}</span>
   <table class="w-full text-sm">
     <thead><tr style="color:var(--faint)">
       <th class="text-left">Answer</th><th class="text-left">Idea</th><th class="text-left">Submitter</th>
@@ -16,20 +40,26 @@
     </tr></thead>
     <tbody>
       {#each data.pending as a (a.id)}
-        <tr style="border-top:1px solid var(--line)">
+        <tr style="border-top:1px solid var(--line)" class:row-dim={shown[a.id] === 'rejecting'}>
           <td class="py-2" style="color:var(--ink)"><a href="/ideas/{a.idea_id}" style="color:var(--green-deep)">{a.title}</a></td>
           <td style="color:var(--muted)">{a.ideas?.title}</td>
           <td style="color:var(--muted)">{a.submitter?.display_name ?? a.submitter?.handle}</td>
           <td class="text-right" style="color:var(--ink)"><Money cents={a.payout_amount_cents} currency={a.payout_currency} /></td>
-          <td class="py-2 text-right">
-            <form method="POST" action="?/approve" class="inline">
-              <input type="hidden" name="answer_id" value={a.id} />
-              <button class="mr-3" style="color:var(--green-deep)">Approve</button>
-            </form>
-            <form method="POST" action="?/reject" class="inline">
-              <input type="hidden" name="answer_id" value={a.id} />
-              <button style="color:var(--neg)">Reject</button>
-            </form>
+          <td class="py-2 text-right" class:payout-glow={shown[a.id] === 'approving'}>
+            {#if shown[a.id] === 'approving'}
+              <span class="inline-flex items-center gap-1 text-sm font-medium" style="color:var(--green-deep)">
+                <VerifySeal play tone="verified" {reduced} /> Approved
+              </span>
+            {:else if !inflight[a.id]}
+              <form method="POST" action="?/approve" class="inline" use:enhance={enhancer(a.id, 'approving', 'Payout approved.')}>
+                <input type="hidden" name="answer_id" value={a.id} />
+                <button class="mr-3" style="color:var(--green-deep)">Approve</button>
+              </form>
+              <form method="POST" action="?/reject" class="inline" use:enhance={enhancer(a.id, 'rejecting', 'Payout rejected.')}>
+                <input type="hidden" name="answer_id" value={a.id} />
+                <button style="color:var(--neg)">Reject</button>
+              </form>
+            {/if}
           </td>
         </tr>
       {/each}

--- a/src/routes/console/+page.svelte
+++ b/src/routes/console/+page.svelte
@@ -1,8 +1,39 @@
 <script lang="ts">
+  import { enhance } from '$app/forms';
+  import { get } from 'svelte/store';
   import StatusBadge from '$lib/components/StatusBadge.svelte';
-  import Money from '$lib/components/Money.svelte';
   import Markdown from '$lib/components/Markdown.svelte';
+  import VerifySeal from '$lib/components/VerifySeal.svelte';
+  import CountUp from '$lib/components/CountUp.svelte';
+  import { makeOutcomeEnhancer, type OutcomeKind } from '$lib/review-motion';
+  import { prefersReducedMotion } from '$lib/motion';
+
   let { data, form } = $props();
+  const reduced = get(prefersReducedMotion);
+
+  let inflight = $state<Record<string, boolean>>({});
+  let shown = $state<Record<string, OutcomeKind | undefined>>({});
+  let verifiedCents = $state<Record<string, number>>({});
+  let announce = $state('');
+
+  function enhancer(id: string, kind: OutcomeKind, label: string) {
+    return makeOutcomeEnhancer({
+      kind, reduced,
+      isPending: () => inflight[id] === true,
+      prepare: kind === 'verifying'
+        ? (input) => {
+            const dollars = Number(input.formData.get('payout'));
+            if (Number.isFinite(dollars)) verifiedCents = { ...verifiedCents, [id]: Math.round(dollars * 100) };
+          }
+        : undefined,
+      markPending: () => { inflight = { ...inflight, [id]: true }; },
+      showSucceeded: () => { shown = { ...shown, [id]: kind }; announce = label; },
+      finish: () => {
+        const i = { ...inflight }; delete i[id]; inflight = i;
+        const s = { ...shown }; delete s[id]; shown = s;
+      }
+    });
+  }
 </script>
 <h1 class="mb-4 text-2xl font-bold" style="color:var(--ink)">Expert console</h1>
 {#if form?.message}<p class="mb-3" style="color:var(--neg)">{form.message}</p>{/if}
@@ -24,15 +55,27 @@
 {#if data.queue.length === 0}
   <p class="mb-8" style="color:var(--muted)">No answers awaiting review.</p>
 {:else}
-  <div class="mb-8 flex flex-col gap-3">
+  <div class="mb-8 flex flex-col gap-3" aria-live="polite">
+    <span class="sr-only">{announce}</span>
     {#each data.queue as a (a.id)}
-      <div class="rounded-2xl border p-5" style="border-color:var(--line); background:var(--surface)">
+      <div class="rounded-2xl border p-5"
+           class:payout-glow={shown[a.id] === 'verifying'}
+           class:reject-settle={shown[a.id] === 'rejecting' || shown[a.id] === 'revising'}
+           class:row-dim={shown[a.id] === 'rejecting'}
+           class:row-warn={shown[a.id] === 'revising'}
+           style="border-color:var(--line); background:var(--surface)">
         <div class="mb-1 flex items-center justify-between gap-2">
           <div>
             <a href="/ideas/{a.idea_id}" class="font-bold" style="color:var(--ink)">{a.title}</a>
             <span class="ml-2 text-xs" style="color:var(--faint)">on “{a.ideas?.title}” · by {a.submitter?.display_name ?? a.submitter?.handle}</span>
           </div>
-          <StatusBadge status={a.status} />
+          {#if shown[a.id] === 'verifying'}
+            <span class="flex items-center gap-1.5 text-sm font-medium whitespace-nowrap" style="color:var(--green-deep)">
+              <VerifySeal play tone="verified" {reduced} /> Verified · <CountUp cents={verifiedCents[a.id] ?? 0} {reduced} />
+            </span>
+          {:else}
+            <StatusBadge status={a.status} />
+          {/if}
         </div>
         <Markdown html={a.explanation_html} class="mb-2" />
         {#if a.answer_artifacts?.length}
@@ -43,34 +86,38 @@
           </ul>
         {/if}
 
-        <form method="POST" action="?/verify" class="flex flex-wrap items-end gap-2 border-t pt-3" style="border-color:var(--line)">
-          <input type="hidden" name="answer_id" value={a.id} />
-          <label class="text-xs" style="color:var(--faint)">Intended payout ($)
-            <input name="payout" type="number" min="0.01" step="0.01" placeholder="0.00" required
-                   class="block w-28 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
-          </label>
-          {#if a.ideas?.type === 'hypothesis'}
-            <label class="text-xs" style="color:var(--faint)">Resolution
-              <select name="resolution" class="block rounded-xl border px-2 py-1" style="border-color:var(--line)">
-                <option value="yes">Yes</option><option value="no">No</option><option value="ambiguous">Ambiguous</option>
-              </select>
+        {#if !inflight[a.id]}
+          <form method="POST" action="?/verify" class="flex flex-wrap items-end gap-2 border-t pt-3"
+                style="border-color:var(--line)" use:enhance={enhancer(a.id, 'verifying', 'Answer verified.')}>
+            <input type="hidden" name="answer_id" value={a.id} />
+            <label class="text-xs" style="color:var(--faint)">Intended payout ($)
+              <input name="payout" type="number" min="0.01" step="0.01" placeholder="0.00" required
+                     class="block w-28 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
             </label>
-          {/if}
-          <input name="note" placeholder="Note (optional)" class="flex-1 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
-          <button class="rounded-xl px-3 py-1 text-sm font-medium" style="background:var(--ink); color:#fff">Verify</button>
-        </form>
+            {#if a.ideas?.type === 'hypothesis'}
+              <label class="text-xs" style="color:var(--faint)">Resolution
+                <select name="resolution" class="block rounded-xl border px-2 py-1" style="border-color:var(--line)">
+                  <option value="yes">Yes</option><option value="no">No</option><option value="ambiguous">Ambiguous</option>
+                </select>
+              </label>
+            {/if}
+            <input name="note" placeholder="Note (optional)" class="flex-1 rounded-xl border px-2 py-1" style="border-color:var(--line)" />
+            <button class="rounded-xl px-3 py-1 text-sm font-medium" style="background:var(--ink); color:#fff">Verify</button>
+          </form>
 
-        <div class="mt-2 flex gap-4">
-          <form method="POST" action="?/request_revision" class="flex flex-1 gap-2">
-            <input type="hidden" name="answer_id" value={a.id} />
-            <input name="note" placeholder="What to revise" class="flex-1 rounded-xl border px-2 py-1 text-sm" style="border-color:var(--line)" />
-            <button class="text-sm" style="color:var(--warn)">Request revision</button>
-          </form>
-          <form method="POST" action="?/reject">
-            <input type="hidden" name="answer_id" value={a.id} />
-            <button class="text-sm" style="color:var(--neg)">Reject</button>
-          </form>
-        </div>
+          <div class="mt-2 flex gap-4">
+            <form method="POST" action="?/request_revision" class="flex flex-1 gap-2"
+                  use:enhance={enhancer(a.id, 'revising', 'Revision requested.')}>
+              <input type="hidden" name="answer_id" value={a.id} />
+              <input name="note" placeholder="What to revise" class="flex-1 rounded-xl border px-2 py-1 text-sm" style="border-color:var(--line)" />
+              <button class="text-sm" style="color:var(--warn)">Request revision</button>
+            </form>
+            <form method="POST" action="?/reject" use:enhance={enhancer(a.id, 'rejecting', 'Answer rejected.')}>
+              <input type="hidden" name="answer_id" value={a.id} />
+              <button class="text-sm" style="color:var(--neg)">Reject</button>
+            </form>
+          </div>
+        {/if}
       </div>
     {/each}
   </div>

--- a/src/routes/console/+page.svelte
+++ b/src/routes/console/+page.svelte
@@ -55,8 +55,8 @@
 {#if data.queue.length === 0}
   <p class="mb-8" style="color:var(--muted)">No answers awaiting review.</p>
 {:else}
-  <div class="mb-8 flex flex-col gap-3" aria-live="polite">
-    <span class="sr-only">{announce}</span>
+  <div class="mb-8 flex flex-col gap-3">
+    <span class="sr-only" aria-live="polite">{announce}</span>
     {#each data.queue as a (a.id)}
       <div class="rounded-2xl border p-5"
            class:payout-glow={shown[a.id] === 'verifying'}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,14 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [tailwindcss(), sveltekit()],
-  resolve: { conditions: ['browser'] },
+  // Resolve Svelte's browser build ONLY under vitest (mode==='test') so @testing-library/svelte
+  // render() works; leaving dev/prod client resolution (module/development|production) untouched.
+  ...(mode === 'test' ? { resolve: { conditions: ['browser'] } } : {}),
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.{test,spec}.{js,ts}', 'scripts/**/*.{test,spec}.{js,ts}']
   }
-});
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
-  test: { environment: 'jsdom', include: ['src/**/*.{test,spec}.{js,ts}', 'scripts/**/*.{test,spec}.{js,ts}'] }
+  resolve: { conditions: ['browser'] },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{js,ts}', 'scripts/**/*.{test,spec}.{js,ts}']
+  }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,9 @@
+// jsdom has no matchMedia; svelte/motion touches it at module load. Stub a no-op (reduced = false).
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  // @ts-expect-error – minimal stub for tests
+  window.matchMedia = (query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener() {}, removeEventListener() {},
+    addListener() {}, removeListener() {}, dispatchEvent() { return false; }
+  });
+}


### PR DESCRIPTION
## Summary
The product-defining brand moment — the one place the green accent goes "loud," restrained and earned.

- **On a successful console verify:** a seal draws its check and fills `--green` with a small pop, then the recorded payout **counts up** with one green glow on the row. **Admin approve** gets a lighter ~400ms seal; **reject** dims to muted; **request_revision** shows an amber settle (and stays in-queue).
- **Success-gated (the money-honesty fix):** the green seal/count-up/glow mount **only when the server confirms** — a rate-limited or failed verify never flashes a fake "Verified · $X". The before-submit phase only marks the row in-flight.
- **Honors `prefers-reduced-motion`** everywhere (jumps to final), driven by an injectable `reduced` prop so both branches are unit-tested.
- Money is OFF — the label stays "Intended payout"; the count-up animates the *recorded* `payout_amount_cents`, never implying a transfer.

## What's inside
- New primitives `VerifySeal` + `CountUp` (width-reserved so the count never reflows), a `prefersReducedMotion` store, `formatCents` (DRY with `Money`), `payout-glow`/`reject-settle`/`row-dim`/`row-warn` keyframes, and a success-gated `makeOutcomeEnhancer` orchestration helper.
- Console + admin/payouts review forms converted from full-reload to `use:enhance` (animate-then-refetch). Admin glow is on the `<td>` (transforms/box-shadow on `<tr>` render unreliably); reject uses opacity.
- **First component render tests** in the repo — `vite.config.ts` gains a test-mode-scoped `resolve.conditions:['browser']` + a `matchMedia` setup stub.
- aria-live region announces each outcome.

Hardened by a 6-lens adversarial plan review (caught the optimistic-flash bug, the missing test config, and the `<tr>` transform pitfall before any code). No RPC/DB/cloud changes.

## Status
- ✅ vitest 89/89 · svelte-check 0/0 · build clean · pgTAP 122/122 unchanged
- Both motion branches (animated + reduced) unit-tested; the fail()→no-success-visual guarantee locked in a test

## Test Plan
- [x] `npx vitest run` · `npm run check` · `npm run build` · `supabase test db`
- [ ] Manual: verify in the console (expert account) → seal+count-up+glow on success; a failed verify shows the error with no green flash; OS reduced-motion → states jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)