### PR TITLE
fix(money): harden formatCents against invalid currency codes — fixes idea-page 500

### DIFF
--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -14,4 +14,13 @@ describe('formatCents', () => {
   it('honors a currency argument', () => {
     expect(formatCents(500, 'EUR')).toBe('€5.00');
   });
+  it('maps legacy currency symbols to ISO codes (never throws)', () => {
+    // legacy ETL rows store "$" — Intl.NumberFormat would throw RangeError and 500 the page
+    expect(formatCents(3712, '$')).toBe('$37.12');
+    expect(formatCents(500, '€')).toBe('€5.00');
+  });
+  it('falls back to USD for an unrecognized/garbage currency code', () => {
+    expect(formatCents(3712, 'not-a-code')).toBe('$37.12');
+    expect(formatCents(3712, '')).toBe('$37.12');
+  });
 });

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,6 +1,31 @@
-/** Format integer cents as a localized currency string; null/undefined → em-dash. */
+// Map currency symbols / common aliases (seen in legacy ETL data) to ISO 4217 codes.
+const CURRENCY_ALIASES: Record<string, string> = {
+  $: 'USD',
+  US$: 'USD',
+  '€': 'EUR',
+  '£': 'GBP',
+  '¥': 'JPY'
+};
+
+/** Coerce arbitrary stored currency values to a usable ISO 4217 code; defaults to USD. */
+function normalizeCurrency(currency: string): string {
+  const raw = (currency ?? '').trim();
+  if (CURRENCY_ALIASES[raw]) return CURRENCY_ALIASES[raw];
+  return /^[A-Za-z]{3}$/.test(raw) ? raw.toUpperCase() : 'USD';
+}
+
+/**
+ * Format integer cents as a localized currency string; null/undefined → em-dash.
+ * Hardened against bad stored currency codes: legacy ETL rows carry values like "$", which
+ * would make `Intl.NumberFormat` throw `RangeError: Invalid currency code` and 500 the page.
+ * We normalize known symbols and fall back to USD for anything not a valid ISO code.
+ */
 export function formatCents(cents: number | null | undefined, currency = 'USD'): string {
-  return cents == null
-    ? '—'
-    : new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100);
+  if (cents == null) return '—';
+  const code = normalizeCurrency(currency);
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(cents / 100);
+  } catch {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+  }
 }


### PR DESCRIPTION
## Summary
**Every idea detail page 500s in production.** Vercel runtime log:
```
RangeError: Invalid currency code : $
  at formatCents (money.js) → Money → BountyMeter
```
Legacy ETL rows store `currency` as the symbol `"$"` instead of an ISO 4217 code (`USD`). `Intl.NumberFormat({ currency: '$' })` throws `RangeError`, crashing the bounty meter on every `/ideas/<slug>` page. (Profile/list pages were unaffected — they don't render `Money`.)

## Fix
`formatCents` now:
- maps known symbols → ISO codes (`$`→USD, `€`→EUR, `£`→GBP, `¥`→JPY)
- accepts any 3-letter code (uppercased)
- falls back to **USD** for anything else, wrapped in `try/catch` so no stored value can throw

User-supplied/legacy data must never be able to 500 a page.

## Test Plan
- [x] `vitest` money suite — 5/5 (added: symbol mapping, garbage-code fallback)
- [x] `svelte-check` 0/0
- [ ] After merge → deploy → `/ideas/<slug>` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)