### PR TITLE
fix(forms): bind:value so a re-render can't wipe in-progress input

### DIFF
--- a/src/routes/console/+page.svelte
+++ b/src/routes/console/+page.svelte
@@ -16,6 +16,13 @@
   let verifiedCents = $state<Record<string, number>>({});
   let announce = $state('');
 
+  // New-idea form: local state + bind:value so a review-action enhance re-render (or any invalidate)
+  // can't wipe a half-typed idea.
+  let newTitle = $state('');
+  let newType = $state('open_ended');
+  let newClaim = $state('');
+  let newSummary = $state('');
+
   function enhancer(id: string, kind: OutcomeKind, label: string) {
     return makeOutcomeEnhancer({
       kind, reduced,
@@ -41,13 +48,13 @@
 <form method="POST" action="?/create" class="mb-8 flex flex-col gap-2 rounded-2xl border p-5"
       style="border-color:var(--line); background:var(--surface)">
   <h2 class="font-bold" style="color:var(--ink)">Post a new idea</h2>
-  <input name="title" placeholder="Title" required class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-  <select name="type" class="rounded-xl border px-3 py-2" style="border-color:var(--line)">
+  <input name="title" placeholder="Title" required bind:value={newTitle} class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
+  <select name="type" bind:value={newType} class="rounded-xl border px-3 py-2" style="border-color:var(--line)">
     <option value="open_ended">Open-ended</option>
     <option value="hypothesis">Hypothesis (yes/no)</option>
   </select>
-  <input name="claim" placeholder="Hypothesis claim (if hypothesis)" class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-  <textarea name="summary_md" placeholder="Summary (markdown)" class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
+  <input name="claim" placeholder="Hypothesis claim (if hypothesis)" bind:value={newClaim} class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
+  <textarea name="summary_md" placeholder="Summary (markdown)" bind:value={newSummary} class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
   <button class="self-start rounded-xl px-4 py-2 font-medium" style="background:var(--ink); color:#fff">Publish</button>
 </form>
 

--- a/src/routes/ideas/[id]/answer/+page.svelte
+++ b/src/routes/ideas/[id]/answer/+page.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
   let { data, form }: { data: any; form: any } = $props();
+  // Local state + bind:value so a background re-render (e.g. the layout's onAuthStateChange
+  // invalidate, or a validation-error reload) never clobbers in-progress input. Seeded from `form`
+  // so a failed submit still repopulates.
+  // svelte-ignore state_referenced_locally
+  let title = $state(form?.title ?? '');
+  // svelte-ignore state_referenced_locally
+  let explanation_md = $state(form?.explanation_md ?? '');
+  let artifacts = $state('');
 </script>
 <h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Submit an answer</h1>
 <p class="mb-6 text-sm" style="color:var(--muted)">for <a href="/ideas/{data.idea.id}" style="color:var(--green-deep)">{data.idea.title}</a></p>
 <form method="POST" class="flex flex-col gap-3 rounded-2xl border p-5" style="border-color:var(--line); background:var(--surface)">
-  <input name="title" placeholder="Answer title" required value={form?.title ?? ''}
+  <input name="title" placeholder="Answer title" required bind:value={title}
          class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-  <textarea name="explanation_md" placeholder="Explain your answer (markdown)" rows="6"
-            class="rounded-xl border px-3 py-2" style="border-color:var(--line)">{form?.explanation_md ?? ''}</textarea>
-  <textarea name="artifacts" placeholder="Artifact links — one per line (GitHub, PDF, Colab, URL)" rows="3"
+  <textarea name="explanation_md" placeholder="Explain your answer (markdown)" rows="6" bind:value={explanation_md}
+            class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
+  <textarea name="artifacts" placeholder="Artifact links — one per line (GitHub, PDF, Colab, URL)" rows="3" bind:value={artifacts}
             class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
   <button class="self-start rounded-xl px-4 py-2 font-medium" style="background:var(--ink); color:#fff">Submit</button>
   {#if form?.message}<span style="color:var(--neg)">{form.message}</span>{/if}

--- a/src/routes/ideas/[id]/answer/page.test.ts
+++ b/src/routes/ideas/[id]/answer/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+const data = { idea: { id: 'i1', title: 'Idea' } };
+
+describe('answer form input binding', () => {
+  it('retains typed input across a re-render (the form prop changing must not clobber it)', async () => {
+    const { container, rerender } = render(Page, { props: { data, form: null } });
+    const title = () => container.querySelector('input[name=title]') as HTMLInputElement;
+    await fireEvent.input(title(), { target: { value: 'My answer' } });
+    expect(title().value).toBe('My answer');
+    // simulate an auth invalidate / validation-error reload handing in a new `form` prop:
+    await rerender({ data, form: { message: 'Some error' } });
+    // bind:value preserves the user's in-progress text (one-way value= would risk resetting it)
+    expect(title().value).toBe('My answer');
+  });
+});

--- a/src/routes/u/[handle]/+page.svelte
+++ b/src/routes/u/[handle]/+page.svelte
@@ -2,6 +2,14 @@
   import Markdown from '$lib/components/Markdown.svelte';
   let { data, form } = $props();
   let isSelf = $derived(data.user?.id === data.profile.id);
+  // Local state + bind:value so a background re-render mid-edit can't reset the fields (seeded from
+  // the persisted profile).
+  // svelte-ignore state_referenced_locally
+  let displayName = $state(data.profile.display_name ?? '');
+  // svelte-ignore state_referenced_locally
+  let careerStage = $state(data.profile.career_stage ?? '');
+  // svelte-ignore state_referenced_locally
+  let bioMd = $state(data.profile.bio_md ?? '');
 </script>
 <article class="rounded-2xl border p-6" style="border-color:var(--line);background:var(--surface);box-shadow:var(--shadow-1)">
   <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.profile.display_name ?? data.profile.handle}</h1>
@@ -10,12 +18,12 @@
 
   {#if isSelf}
     <form method="POST" action="?/update" class="mt-6 flex flex-col gap-2">
-      <input name="display_name" value={data.profile.display_name ?? ''} placeholder="Display name"
+      <input name="display_name" bind:value={displayName} placeholder="Display name"
              class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-      <input name="career_stage" value={data.profile.career_stage ?? ''} placeholder="Career stage"
+      <input name="career_stage" bind:value={careerStage} placeholder="Career stage"
              class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-      <textarea name="bio_md" placeholder="Bio (markdown)"
-             class="rounded-xl border px-3 py-2" style="border-color:var(--line)">{data.profile.bio_md ?? ''}</textarea>
+      <textarea name="bio_md" placeholder="Bio (markdown)" bind:value={bioMd}
+             class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
       <button class="self-start rounded-xl px-4 py-2 font-medium" style="background:var(--ink);color:#fff">Save</button>
       {#if form?.saved}<span style="color:var(--green-deep)">Saved.</span>{/if}
       {#if form?.message}<span style="color:var(--neg)">{form.message}</span>{/if}


### PR DESCRIPTION
## Summary
The authed E2E suite surfaced this: the answer / new-idea / profile-edit forms used one-way `value={…}` bindings, so a background re-render — the layout's `onAuthStateChange → invalidate` firing shortly after navigation, or a validation-error reload — could reset a field a user was typing into (losing in-progress input / a leading keystroke).

Fix: local `$state` + `bind:value` on those multi-field forms (seeded from `form`/`profile` so a failed submit still repopulates). `bind:value` preserves user input across re-renders by design.

- `src/routes/ideas/[id]/answer/+page.svelte` — title / explanation / artifacts
- `src/routes/console/+page.svelte` — new-idea title / type / claim / summary (most exposed: an expert typing a new idea while a review-action enhance re-renders the page)
- `src/routes/u/[handle]/+page.svelte` — display name / career stage / bio

Plus a render-test regression guard (`answer/page.test.ts`) asserting typed input survives a `form`-prop re-render.

## Status
- ✅ vitest 90/90 (incl. the new binding test) · svelte-check 0/0 · build clean

## Test Plan
- [x] `npx vitest run` · `npm run check` · `npm run build`
- [ ] Once #53 (E2E) merges, the loop spec's `form.submit()` workaround can revert to real `fill()` typing — the durable validation of this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)