### PR TITLE
feat(ideas): human-readable /ideas/<slug> URLs (301 from legacy UUID URLs)

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -9,7 +9,7 @@ test('funder dashboard reflects a pledge and a followed expert', async ({ browse
   await ep.goto('/console');
   await ep.getByPlaceholder('Title').fill(title);
   await ep.getByRole('button', { name: 'Publish' }).click();
-  await ep.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await ep.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   const ideaUrl = new URL(ep.url()).pathname;
 
   const funder = await browser.newContext({ storageState: ROLES.funder.state });

--- a/e2e/guards.spec.ts
+++ b/e2e/guards.spec.ts
@@ -30,7 +30,7 @@ test("a second expert does not see another expert's answers in their review queu
   await ep.goto('/console');
   await ep.getByPlaceholder('Title').fill(title);
   await ep.getByRole('button', { name: 'Publish' }).click();
-  await ep.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await ep.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   const ideaUrl = new URL(ep.url()).pathname;
 
   const submitter = await browser.newContext({ storageState: ROLES.submitter.state });
@@ -48,7 +48,7 @@ test("a second expert does not see another expert's answers in their review queu
     (form.elements.namedItem('explanation_md') as HTMLTextAreaElement).value = v.explanation;
     form.submit();
   }, { title: answerTitle, explanation: 'Isolation check answer.' });
-  await sp.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await sp.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   await expect(sp.getByText(answerTitle)).toBeVisible();
 
   const expert2 = await browser.newContext({ storageState: ROLES.expert2.state });

--- a/e2e/loop.spec.ts
+++ b/e2e/loop.spec.ts
@@ -30,7 +30,7 @@ async function submitAnswer(
       (form.elements.namedItem('artifacts') as HTMLTextAreaElement).value = v.artifacts;
     form.submit();
   }, vals);
-  await page.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await page.waitForURL(/\/ideas\/[a-z0-9-]+$/);
 }
 
 test('golden loop: post → fund → answer → verify (payout moment) → admin approve', async ({ browser }) => {
@@ -43,7 +43,7 @@ test('golden loop: post → fund → answer → verify (payout moment) → admin
   await ep.goto('/console');
   await ep.getByPlaceholder('Title').fill(title);
   await ep.getByRole('button', { name: 'Publish' }).click();
-  await ep.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await ep.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   const ideaUrl = new URL(ep.url()).pathname;
   await expect(ep.getByRole('heading', { name: title })).toBeVisible();
 
@@ -108,7 +108,7 @@ test('reject path: author rejects an answer → it leaves the queue', async ({ b
   await ep.goto('/console');
   await ep.getByPlaceholder('Title').fill(title);
   await ep.getByRole('button', { name: 'Publish' }).click();
-  await ep.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await ep.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   const ideaUrl = new URL(ep.url()).pathname;
 
   const submitter = await ctx(browser, ROLES.submitter.state);
@@ -133,7 +133,7 @@ test('revision path: request_revision keeps the answer in the queue', async ({ b
   await ep.goto('/console');
   await ep.getByPlaceholder('Title').fill(title);
   await ep.getByRole('button', { name: 'Publish' }).click();
-  await ep.waitForURL(/\/ideas\/[0-9a-f-]+$/);
+  await ep.waitForURL(/\/ideas\/[a-z0-9-]+$/);
   const ideaUrl = new URL(ep.url()).pathname;
 
   const submitter = await ctx(browser, ROLES.submitter.state);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"dependencies": {
 				"@supabase/ssr": "^0.10.3",
 				"@supabase/supabase-js": "^2.107.0",
-				"isomorphic-dompurify": "^3.16.0",
-				"marked": "^18.0.5"
+				"marked": "^18.0.5",
+				"sanitize-html": "^2.17.4"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
@@ -21,6 +21,7 @@
 				"@tailwindcss/vite": "^4.3.0",
 				"@testing-library/svelte": "^5.3.1",
 				"@types/node": "^25.9.1",
+				"@types/sanitize-html": "^2.16.1",
 				"jsdom": "^29.1.1",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.6.0",
@@ -38,6 +39,7 @@
 			"version": "5.1.11",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
 			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -54,6 +56,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
 			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/generational-cache": "^1.0.1",
@@ -70,6 +73,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
 			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -79,6 +83,7 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
@@ -120,6 +125,7 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
 			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.0"
@@ -132,6 +138,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
 			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -151,6 +158,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
 			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -174,6 +182,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
 			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -201,6 +210,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -223,6 +233,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
 			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -247,6 +258,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
 			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -742,6 +754,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
 			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2307,11 +2320,21 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
+		"node_modules/@types/sanitize-html": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+			"integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"htmlparser2": "^10.1"
+			}
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vercel/nft": {
@@ -2581,6 +2604,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
 			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
@@ -2689,6 +2713,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -2702,6 +2727,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
 			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-mimetype": "^5.0.0",
@@ -2710,6 +2736,12 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.21",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+			"integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -2733,13 +2765,13 @@
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2779,13 +2811,71 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/dompurify": {
-			"version": "3.4.8",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-			"integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -2806,6 +2896,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
 			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20.19.0"
@@ -2861,6 +2952,18 @@
 				"@esbuild/win32-arm64": "0.28.0",
 				"@esbuild/win32-ia32": "0.28.0",
 				"@esbuild/win32-x64": "0.28.0"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/esm-env": {
@@ -2974,12 +3077,44 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
 			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -3005,10 +3140,20 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-reference": {
@@ -3019,19 +3164,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
-			}
-		},
-		"node_modules/isomorphic-dompurify": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.16.0.tgz",
-			"integrity": "sha512-KzTJsMuVPqPwBOD0F6jKXoV/+v8CSx0rxVp+/67KV6Xbw++0zD/avT3bZsgwR0M5QRMiOE+QqQtoZLEJYy1C4Q==",
-			"license": "MIT",
-			"dependencies": {
-				"dompurify": "^3.4.8",
-				"jsdom": "^29.1.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jiti": {
@@ -3055,6 +3187,7 @@
 			"version": "29.1.1",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
 			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.1.11",
@@ -3099,6 +3232,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/launder": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+			"integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+			"license": "MIT",
+			"dependencies": {
+				"dayjs": "^1.11.7"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -3385,6 +3527,7 @@
 			"version": "11.5.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
 			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -3426,6 +3569,7 @@
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
@@ -3498,7 +3642,6 @@
 			"version": "3.3.12",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
 			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3601,10 +3744,17 @@
 				"node": ">=12.20.0"
 			}
 		},
+		"node_modules/parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"license": "MIT"
+		},
 		"node_modules/parse5": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
 			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"entities": "^8.0.0"
@@ -3641,7 +3791,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -3708,7 +3857,6 @@
 			"version": "8.5.15",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
 			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3752,6 +3900,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3782,6 +3931,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3844,10 +3994,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/sanitize-html": {
+			"version": "2.17.4",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+			"integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"deepmerge": "^4.2.2",
+				"escape-string-regexp": "^4.0.0",
+				"htmlparser2": "^10.1.0",
+				"is-plain-object": "^5.0.0",
+				"launder": "^1.7.1",
+				"parse-srcset": "^1.0.2",
+				"postcss": "^8.3.11"
+			}
+		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"xmlchars": "^2.2.0"
@@ -3978,6 +4144,7 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
@@ -4066,6 +4233,7 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
 			"integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tldts-core": "^7.4.2"
@@ -4078,6 +4246,7 @@
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
 			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/totalist": {
@@ -4094,6 +4263,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
 			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^7.0.5"
@@ -4106,6 +4276,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
 			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -4157,6 +4328,7 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
 			"integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -4361,6 +4533,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
 			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"xml-name-validator": "^5.0.0"
@@ -4373,6 +4546,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
 			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20"
@@ -4382,6 +4556,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
 			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -4391,6 +4566,7 @@
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
 			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/bytes": "^1.11.0",
@@ -4422,6 +4598,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
 			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
@@ -4431,6 +4608,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@tailwindcss/vite": "^4.3.0",
 		"@testing-library/svelte": "^5.3.1",
 		"@types/node": "^25.9.1",
+		"@types/sanitize-html": "^2.16.1",
 		"jsdom": "^29.1.1",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.6.0",
@@ -37,7 +38,7 @@
 	"dependencies": {
 		"@supabase/ssr": "^0.10.3",
 		"@supabase/supabase-js": "^2.107.0",
-		"isomorphic-dompurify": "^3.16.0",
-		"marked": "^18.0.5"
+		"marked": "^18.0.5",
+		"sanitize-html": "^2.17.4"
 	}
 }

--- a/src/lib/components/IdeaCard.svelte
+++ b/src/lib/components/IdeaCard.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import StatusBadge from './StatusBadge.svelte';
-  let { idea }: { idea: { id: string; title: string; summary_md: string | null; type: string; status: string; score?: number } } = $props();
+  let { idea }: { idea: { id: string; slug: string; title: string; summary_md: string | null; type: string; status: string; score?: number } } = $props();
 </script>
-<a href="/ideas/{idea.id}" class="block rounded-2xl border p-5 transition"
+<a href="/ideas/{idea.slug}" class="block rounded-2xl border p-5 transition"
    style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
   <div class="mb-2 flex items-center justify-between gap-2">
     <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>

--- a/src/lib/server/ideas.ts
+++ b/src/lib/server/ideas.ts
@@ -1,0 +1,27 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** True when the route param is a raw UUID (a legacy /ideas/<uuid> URL) rather than a slug. */
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+/** Which `ideas` column an /ideas/<param> URL addresses: legacy UUID URLs hit `id`, slugs hit `slug`. */
+export function ideaParamColumn(param: string): 'id' | 'slug' {
+  return isUuid(param) ? 'id' : 'slug';
+}
+
+/**
+ * Resolve an /ideas/<param> route param to the idea's UUID, for form actions that write rows
+ * keyed by idea_id. Returns null if no idea matches (caller should fail/404).
+ * RLS still governs the subsequent write — this only maps the public URL to a primary key.
+ */
+export async function resolveIdeaId(
+  supabase: SupabaseClient,
+  param: string
+): Promise<string | null> {
+  if (isUuid(param)) return param;
+  const { data } = await supabase.from('ideas').select('id').eq('slug', param).maybeSingle();
+  return data?.id ?? null;
+}

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -1,28 +1,52 @@
 import { marked } from 'marked';
-import DOMPurify from 'isomorphic-dompurify';
+import sanitizeHtml from 'sanitize-html';
 
 marked.setOptions({ gfm: true, breaks: true });
-
-// Defense-in-depth: any link that opens a new tab must not reach window.opener (reverse-tabnabbing).
-// Registered once at module load (DOMPurify is a singleton in isomorphic-dompurify).
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if (node.tagName === 'A' && node.getAttribute('target')) {
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
 
 /**
  * Render user-authored Markdown to SANITIZED HTML, server-side.
  * Lives under $lib/server so the heavy deps never ship to the browser.
- * DOMPurify's default HTML profile strips <script>, on* handlers, and javascript:/data: URLs; on top of that we
- * forbid interactive form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing).
+ *
+ * Sanitizer: `sanitize-html` (pure JS, htmlparser2). We deliberately do NOT use a
+ * DOMPurify/jsdom stack here — jsdom's transitive deps break under Vercel's serverless
+ * bundler (ERR_REQUIRE_ESM from html-encoding-sniffer → @exodus/bytes), which 500'd every
+ * markdown-rendering route in production. `sanitize-html` has no DOM dependency and runs
+ * identically locally and in the function.
+ *
+ * Posture (allowlist): drop <script>/<style> and their text, strip all on* handlers, allow
+ * only http/https/mailto URLs (so javascript:/data: links are neutralized), forbid interactive
+ * form controls (phishing) and the style attribute (CSS clickjacking / UI-redressing). Any link
+ * that opens a new tab gets rel="noopener noreferrer" (reverse-tabnabbing defense).
  */
 export function renderMarkdown(md: string | null | undefined): string {
   if (!md) return '';
   const html = marked.parse(md, { async: false }) as string;
-  return DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true },
-    FORBID_TAGS: ['form', 'input', 'button', 'select', 'option', 'textarea', 'label', 'fieldset', 'style'],
-    FORBID_ATTR: ['style']
+  return sanitizeHtml(html, {
+    allowedTags: [
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'p', 'br', 'hr', 'blockquote',
+      'ul', 'ol', 'li',
+      'strong', 'b', 'em', 'i', 'del', 's', 'code', 'pre', 'sup', 'sub',
+      'a', 'img',
+      'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'
+    ],
+    allowedAttributes: {
+      a: ['href', 'title', 'target', 'rel'],
+      img: ['src', 'alt', 'title'],
+      code: ['class'], // marked emits class="language-xx" for fenced blocks
+      th: ['align'],
+      td: ['align']
+    },
+    // http/https/mailto only — javascript: and data: hrefs are dropped (link text kept)
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowProtocolRelative: false,
+    // style attr is not in any allowlist above, so it is already stripped; being explicit is cheap
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: (tagName, attribs) => {
+        if (attribs.target) attribs.rel = 'noopener noreferrer';
+        return { tagName, attribs };
+      }
+    }
   });
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -573,6 +573,7 @@ export type Database = {
           legacy_id: number | null
           published_at: string | null
           resolution: string | null
+          slug: string
           source_url: string | null
           status: string
           summary_md: string | null
@@ -596,6 +597,7 @@ export type Database = {
           legacy_id?: number | null
           published_at?: string | null
           resolution?: string | null
+          slug?: string
           source_url?: string | null
           status?: string
           summary_md?: string | null
@@ -619,6 +621,7 @@ export type Database = {
           legacy_id?: number | null
           published_at?: string | null
           resolution?: string | null
+          slug?: string
           source_url?: string | null
           status?: string
           summary_md?: string | null
@@ -926,6 +929,7 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      slugify: { Args: { txt: string }; Returns: string }
       start_review: {
         Args: { p_answer_id: string }
         Returns: {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,7 +4,7 @@ import type { PageServerLoad } from './$types';
 // fails or returns nothing (e.g. before the production deploy can read the DB), the section hides.
 export const load: PageServerLoad = async ({ locals: { supabase, user } }) => {
   const [{ data: recent }, ideasCount, expertsCount] = await Promise.all([
-    supabase.from('ideas').select('id, title, summary_md, type, status')
+    supabase.from('ideas').select('id, slug, title, summary_md, type, status')
       .neq('status', 'draft').order('created_at', { ascending: false }).limit(3),
     supabase.from('ideas').select('id', { count: 'exact', head: true }).neq('status', 'draft'),
     supabase.from('experts').select('id', { count: 'exact', head: true }).eq('status', 'approved')

--- a/src/routes/admin/payouts/+page.server.ts
+++ b/src/routes/admin/payouts/+page.server.ts
@@ -17,7 +17,7 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
     .from('answers')
     .select(
       'id, title, payout_amount_cents, payout_currency, verified_at, idea_id,' +
-        ' ideas(id, title),' +
+        ' ideas(id, slug, title),' +
         ' submitter:profiles!answers_submitter_id_fkey(handle, display_name)'
     )
     .eq('status', 'verified')

--- a/src/routes/admin/payouts/+page.svelte
+++ b/src/routes/admin/payouts/+page.svelte
@@ -41,7 +41,7 @@
     <tbody>
       {#each data.pending as a (a.id)}
         <tr style="border-top:1px solid var(--line)" class:row-dim={shown[a.id] === 'rejecting'}>
-          <td class="py-2" style="color:var(--ink)"><a href="/ideas/{a.idea_id}" style="color:var(--green-deep)">{a.title}</a></td>
+          <td class="py-2" style="color:var(--ink)"><a href="/ideas/{a.ideas?.slug ?? a.idea_id}" style="color:var(--green-deep)">{a.title}</a></td>
           <td style="color:var(--muted)">{a.ideas?.title}</td>
           <td style="color:var(--muted)">{a.submitter?.display_name ?? a.submitter?.handle}</td>
           <td class="text-right" style="color:var(--ink)"><Money cents={a.payout_amount_cents} currency={a.payout_currency} /></td>

--- a/src/routes/console/+page.server.ts
+++ b/src/routes/console/+page.server.ts
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
   if (!(await requireExpert(supabase, user.id))) error(403, 'Approved experts only');
 
   const { data: ideas } = await supabase
-    .from('ideas').select('id, title, type, status').eq('author_id', user.id)
+    .from('ideas').select('id, slug, title, type, status').eq('author_id', user.id)
     .order('created_at', { ascending: false });
 
   // answers awaiting a decision on MY ideas (ideas!inner — exactly one FK to ideas, so no hint needed; the
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
     .from('answers')
     .select(
       'id, title, explanation_md, status, payout_amount_cents, idea_id,' +
-        ' ideas!inner(id, title, type, author_id),' +
+        ' ideas!inner(id, slug, title, type, author_id),' +
         ' submitter:profiles!answers_submitter_id_fkey(handle, display_name),' +
         ' answer_artifacts(id, kind, url, label)'
     )
@@ -58,9 +58,9 @@ export const actions: Actions = {
       summary_md: String(fd.get('summary_md') ?? ''),
       claim: type === 'hypothesis' ? String(fd.get('claim') ?? '') : null,
       status: 'open', published_at: new Date().toISOString()
-    }).select('id').single();
+    }).select('slug').single();   // slug is assigned by the ideas_set_slug trigger
     if (e) return fail(400, { message: e.message });
-    redirect(303, `/ideas/${data!.id}`);
+    redirect(303, `/ideas/${data!.slug}`);
   },
 
   start_review: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/console/+page.svelte
+++ b/src/routes/console/+page.svelte
@@ -73,7 +73,7 @@
            style="border-color:var(--line); background:var(--surface)">
         <div class="mb-1 flex items-center justify-between gap-2">
           <div>
-            <a href="/ideas/{a.idea_id}" class="font-bold" style="color:var(--ink)">{a.title}</a>
+            <a href="/ideas/{a.ideas?.slug ?? a.idea_id}" class="font-bold" style="color:var(--ink)">{a.title}</a>
             <span class="ml-2 text-xs" style="color:var(--faint)">on “{a.ideas?.title}” · by {a.submitter?.display_name ?? a.submitter?.handle}</span>
           </div>
           {#if shown[a.id] === 'verifying'}
@@ -133,6 +133,6 @@
 <h2 class="mb-2 font-bold" style="color:var(--ink)">Your ideas</h2>
 {#if data.ideas.length === 0}<p style="color:var(--muted)">No ideas yet.</p>{:else}
   <ul class="flex flex-col gap-2">
-    {#each data.ideas as i (i.id)}<li><a href="/ideas/{i.id}" style="color:var(--green-deep)">{i.title}</a> <span style="color:var(--faint)">· {i.status}</span></li>{/each}
+    {#each data.ideas as i (i.id)}<li><a href="/ideas/{i.slug}" style="color:var(--green-deep)">{i.title}</a> <span style="color:var(--faint)">· {i.status}</span></li>{/each}
   </ul>
 {/if}

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -14,7 +14,7 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
   let feed: any[] = [];
   if (followedIds.length) {
     const { data } = await supabase
-      .from('ideas').select('id, title, summary_md, type, status')
+      .from('ideas').select('id, slug, title, summary_md, type, status')
       .in('author_id', followedIds).eq('status', 'open')
       .order('created_at', { ascending: false }).limit(50);
     feed = data ?? [];
@@ -35,7 +35,7 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
   // my funding: my pledges joined to their idea (idea_funding has ONE fk to ideas, no hint needed)
   const { data: rawMine } = await supabase
     .from('idea_funding')
-    .select('id, amount_cents, currency, status, idea_id, ideas(id, title, status)')
+    .select('id, amount_cents, currency, status, idea_id, ideas(id, slug, title, status)')
     .eq('funder_id', user.id)
     .order('created_at', { ascending: false });
   const myPledges = (rawMine ?? []).map((p: any) => ({

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -52,7 +52,7 @@
   <ul class="flex flex-col gap-2">
     {#each data.myPledges as p (p.id)}
       <li class="flex items-center justify-between gap-3 rounded-xl border p-3" style="border-color:var(--line); background:var(--surface)">
-        <a href="/ideas/{p.idea_id}" style="color:var(--green-deep)">{p.idea?.title ?? 'Idea'}</a>
+        <a href="/ideas/{p.idea?.slug ?? p.idea_id}" style="color:var(--green-deep)">{p.idea?.title ?? 'Idea'}</a>
         <span class="flex items-center gap-3">
           <span class="tabular-nums" style="color:var(--ink)"><Money cents={p.amount_cents} currency={p.currency} /></span>
           <span class="text-xs" style="color:var(--faint)">{p.status}</span>

--- a/src/routes/ideas/+page.server.ts
+++ b/src/routes/ideas/+page.server.ts
@@ -17,7 +17,7 @@ export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
 
   let base = supabase
     .from('ideas')
-    .select('id, title, summary_md, type, status, created_at', { count: 'exact' })
+    .select('id, slug, title, summary_md, type, status, created_at', { count: 'exact' })
     .neq('status', 'draft');
   if (type === 'hypothesis' || type === 'open_ended') base = base.eq('type', type);
 

--- a/src/routes/ideas/[slug]/+page.server.ts
+++ b/src/routes/ideas/[slug]/+page.server.ts
@@ -1,16 +1,19 @@
-import { error, fail } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { renderMarkdown } from '$lib/server/markdown';
 import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
+import { ideaParamColumn, isUuid, resolveIdeaId } from '$lib/server/ideas';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
   const { data: idea } = await supabase
     .from('ideas')
-    .select('id, title, summary_md, claim, type, status, resolution, estimated_hours, importance, source_url, author_id, currency')
-    .eq('id', params.id)
+    .select('id, slug, title, summary_md, claim, type, status, resolution, estimated_hours, importance, source_url, author_id, currency')
+    .eq(ideaParamColumn(params.slug), params.slug)
     .single();
   if (!idea) error(404, 'Idea not found');
+  // legacy /ideas/<uuid> URL → permanent-redirect to the canonical slug URL
+  if (isUuid(params.slug)) redirect(301, `/ideas/${idea.slug}`);
 
   const { data: author } = idea.author_id
     ? await supabase.from('profiles').select('handle, display_name').eq('id', idea.author_id).single()
@@ -120,8 +123,10 @@ export const actions: Actions = {
     const fd = await request.formData();
     const dollars = Number(fd.get('amount') ?? '');
     if (!Number.isFinite(dollars) || dollars <= 0) return fail(400, { message: 'Enter an amount greater than 0' });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     const { error: e } = await supabase.from('idea_funding').insert({
-      idea_id: params.id, funder_id: user.id, amount_cents: Math.round(dollars * 100), status: 'committed'
+      idea_id: ideaId, funder_id: user.id, amount_cents: Math.round(dollars * 100), status: 'committed'
     });
     if (e) return fail(400, { message: e.message });
     return { ok: true };
@@ -135,9 +140,11 @@ export const actions: Actions = {
     const body_md = String(fd.get('body_md') ?? '').trim();
     if (!body_md) return fail(400, { message: 'Write something first' });
     if (body_md.length > 10000) return fail(400, { message: 'Comment is too long (max 10,000 characters)' });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     // RLS enforces author = self + visible idea + legacy pinned
     const { error: e } = await supabase.from('comments').insert({
-      idea_id: params.id, author_id: user.id, body_md
+      idea_id: ideaId, author_id: user.id, body_md
     });
     if (e) return fail(400, { message: e.message });
     return { ok: true };
@@ -162,8 +169,10 @@ export const actions: Actions = {
     if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
     const fd = await request.formData();
     const note_md = String(fd.get('note_md') ?? '').trim().slice(0, 2000) || null;
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     const { error: e } = await supabase.from('interest').insert({
-      idea_id: params.id, profile_id: user.id, note_md
+      idea_id: ideaId, profile_id: user.id, note_md
     });
     if (e) {
       // a duplicate (double-click / stale tab) means "already interested" — idempotent, don't leak the constraint name
@@ -180,13 +189,15 @@ export const actions: Actions = {
     const fd = await request.formData();
     const value = Number(fd.get('value'));
     if (value !== 1 && value !== -1) return fail(400, { message: 'Invalid vote' });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     // switch = delete own row first (no UPDATE policy), then insert; a 23505 race means a vote
     // already landed — treat as ok (the page re-load shows the truth)
     const { error: delErr } = await supabase.from('idea_votes')
-      .delete().eq('idea_id', params.id).eq('profile_id', user.id);
+      .delete().eq('idea_id', ideaId).eq('profile_id', user.id);
     if (delErr) return fail(400, { message: delErr.message });
     const { error: e } = await supabase.from('idea_votes').insert({
-      idea_id: params.id, profile_id: user.id, value
+      idea_id: ideaId, profile_id: user.id, value
     });
     if (e && (e as { code?: string }).code !== '23505') return fail(400, { message: e.message });
     return { ok: true };
@@ -196,18 +207,22 @@ export const actions: Actions = {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
     if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     const { error: e } = await supabase.from('idea_votes')
-      .delete().eq('idea_id', params.id).eq('profile_id', user.id);
+      .delete().eq('idea_id', ideaId).eq('profile_id', user.id);
     if (e) return fail(400, { message: e.message });
     return { ok: true };
   },
 
-  uninterest: async ({ request, params, locals: { supabase, safeGetSession } }) => {
+  uninterest: async ({ params, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });
     if (!(await rateLimit(supabase, 'engage')).ok) return fail(429, { message: RATE_LIMIT_MESSAGE });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
     const { data: del, error: e } = await supabase.from('interest')
-      .delete().eq('idea_id', params.id).eq('profile_id', user.id).select('id');
+      .delete().eq('idea_id', ideaId).eq('profile_id', user.id).select('id');
     if (e) return fail(400, { message: e.message });
     if (!del?.length) return fail(409, { message: 'You were not marked interested' });
     return { ok: true };

--- a/src/routes/ideas/[slug]/+page.svelte
+++ b/src/routes/ideas/[slug]/+page.svelte
@@ -29,7 +29,7 @@
     <section class="mt-8">
       <div class="mb-3 flex items-center justify-between">
         <h2 class="text-xl font-bold" style="color:var(--ink)">Answers</h2>
-        {#if data.canSubmit}<a href="/ideas/{data.idea.id}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>{/if}
+        {#if data.canSubmit}<a href="/ideas/{data.idea.slug}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>{/if}
       </div>
       {#if data.answers.length === 0}<p style="color:var(--muted)">No answers yet.</p>{:else}
         <div class="flex flex-col gap-3">{#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}</div>

--- a/src/routes/ideas/[slug]/answer/+page.server.ts
+++ b/src/routes/ideas/[slug]/answer/+page.server.ts
@@ -2,13 +2,16 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { inferKind } from '$lib/artifacts';
 import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
+import { ideaParamColumn, isUuid, resolveIdeaId } from '$lib/server/ideas';
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
-  if (!user) redirect(303, `/login?next=/ideas/${params.id}/answer`);
+  if (!user) redirect(303, `/login?next=/ideas/${params.slug}/answer`);
   const { data: idea } = await supabase
-    .from('ideas').select('id, title, type, status').eq('id', params.id).single();
+    .from('ideas').select('id, slug, title, type, status').eq(ideaParamColumn(params.slug), params.slug).single();
   if (!idea) error(404, 'Idea not found');
+  // legacy /ideas/<uuid>/answer URL → canonical slug URL
+  if (isUuid(params.slug)) redirect(301, `/ideas/${idea.slug}/answer`);
   if (idea.status !== 'open') error(400, 'This idea is not accepting answers');
   return { idea };
 };
@@ -22,11 +25,13 @@ export const actions: Actions = {
     const title = String(fd.get('title') ?? '').trim();
     const explanation_md = String(fd.get('explanation_md') ?? '').trim();
     if (!title) return fail(400, { message: 'Title is required', title, explanation_md });
+    const ideaId = await resolveIdeaId(supabase, params.slug);
+    if (!ideaId) return fail(404, { message: 'Idea not found' });
 
     // RLS enforces submitter = self, status pinned, and idea must be open
     const { data: answer, error: e } = await supabase
       .from('answers')
-      .insert({ idea_id: params.id, submitter_id: user.id, title, explanation_md, status: 'submitted' })
+      .insert({ idea_id: ideaId, submitter_id: user.id, title, explanation_md, status: 'submitted' })
       .select('id').single();
     if (e || !answer) return fail(400, { message: e?.message ?? 'Could not submit answer' });
 
@@ -37,6 +42,6 @@ export const actions: Actions = {
       const { error: ae } = await supabase.from('answer_artifacts').insert(rows);
       if (ae) return fail(400, { message: `Answer saved, but artifacts failed: ${ae.message}` });
     }
-    redirect(303, `/ideas/${params.id}`);
+    redirect(303, `/ideas/${params.slug}`);
   }
 };

--- a/src/routes/ideas/[slug]/answer/+page.svelte
+++ b/src/routes/ideas/[slug]/answer/+page.svelte
@@ -10,7 +10,7 @@
   let artifacts = $state('');
 </script>
 <h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Submit an answer</h1>
-<p class="mb-6 text-sm" style="color:var(--muted)">for <a href="/ideas/{data.idea.id}" style="color:var(--green-deep)">{data.idea.title}</a></p>
+<p class="mb-6 text-sm" style="color:var(--muted)">for <a href="/ideas/{data.idea.slug}" style="color:var(--green-deep)">{data.idea.title}</a></p>
 <form method="POST" class="flex flex-col gap-3 rounded-2xl border p-5" style="border-color:var(--line); background:var(--surface)">
   <input name="title" placeholder="Answer title" required bind:value={title}
          class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />

--- a/src/routes/ideas/[slug]/answer/page.test.ts
+++ b/src/routes/ideas/[slug]/answer/page.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import Page from './+page.svelte';
 
-const data = { idea: { id: 'i1', title: 'Idea' } };
+const data = { idea: { id: 'i1', slug: 'idea', title: 'Idea' } };
 
 describe('answer form input binding', () => {
   it('retains typed input across a re-render (the form prop changing must not clobber it)', async () => {

--- a/src/routes/ideas/[slug]/rate-limit-wiring.test.ts
+++ b/src/routes/ideas/[slug]/rate-limit-wiring.test.ts
@@ -5,12 +5,17 @@ import { RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 function mkEvent(rpcData: boolean) {
   const supabase: any = {
     rpc: vi.fn().mockResolvedValue({ data: rpcData, error: null }),
-    from: vi.fn(() => ({ insert: vi.fn().mockResolvedValue({ error: null }) }))
+    // 'ideas' → slug→id resolution (resolveIdeaId); anything else → insert (the comment write)
+    from: vi.fn((table: string) =>
+      table === 'ideas'
+        ? { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 'idea-uuid-1' }, error: null }) }) }) }
+        : { insert: vi.fn().mockResolvedValue({ error: null }) }
+    )
   };
   const fd = new FormData();
   fd.set('body_md', 'hello');
   return {
-    params: { id: 'idea-1' },
+    params: { slug: 'a-slug' },
     request: { formData: async () => fd },
     locals: { supabase, safeGetSession: async () => ({ user: { id: 'user-1' } }) }
   } as any;

--- a/supabase/migrations/20260607162432_add_idea_slugs.sql
+++ b/supabase/migrations/20260607162432_add_idea_slugs.sql
@@ -1,0 +1,76 @@
+-- Idea slugs: human-readable URLs (/ideas/<slug>) generated from the title, with numeric
+-- dedupe on collision. Slugs are STABLE (assigned once at insert, never changed on title edit)
+-- so existing links never break; the route layer 301-redirects any UUID URL to the slug.
+
+-- ── slugify: lowercase, collapse non-alphanumerics to single hyphens, trim, cap at 80 chars ──
+-- IMMUTABLE + pinned search_path so it is safe to use in generated/indexed contexts and passes advisors.
+create or replace function public.slugify(txt text)
+returns text
+language sql
+immutable
+strict
+set search_path = ''
+as $$
+  select coalesce(
+    nullif(
+      trim(both '-' from
+        left(
+          regexp_replace(lower(txt), '[^a-z0-9]+', '-', 'g'),
+          80
+        )
+      ),
+    ''),
+    'idea'
+  );
+$$;
+
+-- ── column ──
+-- DEFAULT '' (a transient placeholder) so the trigger below always populates it AND so generated
+-- TypeScript Insert types treat slug as optional — column defaults are applied before BEFORE-triggers,
+-- so a slug-less insert arrives at the trigger as '' and gets a real slug. It is never persisted as ''.
+alter table public.ideas add column slug text not null default '';
+
+-- ── backfill existing rows deterministically (oldest-first keeps the bare slug; later
+--    duplicates get -2, -3, …). Window dedupe is fine for the one-time backfill on a small set. ──
+with ranked as (
+  select
+    id,
+    public.slugify(title) as base,
+    row_number() over (partition by public.slugify(title) order by created_at asc, id asc) as rn
+  from public.ideas
+)
+update public.ideas i
+set slug = case when r.rn = 1 then r.base else r.base || '-' || r.rn end
+from ranked r
+where i.id = r.id;
+
+-- ── enforce uniqueness (after backfill, so the transient '' placeholders are gone) ──
+create unique index ideas_slug_key on public.ideas (slug);
+
+-- ── trigger: assign a unique slug on INSERT only (stable). Respects an explicitly provided slug. ──
+create or replace function public.set_idea_slug()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  base      text := public.slugify(new.title);
+  candidate text := base;
+  n         int  := 1;
+begin
+  if new.slug is not null and new.slug <> '' then
+    return new;  -- caller provided a slug explicitly; trust it (unique index is the backstop)
+  end if;
+  -- find the first free candidate; the unique index guarantees correctness under any race
+  while exists (select 1 from public.ideas where slug = candidate) loop
+    n := n + 1;
+    candidate := base || '-' || n;
+  end loop;
+  new.slug := candidate;
+  return new;
+end;
+$$;
+
+create trigger ideas_set_slug
+before insert on public.ideas
+for each row execute function public.set_idea_slug();


### PR DESCRIPTION
Replaces the ugly `/ideas/<uuid>` with `/ideas/<slug-generated-from-title>`.

> **Note:** built on top of #58 (the markdown serverless fix). Merge **#58 first** — the idea page renders markdown, so without #58 `/ideas/<slug>` would still 500 in production. (The PRs share that one commit; once #58 is in `main`, this PR's diff drops it.)

## Behaviour
- `/ideas/define-smart-goals` instead of `/ideas/d7c35945-…`
- Slug = `slugify(title)` (lowercase, hyphenated, capped 80) with numeric `-2`/`-3` dedupe on collision
- Slugs are **stable** — assigned once at insert, not regenerated on title edit, so links never rot
- Every legacy `/ideas/<uuid>` URL **301-redirects** to its canonical slug (the 238 existing indexed/bookmarked UUID URLs keep working) — same for `/ideas/<uuid>/answer`

## DB — migration `20260607162432_add_idea_slugs`
- `slugify(text)` SQL function (IMMUTABLE, pinned `search_path`)
- `ideas.slug` column with `DEFAULT ''` — a transient placeholder so the before-insert trigger always populates it *and* the generated TS `Insert` type treats it as optional (column defaults apply before BEFORE-triggers). Never persisted as `''`.
- Deterministic backfill of existing rows (oldest-first keeps the bare slug; later duplicate titles get `-2`, `-3`, …)
- Unique index + `set_idea_slug()` trigger (numeric dedupe; respects an explicitly-provided slug)

## App
- Route param `[id]` → `[slug]`; loader resolves by slug, UUID param → `redirect(301, slug)`
- New `$lib/server/ideas.ts` (`isUuid` / `ideaParamColumn` / `resolveIdeaId`); all 7 form actions resolve the slug param → idea UUID before writing
- `console` Publish redirects straight to the slug; all idea links use slug (UUID fallback on a couple of embeds, harmlessly covered by the 301)
- Regenerated `database.types.ts`; e2e idea-URL regexes broadened `[0-9a-f-]` → `[a-z0-9-]`

## Test Plan
- [x] `svelte-check` 0/0, `vitest` 90/90, `npm run build` clean
- [x] Local DB: slugify/backfill/dedupe + trigger (default-path, explicit-slug, collision) all verified via psql
- [x] Full Playwright e2e green (publish → **slug redirect** → answer → verify → approve); 2 known animation-window flakes pass on retry (CI `retries:2`)
- [ ] **Apply the migration to the cloud project** (`gjomchhbsbtauzkpyjwa`) before/with deploy — see PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)