### PR TITLE
fix(markdown): drop jsdom for sanitize-html — fixes prod 500 on /ideas/[id] & /u/[handle]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"dependencies": {
 				"@supabase/ssr": "^0.10.3",
 				"@supabase/supabase-js": "^2.107.0",
-				"isomorphic-dompurify": "^3.16.0",
-				"marked": "^18.0.5"
+				"marked": "^18.0.5",
+				"sanitize-html": "^2.17.4"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
@@ -21,6 +21,7 @@
 				"@tailwindcss/vite": "^4.3.0",
 				"@testing-library/svelte": "^5.3.1",
 				"@types/node": "^25.9.1",
+				"@types/sanitize-html": "^2.16.1",
 				"jsdom": "^29.1.1",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.6.0",
@@ -38,6 +39,7 @@
 			"version": "5.1.11",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
 			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -54,6 +56,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
 			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -70,6 +73,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
 			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -79,6 +83,7 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
@@ -120,6 +125,7 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
 			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.0"
@@ -132,6 +138,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
 			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -151,6 +158,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
 			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -174,6 +182,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
 			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -201,6 +210,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -223,6 +233,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
 			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -247,6 +258,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
 			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -742,6 +754,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
 			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2307,11 +2320,21 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
+		"node_modules/@types/sanitize-html": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+			"integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"htmlparser2": "^10.1"
+			}
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vercel/nft": {
@@ -2581,6 +2604,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
 			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
@@ -2689,6 +2713,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -2702,6 +2727,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
 			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-mimetype": "^5.0.0",
@@ -2710,6 +2736,12 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.21",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+			"integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -2733,13 +2765,13 @@
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2779,13 +2811,71 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/dompurify": {
-			"version": "3.4.8",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-			"integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -2806,6 +2896,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
 			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20.19.0"
@@ -2861,6 +2952,18 @@
 				"@esbuild/win32-arm64": "0.28.0",
 				"@esbuild/win32-ia32": "0.28.0",
 				"@esbuild/win32-x64": "0.28.0"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/esm-env": {
@@ -2974,12 +3077,44 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
 			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -3005,10 +3140,20 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-reference": {
@@ -3019,19 +3164,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
-			}
-		},
-		"node_modules/isomorphic-dompurify": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.16.0.tgz",
-			"integrity": "sha512-KzTJsMuVPqPwBOD0F6jKXoV/+v8CSx0rxVp+/67KV6Xbw++0zD/avT3bZsgwR0M5QRMiOE+QqQtoZLEJYy1C4Q==",
-			"license": "MIT",
-			"dependencies": {
-				"dompurify": "^3.4.8",
-				"jsdom": "^29.1.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jiti": {
@@ -3055,6 +3187,7 @@
 			"version": "29.1.1",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
 			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.1.11",
@@ -3099,6 +3232,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/launder": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+			"integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+			"license": "MIT",
+			"dependencies": {
+				"dayjs": "^1.11.7"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -3385,6 +3527,7 @@
 			"version": "11.5.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
 			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -3426,6 +3569,7 @@
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
@@ -3498,7 +3642,6 @@
 			"version": "3.3.12",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
 			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3601,10 +3744,17 @@
 				"node": ">=12.20.0"
 			}
 		},
+		"node_modules/parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"license": "MIT"
+		},
 		"node_modules/parse5": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
 			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"entities": "^8.0.0"
@@ -3641,7 +3791,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -3708,7 +3857,6 @@
 			"version": "8.5.15",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
 			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3752,6 +3900,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3782,6 +3931,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3844,10 +3994,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/sanitize-html": {
+			"version": "2.17.4",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+			"integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"deepmerge": "^4.2.2",
+				"escape-string-regexp": "^4.0.0",
+				"htmlparser2": "^10.1.0",
+				"is-plain-object": "^5.0.0",
+				"launder": "^1.7.1",
+				"parse-srcset": "^1.0.2",
+				"postcss": "^8.3.11"
+			}
+		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"xmlchars": "^2.2.0"
@@ -3978,6 +4144,7 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
@@ -4066,6 +4233,7 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
 			"integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tldts-core": "^7.4.2"
@@ -4078,6 +4246,7 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
 			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/totalist": {
@@ -4094,6 +4263,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
 			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^7.0.5"
@@ -4106,6 +4276,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
 			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -4157,6 +4328,7 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
 			"integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -4361,6 +4533,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
 			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"xml-name-validator": "^5.0.0"
@@ -4373,6 +4546,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
 			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20"
@@ -4382,6 +4556,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
 			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -4391,6 +4566,7 @@
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
 			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.11.0",
@@ -4422,6 +4598,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
 			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
@@ -4431,6 +4608,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tailwindcss/vite": "^4.3.0",
 		"@testing-library/svelte": "^5.3.1",
 		"@types/node": "^25.9.1",
+		"@types/sanitize-html": "^2.16.1",
 		"jsdom": "^29.1.1",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.6.0",
@@ -37,7 +38,7 @@
 	"dependencies": {
 		"@supabase/ssr": "^0.10.3",
 		"@supabase/supabase-js": "^2.107.0",
-		"isomorphic-dompurify": "^3.16.0",
-		"marked": "^18.0.5"
+		"marked": "^18.0.5",
+		"sanitize-html": "^2.17.4"
 	}
 }

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -1,28 +1,52 @@
 import { marked } from 'marked';
-import DOMPurify from 'isomorphic-dompurify';
+import sanitizeHtml from 'sanitize-html';
 
 marked.setOptions({ gfm: true, breaks: true });
-
-// Defense-in-depth: any link that opens a new tab must not reach window.opener (reverse-tabnabbing).
-// Registered once at module load (DOMPurify is a singleton in isomorphic-dompurify).
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if (node.tagName === 'A' && node.getAttribute('target')) {
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
 
 /**
  * Render user-authored Markdown to SANITIZED HTML, server-side.
  * Lives under $lib/server so the heavy deps never ship to the browser.
- * DOMPurify's default HTML profile strips <script>, on* handlers, and javascript:/data: URLs; on top of that we
- * forbid interactive form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing).
+ *
+ * Sanitizer: `sanitize-html` (pure JS, htmlparser2). We deliberately do NOT use a
+ * DOMPurify/jsdom stack here — jsdom's transitive deps break under Vercel's serverless
+ * bundler (ERR_REQUIRE_ESM from html-encoding-sniffer → @exodus/bytes), which 500'd every
+ * markdown-rendering route in production. `sanitize-html` has no DOM dependency and runs
+ * identically locally and in the function.
+ *
+ * Posture (allowlist): drop <script>/<style> and their text, strip all on* handlers, allow
+ * only http/https/mailto URLs (so javascript:/data: links are neutralized), forbid interactive
+ * form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing). Any link
+ * that opens a new tab gets rel="noopener noreferrer" (reverse-tabnabbing defense).
  */
 export function renderMarkdown(md: string | null | undefined): string {
   if (!md) return '';
   const html = marked.parse(md, { async: false }) as string;
-  return DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true },
-    FORBID_TAGS: ['form', 'input', 'button', 'select', 'option', 'textarea', 'label', 'fieldset', 'style'],
-    FORBID_ATTR: ['style']
+  return sanitizeHtml(html, {
+    allowedTags: [
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'p', 'br', 'hr', 'blockquote',
+      'ul', 'ol', 'li',
+      'strong', 'b', 'em', 'i', 'del', 's', 'code', 'pre', 'sup', 'sub',
+      'a', 'img',
+      'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'
+    ],
+    allowedAttributes: {
+      a: ['href', 'title', 'target', 'rel'],
+      img: ['src', 'alt', 'title'],
+      code: ['class'], // marked emits class="language-xx" for fenced blocks
+      th: ['align'],
+      td: ['align']
+    },
+    // http/https/mailto only — javascript: and data: hrefs are dropped (link text kept)
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowProtocolRelative: false,
+    // style attr is not in any allowlist above, so it is already stripped; being explicit is cheap
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: (tagName, attribs) => {
+        if (attribs.target) attribs.rel = 'noopener noreferrer';
+        return { tagName, attribs };
+      }
+    }
   });
 }


### PR DESCRIPTION
## Summary
`/ideas/[id]` and `/u/[handle]` returned **HTTP 500 in production** while every other route worked. Pulled the Vercel runtime log:

```
[500] GET /ideas/...
Error [ERR_REQUIRE_ESM]: require() of ES Module @exodus/bytes/encoding-lite.js
from html-encoding-sniffer/lib/html-encoding-sniffer.js not supported.
```

`html-encoding-sniffer` is a **jsdom** dependency, pulled in by `isomorphic-dompurify` (our markdown sanitizer). A transitive bump shipped `@exodus/bytes` as ESM-only, which breaks jsdom's CommonJS `require()` inside the bundled Vercel function. It worked in local `node` (where the file resolved fine) but failed in the deployed bundle — and only the two routes that call `renderMarkdown` were affected.

## Fix
Render markdown with **`sanitize-html`** (pure JS / htmlparser2 — no DOM, no jsdom). This removes the entire jsdom dependency class from the server bundle, so this failure mode can't recur on a future install.

- `jsdom` stays as a **devDependency** (it's the vitest test environment) — no longer reachable from server code.
- `isomorphic-dompurify` removed.

## Security posture (unchanged — verified by existing tests)
- `<script>`/`<style>` and their text content dropped
- all `on*` handlers stripped
- only `http`/`https`/`mailto` schemes allowed → `javascript:` / `data:` links neutralized
- form controls (phishing) and the `style` attribute (clickjacking) forbidden
- `rel="noopener noreferrer"` added to any link opening a new tab

## Test Plan
- [x] `vitest` — 90/90 pass (7 sanitizer security tests included)
- [x] `svelte-check` — 0 errors / 0 warnings
- [x] `npm run build` — clean
- [x] Verified the broken `html-encoding-sniffer` / `@exodus` / `jsdom` chain is **absent** from `.vercel/output/functions/**`, and `sanitize-html` is present
- [ ] After merge → production deploy → confirm `/ideas/<id>` and `/u/<handle>` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)