### PR TITLE
feat(ideas): infinite scroll + sort by net upvotes; hide archived ideas

### DIFF
--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -14,4 +14,13 @@ describe('formatCents', () => {
   it('honors a currency argument', () => {
     expect(formatCents(500, 'EUR')).toBe('€5.00');
   });
+  it('maps legacy currency symbols to ISO codes (never throws)', () => {
+    // legacy ETL rows store "$" — Intl.NumberFormat would throw RangeError and 500 the page
+    expect(formatCents(3712, '$')).toBe('$37.12');
+    expect(formatCents(500, '€')).toBe('€5.00');
+  });
+  it('falls back to USD for an unrecognized/garbage currency code', () => {
+    expect(formatCents(3712, 'not-a-code')).toBe('$37.12');
+    expect(formatCents(3712, '')).toBe('$37.12');
+  });
 });

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,6 +1,31 @@
-/** Format integer cents as a localized currency string; null/undefined → em-dash. */
+// Map currency symbols / common aliases (seen in legacy ETL data) to ISO 4217 codes.
+const CURRENCY_ALIASES: Record<string, string> = {
+  $: 'USD',
+  US$: 'USD',
+  '€': 'EUR',
+  '£': 'GBP',
+  '¥': 'JPY'
+};
+
+/** Coerce arbitrary stored currency values to a usable ISO 4217 code; defaults to USD. */
+function normalizeCurrency(currency: string): string {
+  const raw = (currency ?? '').trim();
+  if (CURRENCY_ALIASES[raw]) return CURRENCY_ALIASES[raw];
+  return /^[A-Za-z]{3}$/.test(raw) ? raw.toUpperCase() : 'USD';
+}
+
+/**
+ * Format integer cents as a localized currency string; null/undefined → em-dash.
+ * Hardened against bad stored currency codes: legacy ETL rows carry values like "$", which
+ * would make `Intl.NumberFormat` throw `RangeError: Invalid currency code` and 500 the page.
+ * We normalize known symbols and fall back to USD for anything not a valid ISO code.
+ */
 export function formatCents(cents: number | null | undefined, currency = 'USD'): string {
-  return cents == null
-    ? '—'
-    : new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(cents / 100);
+  if (cents == null) return '—';
+  const code = normalizeCurrency(currency);
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).format(cents / 100);
+  } catch {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+  }
 }

--- a/src/lib/server/idea-feed.ts
+++ b/src/lib/server/idea-feed.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { attachScores, sortTop, type VoteTotal } from '$lib/votes';
+
+export const PAGE_SIZE = 24;
+export type IdeaSort = 'top' | 'new';
+
+/** Parse the `sort` query param. Default is 'top' = net upvotes (score = upvotes − downvotes). */
+export function parseSort(value: string | null): IdeaSort {
+  return value === 'new' ? 'new' : 'top';
+}
+
+/** Statuses never shown in public listings: drafts (unpublished) and archived (admin-hidden). */
+const HIDDEN_STATUSES = '(draft,archived)';
+
+export type IdeaListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  summary_md: string | null;
+  type: string;
+  status: string;
+  created_at: string | null;
+  score: number;
+};
+
+export type IdeaFeedPage = {
+  ideas: IdeaListItem[];
+  count: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+};
+
+/**
+ * One page of the public ideas feed, with vote scores attached and archived/draft ideas excluded.
+ * Shared by the SSR page loader and the /api/ideas infinite-scroll endpoint so both stay in lockstep.
+ *
+ * 'new' sorts in the DB and pages with range(). 'top' (net upvotes) needs a global score sort, so it
+ * fetches the whole (small, < 1000-row) set, ranks in memory, and slices the page — same caveat as
+ * before: revisit if the idea count ever approaches PostgREST's 1000-row cap.
+ */
+export async function loadIdeaFeed(
+  supabase: SupabaseClient,
+  opts: { type?: string | null; sort: IdeaSort; page: number }
+): Promise<IdeaFeedPage> {
+  const page = Math.max(0, Math.trunc(opts.page) || 0);
+
+  const { data: rawTotals } = await supabase.from('idea_vote_totals').select('idea_id, score');
+  const totals: VoteTotal[] = (rawTotals ?? []).flatMap((t: { idea_id: string | null; score: number | null }) =>
+    t.idea_id ? [{ idea_id: t.idea_id, score: t.score ?? 0 }] : []
+  );
+
+  let base = supabase
+    .from('ideas')
+    .select('id, slug, title, summary_md, type, status, created_at', { count: 'exact' })
+    .not('status', 'in', HIDDEN_STATUSES);
+  if (opts.type === 'hypothesis' || opts.type === 'open_ended') base = base.eq('type', opts.type);
+
+  if (opts.sort === 'top') {
+    const { data: all } = await base.order('created_at', { ascending: false });
+    const ranked = sortTop(attachScores(all ?? [], totals)) as IdeaListItem[];
+    const start = page * PAGE_SIZE;
+    return {
+      ideas: ranked.slice(start, start + PAGE_SIZE),
+      count: ranked.length,
+      page,
+      pageSize: PAGE_SIZE,
+      hasMore: start + PAGE_SIZE < ranked.length
+    };
+  }
+
+  const { data: ideas, count } = await base
+    .order('created_at', { ascending: false })
+    .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
+  const total = count ?? 0;
+  return {
+    ideas: attachScores(ideas ?? [], totals) as IdeaListItem[],
+    count: total,
+    page,
+    pageSize: PAGE_SIZE,
+    hasMore: (page + 1) * PAGE_SIZE < total
+  };
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -5,8 +5,8 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ locals: { supabase, user } }) => {
   const [{ data: recent }, ideasCount, expertsCount] = await Promise.all([
     supabase.from('ideas').select('id, slug, title, summary_md, type, status')
-      .neq('status', 'draft').order('created_at', { ascending: false }).limit(3),
-    supabase.from('ideas').select('id', { count: 'exact', head: true }).neq('status', 'draft'),
+      .not('status', 'in', '(draft,archived)').order('created_at', { ascending: false }).limit(3),
+    supabase.from('ideas').select('id', { count: 'exact', head: true }).not('status', 'in', '(draft,archived)'),
     supabase.from('experts').select('id', { count: 'exact', head: true }).eq('status', 'approved')
   ]);
   return {

--- a/src/routes/api/ideas/+server.ts
+++ b/src/routes/api/ideas/+server.ts
@@ -1,0 +1,13 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { loadIdeaFeed, parseSort } from '$lib/server/idea-feed';
+
+// Infinite-scroll data source for the ideas page: returns one page of the same feed the SSR loader
+// renders (scores attached, archived/draft excluded). RLS still governs row visibility via `supabase`.
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+  const type = url.searchParams.get('type');
+  const sort = parseSort(url.searchParams.get('sort'));
+  const page = Math.max(0, Math.trunc(Number(url.searchParams.get('page'))) || 0);
+  const feed = await loadIdeaFeed(supabase, { type, sort, page });
+  return json({ ideas: feed.ideas, page: feed.page, hasMore: feed.hasMore });
+};

--- a/src/routes/ideas/+page.server.ts
+++ b/src/routes/ideas/+page.server.ts
@@ -1,41 +1,9 @@
 import type { PageServerLoad } from './$types';
-import { attachScores, sortTop, type VoteTotal } from '$lib/votes';
+import { loadIdeaFeed, parseSort } from '$lib/server/idea-feed';
 
-const PAGE = 24;
 export const load: PageServerLoad = async ({ url, locals: { supabase } }) => {
-  const type = url.searchParams.get('type');       // 'hypothesis' | 'open_ended' | null
-  const sort = url.searchParams.get('sort') === 'top' ? 'top' : 'new';
-  const page = Math.max(0, Math.trunc(Number(url.searchParams.get('page'))) || 0);
-
-  // vote totals are small (≤ #ideas rows; ~240 today, well under PostgREST's 1000-row cap — revisit
-  // both whole-set fetches if the idea count ever approaches 1000) — fetched once for the card scores
-  const { data: rawTotals } = await supabase.from('idea_vote_totals').select('idea_id, score');
-  // the view's generated types are nullable (aggregate view); normalize to non-null VoteTotal
-  const totals: VoteTotal[] = (rawTotals ?? []).flatMap((t) =>
-    t.idea_id ? [{ idea_id: t.idea_id, score: t.score ?? 0 }] : []
-  );
-
-  let base = supabase
-    .from('ideas')
-    .select('id, slug, title, summary_md, type, status, created_at', { count: 'exact' })
-    .neq('status', 'draft');
-  if (type === 'hypothesis' || type === 'open_ended') base = base.eq('type', type);
-
-  if (sort === 'top') {
-    // global sort by score needs the whole (small) set; slice the page in memory
-    const { data: all } = await base.order('created_at', { ascending: false });
-    const ranked = sortTop(attachScores(all ?? [], totals));
-    return {
-      ideas: ranked.slice(page * PAGE, (page + 1) * PAGE),
-      count: ranked.length, page, pageSize: PAGE, type, sort
-    };
-  }
-
-  const { data: ideas, count } = await base
-    .order('created_at', { ascending: false })
-    .range(page * PAGE, page * PAGE + PAGE - 1);
-  return {
-    ideas: attachScores(ideas ?? [], totals),
-    count: count ?? 0, page, pageSize: PAGE, type, sort
-  };
+  const type = url.searchParams.get('type'); // 'hypothesis' | 'open_ended' | null
+  const sort = parseSort(url.searchParams.get('sort')); // default 'top' = net upvotes
+  const feed = await loadIdeaFeed(supabase, { type, sort, page: 0 });
+  return { ...feed, type, sort };
 };

--- a/src/routes/ideas/+page.svelte
+++ b/src/routes/ideas/+page.svelte
@@ -1,29 +1,106 @@
 <script lang="ts">
   import IdeaCard from '$lib/components/IdeaCard.svelte';
+
   let { data } = $props();
+
+  // Infinite scroll: SSR renders page 0; we append further pages from /api/ideas. The list is local
+  // $state seeded from `data`, and re-seeded whenever the filter/sort navigation changes `data`.
+  // svelte-ignore state_referenced_locally
+  let ideas = $state(data.ideas);
+  // svelte-ignore state_referenced_locally
+  let page = $state(data.page);
+  // svelte-ignore state_referenced_locally
+  let hasMore = $state(data.hasMore);
+  let loading = $state(false);
+  let failed = $state(false);
+  let sentinel = $state<HTMLDivElement | null>(null);
+
+  // re-seed only on a real filter/sort change (this key changes ⇒ a navigation happened)
+  let feedKey = $derived(`${data.type ?? ''}|${data.sort}`);
+  $effect(() => {
+    feedKey; // track
+    ideas = data.ideas;
+    page = data.page;
+    hasMore = data.hasMore;
+    failed = false;
+  });
+
+  function buildHref(type: string | null, sort: 'top' | 'new'): string {
+    const p = new URLSearchParams();
+    if (type) p.set('type', type);
+    if (sort === 'new') p.set('sort', 'new'); // 'top' (net upvotes) is the default — omit it
+    const qs = p.toString();
+    return qs ? `/ideas?${qs}` : '/ideas';
+  }
+
+  async function loadMore() {
+    if (loading || !hasMore) return;
+    loading = true;
+    failed = false;
+    try {
+      const p = new URLSearchParams();
+      if (data.type) p.set('type', data.type);
+      if (data.sort === 'new') p.set('sort', 'new');
+      p.set('page', String(page + 1));
+      const res = await fetch(`/api/ideas?${p}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const j = await res.json();
+      ideas = [...ideas, ...j.ideas];
+      page = j.page;
+      hasMore = j.hasMore;
+    } catch {
+      failed = true; // surface a retry control rather than silently stalling
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Auto-load when the sentinel nears the viewport (rootMargin pre-fetches before it's visible).
+  $effect(() => {
+    if (!sentinel) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '600px' }
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  });
 </script>
+
 <h1 class="mb-4 text-2xl font-bold" style="color:var(--ink)">Ideas</h1>
 <nav class="mb-6 flex gap-2 text-sm">
-  <a href="/ideas" style="color:{data.type ? 'var(--muted)' : 'var(--green-deep)'}">All</a>
-  <a href="/ideas?type=hypothesis" style="color:{data.type === 'hypothesis' ? 'var(--green-deep)' : 'var(--muted)'}">Hypotheses</a>
-  <a href="/ideas?type=open_ended" style="color:{data.type === 'open_ended' ? 'var(--green-deep)' : 'var(--muted)'}">Open-ended</a>
+  <a href={buildHref(null, data.sort)} style="color:{data.type ? 'var(--muted)' : 'var(--green-deep)'}">All</a>
+  <a href={buildHref('hypothesis', data.sort)} style="color:{data.type === 'hypothesis' ? 'var(--green-deep)' : 'var(--muted)'}">Hypotheses</a>
+  <a href={buildHref('open_ended', data.sort)} style="color:{data.type === 'open_ended' ? 'var(--green-deep)' : 'var(--muted)'}">Open-ended</a>
 </nav>
 <nav class="mb-6 -mt-4 flex gap-2 text-sm">
-  <a href="/ideas{data.type ? `?type=${data.type}` : ''}"
-     style="color:{data.sort === 'top' ? 'var(--muted)' : 'var(--green-deep)'}">Newest</a>
-  <a href="/ideas?{data.type ? `type=${data.type}&` : ''}sort=top"
-     style="color:{data.sort === 'top' ? 'var(--green-deep)' : 'var(--muted)'}">Top</a>
+  <a href={buildHref(data.type, 'top')} style="color:{data.sort === 'top' ? 'var(--green-deep)' : 'var(--muted)'}">Top</a>
+  <a href={buildHref(data.type, 'new')} style="color:{data.sort === 'new' ? 'var(--green-deep)' : 'var(--muted)'}">Newest</a>
 </nav>
-{#if data.ideas.length === 0}
+
+{#if ideas.length === 0}
   <p style="color:var(--muted)">No ideas yet.</p>
 {:else}
   <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-    {#each data.ideas as idea (idea.id)}<IdeaCard {idea} />{/each}
+    {#each ideas as idea (idea.id)}<IdeaCard {idea} />{/each}
   </div>
-{/if}
-{#if data.count > data.pageSize}
-  <div class="mt-6 flex gap-3" style="color:var(--muted)">
-    {#if data.page > 0}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}{data.sort === 'top' ? 'sort=top&' : ''}page={data.page - 1}">← Prev</a>{/if}
-    {#if (data.page + 1) * data.pageSize < data.count}<a href="/ideas?{data.type ? `type=${data.type}&` : ''}{data.sort === 'top' ? 'sort=top&' : ''}page={data.page + 1}">Next →</a>{/if}
+
+  <!-- sentinel + status row -->
+  <div class="mt-8 flex flex-col items-center gap-3">
+    {#if loading}
+      <span class="text-sm" style="color:var(--faint)">Loading more…</span>
+    {:else if failed}
+      <button onclick={loadMore} class="rounded-xl border px-4 py-2 text-sm font-medium"
+              style="border-color:var(--line); color:var(--ink)">Couldn’t load — retry</button>
+    {:else if hasMore}
+      <!-- manual fallback (keyboard / no-IntersectionObserver); the observer auto-triggers loadMore -->
+      <button onclick={loadMore} class="rounded-xl border px-4 py-2 text-sm font-medium"
+              style="border-color:var(--line); color:var(--muted)">Load more</button>
+    {:else}
+      <span class="text-sm" style="color:var(--faint)">That’s all {data.count} ideas.</span>
+    {/if}
+    <div bind:this={sentinel} aria-hidden="true"></div>
   </div>
 {/if}

--- a/src/routes/ideas/[slug]/+page.server.ts
+++ b/src/routes/ideas/[slug]/+page.server.ts
@@ -12,6 +12,8 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     .eq(ideaParamColumn(params.slug), params.slug)
     .single();
   if (!idea) error(404, 'Idea not found');
+  // archived (admin-hidden) and draft (unpublished) ideas are not publicly reachable
+  if (idea.status === 'archived' || idea.status === 'draft') error(404, 'Idea not found');
   // legacy /ideas/<uuid> URL → permanent-redirect to the canonical slug URL
   if (isUuid(params.slug)) redirect(301, `/ideas/${idea.slug}`);
 

--- a/src/routes/ideas/ideas.test.ts
+++ b/src/routes/ideas/ideas.test.ts
@@ -7,7 +7,7 @@ function mkLocals(rows: unknown[], totals: unknown[] = []) {
     // thenable builder: serves both `…order().range()` (new) and a directly-awaited `…order()` (top)
     const result = { data: rows, count: rows.length };
     const builder: any = {
-      select() { return this; }, neq() { return this; }, eq() { return this; }, order() { return this; },
+      select() { return this; }, neq() { return this; }, not() { return this; }, eq() { return this; }, order() { return this; },
       range() { return Promise.resolve(result); },
       then(resolve: any, reject: any) { return Promise.resolve(result).then(resolve, reject); }
     };


### PR DESCRIPTION
Addresses two requests: the archived idea that "doesn't load" should be hidden/unreachable, and the ideas page should infinite-scroll sorted by net upvotes.

> Built on top of #60 (the currency-crash fix). Merge **#60 first** — the idea detail page renders the bounty meter. The PRs share that commit; once #60 is in `main`, this diff drops it.

## Hide admin-archived ideas
The page you clicked (`context-based-consciousness`) is `status = 'archived'`. Archived (and draft) ideas are now:
- excluded from the `/ideas` feed, the home "recent" section, and its counts
- **404** on the detail page (`/ideas/<slug>` and legacy `/ideas/<uuid>`)

So the ideas an admin archived are hidden from listings *and* unreachable by URL. Enforced at the app/data layer (list filters + detail 404), not RLS, so the author/admin console still lists them for management.

> Note: the archived page was *also* hit by the separate `Invalid currency code` crash (every idea page) — that's fixed in #60. Both together fully restore idea pages.

## Infinite scroll + net-upvotes sort
- **Infinite scroll**: `IntersectionObserver` (with `rootMargin` pre-fetch) appends pages from a new **`/api/ideas`** endpoint; SSR still renders page 0 for first paint/SEO. A "Load more" button doubles as keyboard/no-observer fallback and a fetch-failure retry.
- **Sort**: default is now **Top = net upvotes** (`score = upvotes − downvotes`); **Newest** is the opt-in toggle (`?sort=new`).
- Shared `$lib/server/idea-feed.ts` (`loadIdeaFeed`/`parseSort`/`PAGE_SIZE`) backs both the SSR loader and the API endpoint so they can't drift.

## Test Plan
- [x] `svelte-check` 0/0, `vitest` 92/92, `npm run build` clean
- [x] Local smoke (30 seeded ideas, 2 archived): `/api/ideas` paginates **24 → 10** with `hasMore` flipping; archived absent from both pages; archived detail **404**, open detail **200**; default sort = Top, `?sort=new` toggles
- [ ] After merge → deploy → scroll `/ideas`, confirm archived ideas gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)