### PR TITLE
redesign: cohesive public face — fonts + shell + landing (then app pages)

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -15,7 +15,7 @@ test('funder dashboard reflects a pledge and a followed expert', async ({ browse
   const funder = await browser.newContext({ storageState: ROLES.funder.state });
   const fp = await funder.newPage();
   await fp.goto(ideaUrl);
-  await fp.getByLabel('Fund this idea ($)').fill('25');
+  await fp.getByLabel('Pledge an amount').fill('25');
   await fp.getByRole('button', { name: 'Pledge' }).click();
   await expect(fp.locator('aside').getByText(/\$25\.00/).first()).toBeVisible();
 

--- a/e2e/loop.spec.ts
+++ b/e2e/loop.spec.ts
@@ -51,7 +51,7 @@ test('golden loop: post → fund → answer → verify (payout moment) → admin
   const funder = await ctx(browser, ROLES.funder.state);
   const fp = await funder.newPage();
   await fp.goto(ideaUrl);
-  await fp.getByLabel('Fund this idea ($)').fill('50');
+  await fp.getByLabel('Pledge an amount').fill('50');
   await fp.getByRole('button', { name: 'Pledge' }).click();
   await expect(fp.locator('aside').getByText(/\$50\.00/).first()).toBeVisible();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "aisafetyideas",
 			"version": "0.0.1",
 			"dependencies": {
+				"@fontsource-variable/lora": "^5.2.8",
+				"@fontsource-variable/sora": "^5.2.8",
 				"@supabase/ssr": "^0.10.3",
 				"@supabase/supabase-js": "^2.107.0",
 				"marked": "^18.0.5",
@@ -766,6 +768,24 @@
 				"@noble/hashes": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@fontsource-variable/lora": {
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/lora/-/lora-5.2.8.tgz",
+			"integrity": "sha512-cxjTJ9BbOWIzusewR4UMBLVePvTSWV6dtNaNsCkF/oKoyA68fJGWfaYCILOOP1BObE4dmjfZ3xo6m9hdHhtYhg==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fontsource-variable/sora": {
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.2.8.tgz",
+			"integrity": "sha512-sP+ILTfi5r3cqmMBntI4ooQNxFI+LyHyD5hcPbWwwL4uh4kKFAkOz0w2veCXjz18fKRdva6OG0dY+5yQ02f30w==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
 			}
 		},
 		"node_modules/@isaacs/fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 		"vitest": "^4.1.8"
 	},
 	"dependencies": {
+		"@fontsource-variable/lora": "^5.2.8",
+		"@fontsource-variable/sora": "^5.2.8",
 		"@supabase/ssr": "^0.10.3",
 		"@supabase/supabase-js": "^2.107.0",
 		"marked": "^18.0.5",

--- a/src/app.css
+++ b/src/app.css
@@ -99,6 +99,19 @@ h1, h2, h3, h4, h5 { font-family: var(--font-display); color: var(--ink); letter
 .btn-ghost { color: var(--muted); }
 .btn-ghost:hover { color: var(--ink); background: var(--surface-2); }
 
+/* ── Form fields ── */
+.input, .textarea, .select {
+  width: 100%; border: 1px solid var(--line-strong); background: var(--surface); color: var(--ink);
+  border-radius: var(--r-ctrl); padding: .6rem .8rem; font-family: inherit; font-size: .92rem; line-height: 1.4;
+  transition: border-color var(--dur-fast) var(--ease-snappy), box-shadow var(--dur-fast);
+}
+.input::placeholder, .textarea::placeholder { color: var(--faint); }
+.input:focus, .textarea:focus, .select:focus {
+  outline: none; border-color: var(--green);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 20%, transparent);
+}
+.textarea { resize: vertical; min-height: 4.5rem; }
+
 /* ── Card ── */
 .card { background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-card); box-shadow: var(--shadow-1); }
 .card-hover { transition: transform var(--dur-base) var(--ease-snappy), box-shadow var(--dur-base) var(--ease-snappy), border-color var(--dur-base); }

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,7 @@
 @import 'tailwindcss';
+/* Self-hosted brand fonts (CLAUDE.md §1): Sora (display/UI) + Lora (serif accent) */
+@import '@fontsource-variable/sora/index.css';
+@import '@fontsource-variable/lora/index.css';
 
 :root {
   /* Structure & text: greyscale only */
@@ -30,8 +33,104 @@
   --radius-card:16px; --radius-ctrl:12px;
 }
 
-html { font-family: var(--font-display); color: var(--body); background: var(--canvas); }
+html { font-family: var(--font-display); color: var(--body); background: var(--canvas); -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+body { line-height: 1.55; }
 *, *::before, *::after { box-sizing: border-box; }
+
+h1, h2, h3, h4, h5 { font-family: var(--font-display); color: var(--ink); letter-spacing: -0.015em; line-height: 1.1; }
+::selection { background: var(--green); color: var(--ink-2); }
+:focus-visible { outline: 2px solid var(--green); outline-offset: 2px; border-radius: 5px; }
+
+.font-serif { font-family: var(--font-serif); }
+.tnum { font-variant-numeric: tabular-nums; }
+
+/* Span the viewport width from inside the centered .site-main container. */
+.full-bleed { margin-inline: calc(50% - 50vw); }
+
+/* Staggered entrance (set animation-delay inline). Reduced-motion collapses to an instant fade. */
+@keyframes reveal-up { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+.reveal { animation: reveal-up var(--dur-slow) var(--ease-out-soft) both; }
+
+/* ── Texture (CLAUDE.md §1) ── */
+.u-dots { background-image: radial-gradient(var(--line) 1px, transparent 1px); background-size: 22px 22px; }
+.u-dots-strong { background-image: radial-gradient(var(--line-strong) 1px, transparent 1px); background-size: 24px 24px; }
+
+/* ── Tracked uppercase micro-label (the "AVG. CHEQUE SIZE" pattern) ── */
+.u-label { font-size: .7rem; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); font-weight: 600; }
+
+/* ── App shell ── */
+.site { min-height: 100dvh; display: flex; flex-direction: column; }
+.site-main { flex: 1 0 auto; width: 100%; max-width: 72rem; margin-inline: auto; padding: 2.5rem 1.5rem 4rem; }
+
+.site-header { position: sticky; top: 0; z-index: 40; border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--canvas) 82%, transparent); backdrop-filter: saturate(140%) blur(10px); }
+.site-header__inner { max-width: 72rem; margin-inline: auto; padding: .7rem 1.5rem;
+  display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.site-brand { display: inline-flex; align-items: center; gap: .55rem; }
+.site-brand__name { font-family: var(--font-display); font-weight: 700; letter-spacing: -0.02em; color: var(--ink); font-size: 1.02rem; }
+.site-nav { display: flex; align-items: center; gap: 1.1rem; }
+.site-nav__link { color: var(--muted); font-size: .9rem; font-weight: 500; transition: color var(--dur-fast) var(--ease-snappy); }
+.site-nav__link:hover { color: var(--ink); }
+.contents { display: contents; }
+
+.site-footer { border-top: 1px solid var(--line); background: var(--surface-2); }
+.site-footer__inner { max-width: 72rem; margin-inline: auto; padding: 2.5rem 1.5rem;
+  display: grid; gap: 1.25rem; grid-template-columns: 1fr; }
+@media (min-width: 768px) { .site-footer__inner { grid-template-columns: 2fr 1fr; align-items: start; } }
+.site-footer__mission { margin-top: .6rem; max-width: 32rem; color: var(--muted); font-size: .9rem; }
+.site-footer__links { display: flex; flex-wrap: wrap; gap: .35rem 1.1rem; }
+.site-footer__links a { color: var(--body); font-size: .9rem; }
+.site-footer__links a:hover { color: var(--ink); }
+.site-footer__legal { grid-column: 1 / -1; color: var(--faint); font-size: .8rem; border-top: 1px solid var(--line); padding-top: 1.1rem; }
+
+/* ── Buttons (CLAUDE.md §1 & §5): primary = ink pill; secondary = white + hairline ── */
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: .5rem;
+  border-radius: var(--r-pill); padding: .62rem 1.15rem; font-family: var(--font-display);
+  font-weight: 600; font-size: .9rem; line-height: 1; white-space: nowrap; cursor: pointer; border: 1px solid transparent;
+  transition: transform var(--dur-fast) var(--ease-snappy), box-shadow var(--dur-fast) var(--ease-snappy),
+    background var(--dur-fast), border-color var(--dur-fast), color var(--dur-fast); }
+.btn:active { transform: scale(.97); }
+.btn-sm { padding: .42rem .85rem; font-size: .84rem; }
+.btn-lg { padding: .8rem 1.5rem; font-size: 1rem; }
+.btn-primary { background: var(--ink); color: #fff; box-shadow: var(--shadow-1); }
+.btn-primary:hover { background: #000; transform: translateY(-1px); box-shadow: var(--shadow-2); }
+.btn-secondary { background: var(--surface); color: var(--ink); border-color: var(--line-strong); }
+.btn-secondary:hover { border-color: var(--ink); transform: translateY(-1px); box-shadow: var(--shadow-2); }
+.btn-ghost { color: var(--muted); }
+.btn-ghost:hover { color: var(--ink); background: var(--surface-2); }
+
+/* ── Card ── */
+.card { background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-card); box-shadow: var(--shadow-1); }
+.card-hover { transition: transform var(--dur-base) var(--ease-snappy), box-shadow var(--dur-base) var(--ease-snappy), border-color var(--dur-base); }
+.card-hover:hover { transform: translateY(-2px); box-shadow: var(--shadow-3); border-color: var(--line-strong); }
+
+/* ── Chip / tag ── */
+.chip { display: inline-flex; align-items: center; gap: .35rem; border-radius: var(--r-chip);
+  padding: .22rem .55rem; font-size: .72rem; font-weight: 600; line-height: 1; }
+.chip-line { border: 1px solid var(--line-strong); color: var(--muted); background: var(--surface); }
+.chip-open { color: var(--green-deep); background: color-mix(in srgb, var(--green) 13%, transparent); }
+.chip-muted { color: var(--muted); background: var(--surface-2); }
+
+/* ── Score (▲ net upvotes) ── */
+.score { display: inline-flex; align-items: center; gap: .25rem; font-variant-numeric: tabular-nums; font-weight: 700; }
+
+/* ── Progress fill (the "loud green" funding/verify moment, CLAUDE.md §5) ── */
+.meter { height: 8px; border-radius: 999px; background: var(--surface-2); overflow: hidden; border: 1px solid var(--line); }
+.meter__fill { height: 100%; border-radius: 999px; transform-origin: left;
+  background: linear-gradient(90deg, var(--green-deep), var(--green));
+  transition: transform var(--dur-slow) var(--ease-emphasized); }
+
+/* ── Prose (rendered markdown) ── */
+.prose-sm { font-size: .95rem; line-height: 1.7; color: var(--body); }
+.prose-sm :where(h1,h2,h3) { margin: 1.3em 0 .5em; }
+.prose-sm :where(p, ul, ol, blockquote, pre, table) { margin: .7em 0; }
+.prose-sm :where(ul, ol) { padding-left: 1.25em; }
+.prose-sm :where(ul) { list-style: disc; } .prose-sm :where(ol) { list-style: decimal; }
+.prose-sm :where(a) { color: var(--green-deep); text-underline-offset: 2px; text-decoration: underline; }
+.prose-sm :where(code) { font-size: .88em; background: var(--surface-2); padding: .1em .35em; border-radius: 6px; border: 1px solid var(--line); }
+.prose-sm :where(pre) { background: var(--surface-dk); color: var(--on-dark); padding: 1em; border-radius: var(--r-ctrl); overflow-x: auto; }
+.prose-sm :where(pre code) { background: none; border: 0; padding: 0; }
+.prose-sm :where(blockquote) { border-left: 3px solid var(--green); padding-left: 1em; color: var(--muted); font-family: var(--font-serif); font-style: italic; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -14,4 +14,5 @@ declare global {
     // interface Platform {}
   }
 }
+
 export {};

--- a/src/lib/components/AnswerCard.svelte
+++ b/src/lib/components/AnswerCard.svelte
@@ -11,7 +11,7 @@
     }
   } = $props();
 </script>
-<article class="card answer">
+<article class="card answer" id="answer-{answer.id}">
   <div class="answer__head">
     <h3 class="answer__title">{answer.title}</h3>
     <StatusBadge status={answer.status} />

--- a/src/lib/components/AnswerCard.svelte
+++ b/src/lib/components/AnswerCard.svelte
@@ -11,21 +11,39 @@
     }
   } = $props();
 </script>
-<article class="rounded-2xl border p-5" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
-  <div class="mb-1 flex items-center justify-between gap-2">
-    <h3 class="font-bold" style="color:var(--ink)">{answer.title}</h3>
+<article class="card answer">
+  <div class="answer__head">
+    <h3 class="answer__title">{answer.title}</h3>
     <StatusBadge status={answer.status} />
   </div>
-  {#if answer.submitter}<p class="text-sm" style="color:var(--faint)">by {answer.submitter.display_name ?? answer.submitter.handle}</p>{/if}
-  {#if answer.explanation_html}<Markdown html={answer.explanation_html} class="mt-2" />{/if}
+  {#if answer.submitter}<p class="answer__by">by {answer.submitter.display_name ?? answer.submitter.handle}</p>{/if}
+  {#if answer.explanation_html}<Markdown html={answer.explanation_html} class="answer__body" />{/if}
   {#if answer.answer_artifacts?.length}
-    <ul class="mt-3 flex flex-col gap-1 text-sm">
+    <ul class="answer__artifacts">
       {#each answer.answer_artifacts as a (a.id)}
-        <li><a href={a.url} target="_blank" rel="noopener" style="color:var(--green-deep)">{a.label ?? a.kind} ↗</a></li>
+        <li><a href={a.url} target="_blank" rel="noopener">{a.label ?? a.kind}&nbsp;↗</a></li>
       {/each}
     </ul>
   {/if}
   {#if answer.status === 'verified' && answer.payout_amount_cents != null}
-    <p class="mt-3 text-sm" style="color:var(--muted)">Intended payout: <Money cents={answer.payout_amount_cents} /></p>
+    <p class="answer__payout">
+      <span class="u-label">Intended payout</span>
+      <span class="answer__payout-amt tnum"><Money cents={answer.payout_amount_cents} /></span>
+    </p>
   {/if}
 </article>
+<style>
+  .answer { padding: 1.25rem 1.35rem; }
+  .answer__head { display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
+  .answer__title { font-size: 1.05rem; font-weight: 700; color: var(--ink); line-height: 1.3; }
+  .answer__by { margin-top: .25rem; font-size: .82rem; color: var(--faint); }
+  :global(.answer__body) { margin-top: .7rem; }
+  .answer__artifacts { margin-top: .85rem; display: flex; flex-direction: column; gap: .3rem; font-size: .88rem; }
+  .answer__artifacts a { color: var(--green-deep); }
+  .answer__artifacts a:hover { text-decoration: underline; text-underline-offset: 2px; }
+  .answer__payout {
+    margin-top: 1rem; padding-top: .85rem; border-top: 1px solid var(--line);
+    display: flex; align-items: center; justify-content: space-between; gap: .75rem;
+  }
+  .answer__payout-amt { font-weight: 700; color: var(--green-deep); }
+</style>

--- a/src/lib/components/IdeaCard.svelte
+++ b/src/lib/components/IdeaCard.svelte
@@ -1,18 +1,48 @@
 <script lang="ts">
   import StatusBadge from './StatusBadge.svelte';
-  let { idea }: { idea: { id: string; slug: string; title: string; summary_md: string | null; type: string; status: string; score?: number } } = $props();
+  let { idea }: {
+    idea: { id: string; slug: string; title: string; summary_md: string | null; type: string; status: string; score?: number };
+  } = $props();
 </script>
-<a href="/ideas/{idea.slug}" class="block rounded-2xl border p-5 transition"
-   style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
-  <div class="mb-2 flex items-center justify-between gap-2">
-    <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
-    <span class="flex items-center gap-2">
-      {#if typeof idea.score === 'number'}
-        <span class="text-xs font-semibold tabular-nums" style="color:var(--muted)">▲ {idea.score}</span>
-      {/if}
-      <StatusBadge status={idea.status} />
-    </span>
+<a href="/ideas/{idea.slug}" class="card card-hover idea">
+  <div class="idea__top">
+    <span class="u-label">{idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
+    <StatusBadge status={idea.status} />
   </div>
-  <h3 class="font-bold" style="color:var(--ink)">{idea.title}</h3>
-  {#if idea.summary_md}<p class="mt-1 line-clamp-2 text-sm" style="color:var(--muted)">{idea.summary_md}</p>{/if}
+  <h3 class="idea__title">{idea.title}</h3>
+  {#if idea.summary_md}<p class="idea__summary">{idea.summary_md}</p>{/if}
+  <div class="idea__foot">
+    <span class="score" title="Net votes">
+      <span class="score__caret" aria-hidden="true">▲</span>
+      <span class="tnum">{idea.score ?? 0}</span>
+      <span class="idea__foot-label">net votes</span>
+    </span>
+    <span class="idea__go" aria-hidden="true">→</span>
+  </div>
 </a>
+<style>
+  .idea { display: flex; flex-direction: column; padding: 1.35rem; height: 100%; position: relative; }
+  /* thin green accent edge on hover (CLAUDE.md §5 cards) */
+  .idea::after {
+    content: ''; position: absolute; inset: 0; border-radius: var(--r-card); pointer-events: none;
+    box-shadow: inset 0 0 0 1.5px transparent; transition: box-shadow var(--dur-base) var(--ease-snappy);
+  }
+  .idea:hover::after { box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--green) 60%, transparent); }
+
+  .idea__top { display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
+  .idea__title { margin-top: .85rem; font-size: 1.08rem; font-weight: 700; color: var(--ink); line-height: 1.3; letter-spacing: -0.01em; }
+  .idea__summary {
+    margin-top: .5rem; color: var(--muted); font-size: .9rem; line-height: 1.55;
+    display: -webkit-box; -webkit-line-clamp: 3; line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  /* margin-top:auto pins the foot to the bottom so cards in a row align (and short cards get a gap) */
+  .idea__foot {
+    margin-top: auto; padding-top: 1rem; border-top: 1px solid var(--line);
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .score { display: inline-flex; align-items: baseline; gap: .35rem; font-weight: 700; color: var(--ink); }
+  .score__caret { color: var(--green-deep); font-size: .8em; }
+  .idea__foot-label { font-size: .75rem; font-weight: 500; color: var(--faint); margin-left: .15rem; }
+  .idea__go { color: var(--faint); transition: transform var(--dur-fast) var(--ease-snappy), color var(--dur-fast); }
+  .idea:hover .idea__go { color: var(--ink); transform: translateX(3px); }
+</style>

--- a/src/lib/components/IdeaCard.svelte
+++ b/src/lib/components/IdeaCard.svelte
@@ -1,48 +1,80 @@
 <script lang="ts">
   import StatusBadge from './StatusBadge.svelte';
+  // mirrors $lib/server/idea-feed#IdeaListItem (kept inline so this client component never imports a $lib/server module)
   let { idea }: {
-    idea: { id: string; slug: string; title: string; summary_md: string | null; type: string; status: string; score?: number };
+    idea: {
+      id: string; slug: string; title: string; summary_md: string | null; type: string; status: string;
+      score?: number; answerCount?: number; commentCount?: number; verified?: { id: string; title: string } | null;
+    };
   } = $props();
 </script>
-<a href="/ideas/{idea.slug}" class="card card-hover idea">
+<article class="card card-hover idea">
   <div class="idea__top">
     <span class="u-label">{idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
     <StatusBadge status={idea.status} />
   </div>
-  <h3 class="idea__title">{idea.title}</h3>
+
+  <h3 class="idea__title">
+    <!-- stretched link: whole card → idea; sits below the verified sub-link's z-index -->
+    <a class="idea__link" href="/ideas/{idea.slug}">{idea.title}</a>
+  </h3>
   {#if idea.summary_md}<p class="idea__summary">{idea.summary_md}</p>{/if}
-  <div class="idea__foot">
-    <span class="score" title="Net votes">
-      <span class="score__caret" aria-hidden="true">▲</span>
-      <span class="tnum">{idea.score ?? 0}</span>
-      <span class="idea__foot-label">net votes</span>
-    </span>
-    <span class="idea__go" aria-hidden="true">→</span>
-  </div>
-</a>
+
+  {#if typeof idea.score === 'number' || idea.answerCount !== undefined}
+    <div class="idea__stats">
+      {#if typeof idea.score === 'number'}
+        <span class="score" title="Net votes"><span class="score__caret" aria-hidden="true">▲</span><span class="tnum">{idea.score}</span></span>
+      {/if}
+      {#if idea.answerCount !== undefined}
+        <span class="idea__stat" title="Answers"><span class="tnum">{idea.answerCount}</span> {idea.answerCount === 1 ? 'answer' : 'answers'}</span>
+        <span class="idea__stat" title="Comments"><span class="tnum">{idea.commentCount ?? 0}</span> {idea.commentCount === 1 ? 'comment' : 'comments'}</span>
+      {/if}
+    </div>
+  {/if}
+
+  {#if idea.verified}
+    <a class="idea__verified" href="/ideas/{idea.slug}#answer-{idea.verified.id}">
+      <span class="idea__verified-tick" aria-hidden="true">✓</span>
+      <span class="idea__verified-label">Verified solution</span>
+      <span class="idea__verified-title">{idea.verified.title}</span>
+    </a>
+  {/if}
+</article>
 <style>
-  .idea { display: flex; flex-direction: column; padding: 1.35rem; height: 100%; position: relative; }
-  /* thin green accent edge on hover (CLAUDE.md §5 cards) */
-  .idea::after {
+  .idea { position: relative; display: flex; flex-direction: column; padding: 1.35rem; height: 100%; }
+  .idea::after { /* green accent edge on hover */
     content: ''; position: absolute; inset: 0; border-radius: var(--r-card); pointer-events: none;
     box-shadow: inset 0 0 0 1.5px transparent; transition: box-shadow var(--dur-base) var(--ease-snappy);
   }
   .idea:hover::after { box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--green) 60%, transparent); }
 
   .idea__top { display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
-  .idea__title { margin-top: .85rem; font-size: 1.08rem; font-weight: 700; color: var(--ink); line-height: 1.3; letter-spacing: -0.01em; }
+  .idea__title { margin-top: .85rem; font-size: 1.08rem; font-weight: 700; line-height: 1.3; letter-spacing: -0.01em; }
+  .idea__link { color: var(--ink); }
+  .idea__link::after { content: ''; position: absolute; inset: 0; z-index: 0; border-radius: var(--r-card); }
+  .idea:hover .idea__link { color: var(--green-deep); }
   .idea__summary {
     margin-top: .5rem; color: var(--muted); font-size: .9rem; line-height: 1.55;
-    display: -webkit-box; -webkit-line-clamp: 3; line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+    display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
   }
-  /* margin-top:auto pins the foot to the bottom so cards in a row align (and short cards get a gap) */
-  .idea__foot {
-    margin-top: auto; padding-top: 1rem; border-top: 1px solid var(--line);
-    display: flex; align-items: center; justify-content: space-between;
+
+  .idea__stats { margin-top: auto; padding-top: .9rem; border-top: 1px solid var(--line);
+    display: flex; align-items: center; gap: .9rem; font-size: .82rem; color: var(--muted); }
+  .score { display: inline-flex; align-items: center; gap: .25rem; font-weight: 700; color: var(--ink); }
+  .score__caret { color: var(--green-deep); font-size: .82em; }
+  .idea__stat { white-space: nowrap; }
+  .idea__stat .tnum { color: var(--body); font-weight: 600; }
+
+  /* verified solution strip — sits above the stretched link so it's independently clickable */
+  .idea__verified {
+    position: relative; z-index: 1; margin-top: .85rem; display: flex; align-items: center; gap: .4rem;
+    padding: .55rem .7rem; border-radius: var(--r-chip); font-size: .82rem;
+    background: color-mix(in srgb, var(--green) 9%, transparent);
+    border: 1px solid color-mix(in srgb, var(--green) 30%, transparent);
+    transition: background var(--dur-fast) var(--ease-snappy);
   }
-  .score { display: inline-flex; align-items: baseline; gap: .35rem; font-weight: 700; color: var(--ink); }
-  .score__caret { color: var(--green-deep); font-size: .8em; }
-  .idea__foot-label { font-size: .75rem; font-weight: 500; color: var(--faint); margin-left: .15rem; }
-  .idea__go { color: var(--faint); transition: transform var(--dur-fast) var(--ease-snappy), color var(--dur-fast); }
-  .idea:hover .idea__go { color: var(--ink); transform: translateX(3px); }
+  .idea__verified:hover { background: color-mix(in srgb, var(--green) 16%, transparent); }
+  .idea__verified-tick { flex: none; color: var(--green-deep); font-weight: 800; }
+  .idea__verified-label { flex: none; font-weight: 700; color: var(--green-deep); }
+  .idea__verified-title { color: var(--body); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // Brand mark: a small static version of the brand orb (the one sanctioned green surface).
+  // Pairs with the Sora wordmark in the header/footer.
+  let { size = 26 }: { size?: number } = $props();
+</script>
+<span class="logo" style="width:{size}px; height:{size}px" aria-hidden="true"></span>
+<style>
+  .logo {
+    flex: none;
+    border-radius: 9999px;
+    background: radial-gradient(circle at 34% 30%, var(--green-bright), var(--green) 45%, var(--green-deep) 100%);
+    box-shadow: 0 2px 8px -1px rgba(28, 219, 114, 0.5), inset 0 -2px 5px rgba(20, 24, 22, 0.22);
+  }
+</style>

--- a/src/lib/components/SkeletonCard.svelte
+++ b/src/lib/components/SkeletonCard.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  // Calm greyscale shimmer placeholder mirroring IdeaCard's shape (CLAUDE.md: skeletons over
+  // spinners for content). Shimmer becomes a static tint under reduced motion.
+</script>
+<div class="card sk" aria-hidden="true">
+  <div class="sk__row">
+    <span class="sk__bar" style="width:5.5rem"></span>
+    <span class="sk__bar" style="width:3.5rem"></span>
+  </div>
+  <span class="sk__bar sk__title" style="width:85%"></span>
+  <span class="sk__bar" style="width:95%"></span>
+  <span class="sk__bar" style="width:70%"></span>
+  <div class="sk__foot"><span class="sk__bar" style="width:4rem"></span></div>
+</div>
+<style>
+  .sk { display: flex; flex-direction: column; gap: .7rem; padding: 1.35rem; height: 100%; }
+  .sk__row { display: flex; justify-content: space-between; }
+  .sk__bar {
+    height: .72rem; border-radius: 6px;
+    background: linear-gradient(90deg, var(--surface-2) 0%, color-mix(in srgb, var(--line-strong) 60%, var(--surface-2)) 50%, var(--surface-2) 100%);
+    background-size: 200% 100%; animation: shimmer 1.3s var(--ease-in-out) infinite;
+  }
+  .sk__title { height: 1.15rem; margin-top: .35rem; }
+  .sk__foot { margin-top: auto; padding-top: 1rem; border-top: 1px solid var(--line); }
+  @keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+  @media (prefers-reduced-motion: reduce) { .sk__bar { animation: none; background: var(--surface-2); } }
+</style>

--- a/src/lib/components/Spinner.svelte
+++ b/src/lib/components/Spinner.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // Greyscale inline spinner for ≤1s actions (infinite-scroll fetch). Reduced-motion → static ring.
+  let { size = 18, label = 'Loading' }: { size?: number; label?: string } = $props();
+</script>
+<span class="spinner" style="width:{size}px; height:{size}px" role="status" aria-label={label}></span>
+<style>
+  .spinner {
+    display: inline-block; border-radius: 9999px;
+    border: 2px solid var(--line-strong); border-top-color: var(--muted);
+    animation: spin .7s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+</style>

--- a/src/lib/components/StatusBadge.svelte
+++ b/src/lib/components/StatusBadge.svelte
@@ -9,12 +9,22 @@
     open: 'accent', resolved: 'accent', verified: 'accent',
     rejected: 'neg', revision_requested: 'warn'
   };
-  const t = $derived(tone[status]);
+  let t = $derived(tone[status] ?? 'neutral');
 </script>
-<span class="rounded-full px-2 py-0.5 text-xs font-medium"
-      style="border:1px solid var(--line); color:var(--muted);
-             {t === 'accent' ? 'color:var(--green-deep); border-color:var(--green);' : ''}
-             {t === 'neg' ? 'color:var(--neg); border-color:var(--neg);' : ''}
-             {t === 'warn' ? 'color:var(--warn); border-color:var(--warn);' : ''}">
-  {label[status] ?? status}
-</span>
+<span class="badge" data-tone={t}>{label[status] ?? status}</span>
+<style>
+  .badge {
+    display: inline-flex; align-items: center; border-radius: var(--r-chip);
+    padding: .22rem .55rem; font-size: .72rem; font-weight: 600; line-height: 1; white-space: nowrap;
+    border: 1px solid var(--line-strong); color: var(--muted); background: var(--surface);
+  }
+  .badge[data-tone='accent'] { color: var(--green-deep);
+    border-color: color-mix(in srgb, var(--green) 55%, transparent);
+    background: color-mix(in srgb, var(--green) 10%, transparent); }
+  .badge[data-tone='neg'] { color: var(--neg);
+    border-color: color-mix(in srgb, var(--neg) 45%, transparent);
+    background: color-mix(in srgb, var(--neg) 8%, transparent); }
+  .badge[data-tone='warn'] { color: var(--warn);
+    border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+    background: color-mix(in srgb, var(--warn) 8%, transparent); }
+</style>

--- a/src/lib/server/idea-feed.ts
+++ b/src/lib/server/idea-feed.ts
@@ -12,6 +12,7 @@ export function parseSort(value: string | null): IdeaSort {
 /** Statuses never shown in public listings: drafts (unpublished) and archived (admin-hidden). */
 const HIDDEN_STATUSES = '(draft,archived)';
 
+export type VerifiedSolution = { id: string; title: string };
 export type IdeaListItem = {
   id: string;
   slug: string;
@@ -21,7 +22,40 @@ export type IdeaListItem = {
   status: string;
   created_at: string | null;
   score: number;
+  answerCount: number;
+  commentCount: number;
+  verified: VerifiedSolution | null;
 };
+
+/**
+ * Attach per-card engagement stats (answers, comments, first verified solution) to a page of ideas.
+ * Two small reads keyed by the page's idea ids — RLS governs visibility (same as the detail page).
+ */
+async function enrichCards(
+  supabase: SupabaseClient,
+  ideas: (Record<string, unknown> & { id: string; score: number })[]
+): Promise<IdeaListItem[]> {
+  if (!ideas.length) return ideas as IdeaListItem[];
+  const ids = ideas.map((i) => i.id);
+  const [{ data: answers }, { data: comments }] = await Promise.all([
+    supabase.from('answers').select('idea_id, id, title, status').in('idea_id', ids),
+    supabase.from('comments').select('idea_id').in('idea_id', ids)
+  ]);
+
+  const stats = new Map<string, { answerCount: number; commentCount: number; verified: VerifiedSolution | null }>();
+  for (const id of ids) stats.set(id, { answerCount: 0, commentCount: 0, verified: null });
+  for (const a of (answers ?? []) as { idea_id: string; id: string; title: string; status: string }[]) {
+    const s = stats.get(a.idea_id);
+    if (!s) continue;
+    s.answerCount++;
+    if (a.status === 'verified' && !s.verified) s.verified = { id: a.id, title: a.title };
+  }
+  for (const c of (comments ?? []) as { idea_id: string }[]) {
+    const s = stats.get(c.idea_id);
+    if (s) s.commentCount++;
+  }
+  return ideas.map((i) => ({ ...i, ...stats.get(i.id)! })) as IdeaListItem[];
+}
 
 export type IdeaFeedPage = {
   ideas: IdeaListItem[];
@@ -58,10 +92,10 @@ export async function loadIdeaFeed(
 
   if (opts.sort === 'top') {
     const { data: all } = await base.order('created_at', { ascending: false });
-    const ranked = sortTop(attachScores(all ?? [], totals)) as IdeaListItem[];
+    const ranked = sortTop(attachScores(all ?? [], totals));
     const start = page * PAGE_SIZE;
     return {
-      ideas: ranked.slice(start, start + PAGE_SIZE),
+      ideas: await enrichCards(supabase, ranked.slice(start, start + PAGE_SIZE)),
       count: ranked.length,
       page,
       pageSize: PAGE_SIZE,
@@ -74,7 +108,7 @@ export async function loadIdeaFeed(
     .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
   const total = count ?? 0;
   return {
-    ideas: attachScores(ideas ?? [], totals) as IdeaListItem[],
+    ideas: await enrichCards(supabase, attachScores(ideas ?? [], totals)),
     count: total,
     page,
     pageSize: PAGE_SIZE,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import '../app.css';
   import { invalidate } from '$app/navigation';
   import { onMount } from 'svelte';
+  import Logo from '$lib/components/Logo.svelte';
   let { data, children } = $props();
   let supabase = $derived(data.supabase);
 
@@ -13,17 +14,47 @@
   });
 </script>
 
-<header class="flex items-center justify-between border-b px-6 py-3"
-        style="border-color:var(--line)">
-  <a href="/" class="font-bold" style="color:var(--ink)">AI Safety Ideas</a>
-  <nav class="flex gap-4" style="color:var(--muted)">
-    {#if data.user}
-      <a href="/dashboard">Dashboard</a>
-      <form method="POST" action="/logout"><button type="submit">Sign out</button></form>
-    {:else}
-      <a href="/login">Sign in</a>
-    {/if}
-  </nav>
-</header>
+<div class="site">
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a href="/" class="site-brand" aria-label="AI Safety Ideas — home">
+        <Logo size={26} />
+        <span class="site-brand__name">AI&nbsp;Safety&nbsp;Ideas</span>
+      </a>
+      <nav class="site-nav">
+        <a href="/ideas" class="site-nav__link">Ideas</a>
+        <a href="/experts" class="site-nav__link">Experts</a>
+        {#if data.user}
+          <a href="/dashboard" class="site-nav__link">Dashboard</a>
+          <form method="POST" action="/logout" class="contents">
+            <button type="submit" class="btn btn-secondary btn-sm">Sign out</button>
+          </form>
+        {:else}
+          <a href="/login" class="btn btn-primary btn-sm">Sign in</a>
+        {/if}
+      </nav>
+    </div>
+  </header>
 
-<main class="mx-auto max-w-5xl p-6">{@render children()}</main>
+  <main class="site-main">{@render children()}</main>
+
+  <footer class="site-footer">
+    <div class="site-footer__inner">
+      <div class="site-footer__brand">
+        <a href="/" class="site-brand"><Logo size={22} /><span class="site-brand__name">AI&nbsp;Safety&nbsp;Ideas</span></a>
+        <p class="site-footer__mission">
+          A charitable research-bounty platform — experts post the open questions in AI safety,
+          funders back them, researchers answer.
+        </p>
+      </div>
+      <nav class="site-footer__links" aria-label="Footer">
+        <a href="/ideas">Browse ideas</a>
+        <a href="/experts">Experts</a>
+        <a href="/login">Sign in</a>
+      </nav>
+      <p class="site-footer__legal">
+        Donations support a 501(c)(3) charitable mission. © {new Date().getFullYear()} AI Safety Ideas.
+      </p>
+    </div>
+  </footer>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
     <div class="site-header__inner">
       <a href="/" class="site-brand" aria-label="AI Safety Ideas — home">
         <Logo size={26} />
-        <span class="site-brand__name">AI&nbsp;Safety&nbsp;Ideas</span>
+        <span class="site-brand__name">AISI</span>
       </a>
       <nav class="site-nav">
         <a href="/ideas" class="site-nav__link">Ideas</a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,80 +2,161 @@
   import Orb from '$lib/components/Orb.svelte';
   import IdeaCard from '$lib/components/IdeaCard.svelte';
   let { data } = $props();
+
   const steps = [
     { n: '01', t: 'Experts post ideas', d: 'Vetted researchers publish concrete AI-safety questions and hypotheses worth investigating.' },
-    { n: '02', t: 'Funders back them', d: 'Supporters pledge toward the ideas they want answered — building a transparent bounty.' },
+    { n: '02', t: 'Funders back them', d: 'Supporters pledge toward the questions they want answered — building a transparent bounty.' },
     { n: '03', t: 'Researchers answer', d: 'Anyone can submit an answer with evidence and artifacts — code, papers, notebooks.' },
     { n: '04', t: 'Verified payouts', d: 'The author verifies a result and the payout is recorded — a clear path from question to impact.' }
   ];
 </script>
 
-<!-- Hero -->
-<section class="relative -mx-6 -mt-6 overflow-hidden px-6 py-20"
-         style="background-image: radial-gradient(var(--line) 1px, transparent 1px); background-size: 22px 22px;">
-  <div class="mx-auto grid max-w-5xl items-center gap-10 md:grid-cols-[1.4fr_1fr]">
-    <div>
-      <h1 class="text-4xl font-bold leading-tight md:text-5xl" style="color:var(--ink)">
+<!-- ── Hero ── -->
+<section class="full-bleed hero">
+  <div class="hero__inner">
+    <div class="hero__copy">
+      <span class="u-label reveal" style="animation-delay:40ms">Charitable research bounties · AI safety</span>
+      <h1 class="hero__title reveal" style="animation-delay:90ms">
         Fund the AI safety research that matters.
       </h1>
-      <p class="mt-5 max-w-xl text-lg" style="font-family:var(--font-serif); color:var(--body)">
-        Experts post research bounties, funders back them, and researchers submit answers. When an
-        author verifies a result, the payout is recorded — a transparent path from open question to impact.
+      <p class="hero__lede font-serif reveal" style="animation-delay:150ms">
+        Experts post the open questions. Funders back the ones worth answering. Researchers
+        submit evidence — and when an author verifies a result, the payout is recorded.
+        A transparent path from open question to real impact.
       </p>
-      <div class="mt-8 flex flex-wrap gap-3">
-        <a href="/ideas" class="rounded-xl px-5 py-2.5 font-medium" style="background:var(--ink); color:#fff">Browse ideas</a>
-        <a href={data.signedIn ? '/dashboard' : '/login'}
-           class="rounded-xl border px-5 py-2.5 font-medium" style="border-color:var(--line-strong); color:var(--ink)">
+      <div class="hero__cta reveal" style="animation-delay:210ms">
+        <a href="/ideas" class="btn btn-primary btn-lg">Browse ideas</a>
+        <a href={data.signedIn ? '/dashboard' : '/login'} class="btn btn-secondary btn-lg">
           {data.signedIn ? 'Your dashboard' : 'Sign in'}
         </a>
       </div>
       {#if data.ideaCount > 0}
-        <p class="mt-6 text-sm tabular-nums" style="color:var(--faint)">
-          {data.ideaCount} open {data.ideaCount === 1 ? 'idea' : 'ideas'}{#if data.expertCount > 0} · {data.expertCount} {data.expertCount === 1 ? 'expert' : 'experts'}{/if}
-        </p>
+        <dl class="hero__stats reveal" style="animation-delay:280ms">
+          <div>
+            <dt class="u-label">Open ideas</dt>
+            <dd class="hero__stat tnum">{data.ideaCount.toLocaleString()}</dd>
+          </div>
+          {#if data.expertCount > 0}
+            <div>
+              <dt class="u-label">Vetted experts</dt>
+              <dd class="hero__stat tnum">{data.expertCount.toLocaleString()}</dd>
+            </div>
+          {/if}
+        </dl>
       {/if}
     </div>
-    <div class="flex justify-center md:justify-end"><Orb size={210} /></div>
+    <div class="hero__orb reveal" style="animation-delay:120ms"><Orb size={230} /></div>
   </div>
 </section>
 
-<!-- How it works -->
-<section class="mx-auto mt-16 max-w-5xl">
-  <h2 class="mb-6 text-xs font-medium uppercase tracking-[.06em]" style="color:var(--faint)">How it works</h2>
-  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+<!-- ── How it works ── -->
+<section class="section">
+  <h2 class="u-label section__eyebrow">How it works</h2>
+  <ol class="steps">
     {#each steps as s (s.n)}
-      <div class="rounded-2xl border p-5" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
-        <span class="text-sm font-bold tabular-nums" style="color:var(--green-deep)">{s.n}</span>
-        <h3 class="mt-2 font-bold" style="color:var(--ink)">{s.t}</h3>
-        <p class="mt-1 text-sm" style="color:var(--muted)">{s.d}</p>
-      </div>
+      <li class="card card-hover step">
+        <span class="step__n tnum">{s.n}</span>
+        <h3 class="step__t">{s.t}</h3>
+        <p class="step__d">{s.d}</p>
+      </li>
     {/each}
-  </div>
+  </ol>
 </section>
 
-<!-- Recent bounties (degrades: hidden when empty) -->
+<!-- ── Recent bounties (degrades: hidden when empty) ── -->
 {#if data.recent.length}
-  <section class="mx-auto mt-16 max-w-5xl">
-    <div class="mb-4 flex items-baseline justify-between">
-      <h2 class="text-xl font-bold" style="color:var(--ink)">Recent bounties</h2>
-      <a href="/ideas" style="color:var(--green-deep)">Browse all →</a>
+  <section class="section">
+    <div class="section__head">
+      <h2 class="section__title">Recent bounties</h2>
+      <a href="/ideas" class="section__more">Browse all&nbsp;→</a>
     </div>
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
       {#each data.recent as idea (idea.id)}<IdeaCard {idea} />{/each}
     </div>
   </section>
 {/if}
 
-<!-- Closing CTA -->
-<section class="mx-auto mt-16 max-w-5xl rounded-2xl border p-8 text-center"
-         style="border-color:var(--line); background:var(--surface-2)">
-  <h2 class="text-2xl font-bold" style="color:var(--ink)">Back the questions that move AI safety forward.</h2>
-  <p class="mx-auto mt-2 max-w-xl" style="color:var(--muted)">
-    Donations support a 501(c)(3) charitable mission; funds are recorded as intended payouts to the
-    researchers whose answers are verified.
-  </p>
-  <div class="mt-5 flex justify-center gap-3">
-    <a href="/ideas" class="rounded-xl px-5 py-2.5 font-medium" style="background:var(--ink); color:#fff">Explore the bounties</a>
-    <a href="/experts" class="rounded-xl border px-5 py-2.5 font-medium" style="border-color:var(--line-strong); color:var(--ink)">Meet the experts</a>
+<!-- ── Closing CTA (rare neutral-dark panel; green stays an accent) ── -->
+<section class="section">
+  <div class="closing">
+    <div class="closing__orb"><Orb size={120} /></div>
+    <h2 class="closing__title">Back the questions that move AI safety forward.</h2>
+    <p class="closing__lede">
+      Donations support a 501(c)(3) charitable mission; funds are recorded as intended payouts
+      to the researchers whose answers are verified.
+    </p>
+    <div class="closing__cta">
+      <a href="/ideas" class="btn btn-lg closing__primary">Explore the bounties</a>
+      <a href="/experts" class="btn btn-lg closing__ghost">Meet the experts</a>
+    </div>
   </div>
 </section>
+
+<style>
+  /* Hero */
+  .hero {
+    margin-top: -2.5rem; /* sit flush under the sticky header (cancels .site-main top padding) */
+    background: var(--canvas);
+    background-image: radial-gradient(var(--line) 1px, transparent 1px);
+    background-size: 22px 22px;
+    border-bottom: 1px solid var(--line);
+    position: relative;
+    overflow: hidden;
+  }
+  .hero::before { /* soft green atmosphere bleeding from the orb side */
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background: radial-gradient(60% 70% at 88% 22%, rgba(68, 255, 152, 0.14), transparent 70%);
+  }
+  .hero__inner {
+    position: relative; max-width: 72rem; margin-inline: auto;
+    padding: clamp(3.5rem, 8vw, 6rem) 1.5rem clamp(3rem, 6vw, 5rem);
+    display: grid; gap: 2.5rem; align-items: center;
+  }
+  @media (min-width: 900px) { .hero__inner { grid-template-columns: 1.45fr 1fr; } }
+  .hero__title {
+    margin-top: 1rem; font-size: clamp(2.4rem, 5.4vw, 3.9rem); font-weight: 700;
+    letter-spacing: -0.03em; line-height: 1.02; color: var(--ink); max-width: 16ch;
+  }
+  .hero__lede { margin-top: 1.25rem; max-width: 36rem; font-size: clamp(1.05rem, 1.6vw, 1.2rem); color: var(--body); line-height: 1.6; }
+  .hero__cta { margin-top: 1.9rem; display: flex; flex-wrap: wrap; gap: .7rem; }
+  .hero__stats { margin-top: 2.4rem; display: flex; gap: 2.75rem; }
+  .hero__stat { font-size: 1.9rem; font-weight: 700; color: var(--ink); letter-spacing: -0.02em; margin-top: .15rem; }
+  .hero__orb { display: flex; justify-content: center; }
+  @media (min-width: 900px) { .hero__orb { justify-content: flex-end; } }
+
+  /* Sections */
+  .section { max-width: 72rem; margin: clamp(3.5rem, 7vw, 5.5rem) auto 0; }
+  .section__eyebrow { margin-bottom: 1.5rem; }
+  .section__head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.5rem; gap: 1rem; }
+  .section__title { font-size: 1.5rem; font-weight: 700; }
+  .section__more { color: var(--green-deep); font-weight: 600; font-size: .92rem; white-space: nowrap; }
+  .section__more:hover { color: var(--green-deep); text-decoration: underline; text-underline-offset: 3px; }
+
+  /* Steps */
+  .steps { display: grid; gap: 1.1rem; grid-template-columns: 1fr; list-style: none; }
+  @media (min-width: 640px) { .steps { grid-template-columns: repeat(2, 1fr); } }
+  @media (min-width: 1024px) { .steps { grid-template-columns: repeat(4, 1fr); } }
+  .step { padding: 1.4rem; }
+  .step__n { font-size: .85rem; font-weight: 700; color: var(--green-deep); letter-spacing: .05em; }
+  .step__t { margin-top: .7rem; font-size: 1.02rem; font-weight: 700; color: var(--ink); }
+  .step__d { margin-top: .4rem; font-size: .9rem; color: var(--muted); line-height: 1.55; }
+
+  /* Closing */
+  .closing {
+    position: relative; overflow: hidden;
+    background: var(--surface-dk); color: var(--on-dark);
+    border-radius: var(--r-card); padding: clamp(2.5rem, 5vw, 4rem) 1.5rem; text-align: center;
+  }
+  .closing::before {
+    content: ''; position: absolute; inset: 0; pointer-events: none; opacity: .5;
+    background: radial-gradient(50% 80% at 50% -10%, rgba(68, 255, 152, 0.18), transparent 70%);
+  }
+  .closing__orb { position: relative; display: flex; justify-content: center; margin-bottom: 1.4rem; opacity: .95; }
+  .closing__title { position: relative; font-size: clamp(1.6rem, 3.2vw, 2.2rem); font-weight: 700; color: #fff; letter-spacing: -0.02em; max-width: 22ch; margin-inline: auto; }
+  .closing__lede { position: relative; margin: .9rem auto 0; max-width: 40rem; color: rgba(245, 246, 245, 0.72); font-size: .98rem; line-height: 1.6; }
+  .closing__cta { position: relative; margin-top: 1.9rem; display: flex; flex-wrap: wrap; gap: .7rem; justify-content: center; }
+  .closing__primary { background: #fff; color: var(--ink); }
+  .closing__primary:hover { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(0,0,0,.3); }
+  .closing__ghost { color: var(--on-dark); border-color: rgba(245, 246, 245, 0.25); }
+  .closing__ghost:hover { border-color: rgba(245, 246, 245, 0.6); transform: translateY(-1px); }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 
   const steps = [
     { n: '01', t: 'Experts post ideas', d: 'Vetted researchers publish concrete AI-safety questions and hypotheses worth investigating.' },
-    { n: '02', t: 'Funders back them', d: 'Supporters pledge toward the questions they want answered — building a transparent bounty.' },
+    { n: '02', t: 'Funders back them', d: 'Supporters pledge toward the questions they want answered — building transparent, pooled support.' },
     { n: '03', t: 'Researchers answer', d: 'Anyone can submit an answer with evidence and artifacts — code, papers, notebooks.' },
     { n: '04', t: 'Verified payouts', d: 'The author verifies a result and the payout is recorded — a clear path from question to impact.' }
   ];
@@ -15,7 +15,7 @@
 <section class="full-bleed hero">
   <div class="hero__inner">
     <div class="hero__copy">
-      <span class="u-label reveal" style="animation-delay:40ms">Charitable research bounties · AI safety</span>
+      <span class="u-label reveal" style="animation-delay:40ms">Charitable research · AI safety</span>
       <h1 class="hero__title reveal" style="animation-delay:90ms">
         Fund the AI safety research that matters.
       </h1>
@@ -63,11 +63,11 @@
   </ol>
 </section>
 
-<!-- ── Recent bounties (degrades: hidden when empty) ── -->
+<!-- ── Recent ideas (degrades: hidden when empty) ── -->
 {#if data.recent.length}
   <section class="section">
     <div class="section__head">
-      <h2 class="section__title">Recent bounties</h2>
+      <h2 class="section__title">Recent ideas</h2>
       <a href="/ideas" class="section__more">Browse all&nbsp;→</a>
     </div>
     <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
@@ -86,7 +86,7 @@
       to the researchers whose answers are verified.
     </p>
     <div class="closing__cta">
-      <a href="/ideas" class="btn btn-lg closing__primary">Explore the bounties</a>
+      <a href="/ideas" class="btn btn-lg closing__primary">Explore the ideas</a>
       <a href="/experts" class="btn btn-lg closing__ghost">Meet the experts</a>
     </div>
   </div>

--- a/src/routes/ideas/+page.svelte
+++ b/src/routes/ideas/+page.svelte
@@ -69,38 +69,67 @@
   });
 </script>
 
-<h1 class="mb-4 text-2xl font-bold" style="color:var(--ink)">Ideas</h1>
-<nav class="mb-6 flex gap-2 text-sm">
-  <a href={buildHref(null, data.sort)} style="color:{data.type ? 'var(--muted)' : 'var(--green-deep)'}">All</a>
-  <a href={buildHref('hypothesis', data.sort)} style="color:{data.type === 'hypothesis' ? 'var(--green-deep)' : 'var(--muted)'}">Hypotheses</a>
-  <a href={buildHref('open_ended', data.sort)} style="color:{data.type === 'open_ended' ? 'var(--green-deep)' : 'var(--muted)'}">Open-ended</a>
-</nav>
-<nav class="mb-6 -mt-4 flex gap-2 text-sm">
-  <a href={buildHref(data.type, 'top')} style="color:{data.sort === 'top' ? 'var(--green-deep)' : 'var(--muted)'}">Top</a>
-  <a href={buildHref(data.type, 'new')} style="color:{data.sort === 'new' ? 'var(--green-deep)' : 'var(--muted)'}">Newest</a>
-</nav>
+<header class="ideas-head">
+  <div>
+    <span class="u-label">Research bounties</span>
+    <h1 class="ideas-title">Ideas</h1>
+  </div>
+  <p class="ideas-count tnum">{data.count.toLocaleString()} open</p>
+</header>
+
+<div class="ideas-controls">
+  <div class="seg" role="tablist" aria-label="Filter by type">
+    <a class="seg__item" aria-current={!data.type} href={buildHref(null, data.sort)}>All</a>
+    <a class="seg__item" aria-current={data.type === 'hypothesis'} href={buildHref('hypothesis', data.sort)}>Hypotheses</a>
+    <a class="seg__item" aria-current={data.type === 'open_ended'} href={buildHref('open_ended', data.sort)}>Open-ended</a>
+  </div>
+  <div class="seg" role="tablist" aria-label="Sort">
+    <a class="seg__item" aria-current={data.sort === 'top'} href={buildHref(data.type, 'top')}>Top</a>
+    <a class="seg__item" aria-current={data.sort === 'new'} href={buildHref(data.type, 'new')}>Newest</a>
+  </div>
+</div>
 
 {#if ideas.length === 0}
-  <p style="color:var(--muted)">No ideas yet.</p>
+  <div class="ideas-empty card">
+    <p>No ideas here yet.</p>
+    {#if data.type}<a class="btn btn-secondary btn-sm" href={buildHref(null, data.sort)}>Clear filter</a>{/if}
+  </div>
 {:else}
-  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+  <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
     {#each ideas as idea (idea.id)}<IdeaCard {idea} />{/each}
   </div>
 
-  <!-- sentinel + status row -->
-  <div class="mt-8 flex flex-col items-center gap-3">
+  <div class="ideas-foot">
     {#if loading}
-      <span class="text-sm" style="color:var(--faint)">Loading more…</span>
+      <span class="ideas-foot__note">Loading more…</span>
     {:else if failed}
-      <button onclick={loadMore} class="rounded-xl border px-4 py-2 text-sm font-medium"
-              style="border-color:var(--line); color:var(--ink)">Couldn’t load — retry</button>
+      <button onclick={loadMore} class="btn btn-secondary btn-sm">Couldn’t load — retry</button>
     {:else if hasMore}
       <!-- manual fallback (keyboard / no-IntersectionObserver); the observer auto-triggers loadMore -->
-      <button onclick={loadMore} class="rounded-xl border px-4 py-2 text-sm font-medium"
-              style="border-color:var(--line); color:var(--muted)">Load more</button>
+      <button onclick={loadMore} class="btn btn-ghost btn-sm">Load more</button>
     {:else}
-      <span class="text-sm" style="color:var(--faint)">That’s all {data.count} ideas.</span>
+      <span class="ideas-foot__note">That’s all {data.count.toLocaleString()} ideas.</span>
     {/if}
     <div bind:this={sentinel} aria-hidden="true"></div>
   </div>
 {/if}
+
+<style>
+  .ideas-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; }
+  .ideas-title { margin-top: .35rem; font-size: 2rem; font-weight: 700; letter-spacing: -0.02em; }
+  .ideas-count { color: var(--faint); font-size: .9rem; font-weight: 500; }
+
+  .ideas-controls { margin: 1.5rem 0 1.75rem; display: flex; flex-wrap: wrap; gap: .6rem; }
+  .seg { display: inline-flex; padding: 3px; gap: 2px; background: var(--surface-2); border: 1px solid var(--line); border-radius: var(--r-pill); }
+  .seg__item {
+    border-radius: var(--r-pill); padding: .4rem .9rem; font-size: .85rem; font-weight: 600; color: var(--muted);
+    transition: background var(--dur-fast) var(--ease-snappy), color var(--dur-fast); white-space: nowrap;
+  }
+  .seg__item:hover { color: var(--ink); }
+  .seg__item[aria-current='true'] { background: var(--surface); color: var(--ink); box-shadow: var(--shadow-1); }
+
+  .ideas-empty { display: flex; flex-direction: column; align-items: center; gap: 1rem; padding: 3rem 1.5rem; color: var(--muted); }
+
+  .ideas-foot { margin-top: 2.25rem; display: flex; flex-direction: column; align-items: center; gap: .5rem; }
+  .ideas-foot__note { font-size: .85rem; color: var(--faint); }
+</style>

--- a/src/routes/ideas/+page.svelte
+++ b/src/routes/ideas/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
+  import { navigating } from '$app/stores';
   import IdeaCard from '$lib/components/IdeaCard.svelte';
+  import SkeletonCard from '$lib/components/SkeletonCard.svelte';
+  import Spinner from '$lib/components/Spinner.svelte';
 
   let { data } = $props();
+
+  // show a skeleton grid while a client-side navigation to the ideas list is in flight
+  let isNavigating = $derived(!!$navigating && $navigating.to?.url.pathname === '/ideas');
 
   // Infinite scroll: SSR renders page 0; we append further pages from /api/ideas. The list is local
   // $state seeded from `data`, and re-seeded whenever the filter/sort navigation changes `data`.
@@ -71,7 +77,7 @@
 
 <header class="ideas-head">
   <div>
-    <span class="u-label">Research bounties</span>
+    <span class="u-label">Open research ideas</span>
     <h1 class="ideas-title">Ideas</h1>
   </div>
   <p class="ideas-count tnum">{data.count.toLocaleString()} open</p>
@@ -89,7 +95,11 @@
   </div>
 </div>
 
-{#if ideas.length === 0}
+{#if isNavigating}
+  <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+    {#each Array(6) as _, i (i)}<SkeletonCard />{/each}
+  </div>
+{:else if ideas.length === 0}
   <div class="ideas-empty card">
     <p>No ideas here yet.</p>
     {#if data.type}<a class="btn btn-secondary btn-sm" href={buildHref(null, data.sort)}>Clear filter</a>{/if}
@@ -101,7 +111,7 @@
 
   <div class="ideas-foot">
     {#if loading}
-      <span class="ideas-foot__note">Loading more…</span>
+      <Spinner label="Loading more ideas" />
     {:else if failed}
       <button onclick={loadMore} class="btn btn-secondary btn-sm">Couldn’t load — retry</button>
     {:else if hasMore}

--- a/src/routes/ideas/[slug]/+page.svelte
+++ b/src/routes/ideas/[slug]/+page.svelte
@@ -2,58 +2,72 @@
   import StatusBadge from '$lib/components/StatusBadge.svelte';
   import VoteControl from '$lib/components/VoteControl.svelte';
   import AnswerCard from '$lib/components/AnswerCard.svelte';
-  import BountyMeter from '$lib/components/BountyMeter.svelte';
   import Money from '$lib/components/Money.svelte';
   import Markdown from '$lib/components/Markdown.svelte';
   let { data, form } = $props();
+  let signinHref = $derived('/login?next=' + encodeURIComponent('/ideas/' + data.idea.slug));
 </script>
-<div class="grid gap-6 lg:grid-cols-[1fr_280px]">
-  <div>
-    <article class="rounded-2xl border p-6" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">{data.idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
-        <div class="flex items-center gap-2">
-          <VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage}
-                       signinHref={'/login?next=' + encodeURIComponent('/ideas/' + data.idea.id)} />
+
+<div class="idea-layout">
+  <div class="idea-main">
+    <article class="idea-hero card u-dots">
+      <div class="idea-hero__top">
+        <span class="u-label">{data.idea.type === 'hypothesis' ? 'Hypothesis' : 'Open-ended'}</span>
+        <div class="idea-hero__meta">
+          <VoteControl score={data.score} myVote={data.myVote} canVote={data.canEngage} {signinHref} />
           <StatusBadge status={data.idea.status} />
         </div>
       </div>
-      <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.idea.title}</h1>
-      {#if data.author}<p class="text-sm" style="color:var(--faint)">by <a href="/u/{data.author.handle}" style="color:var(--green-deep)">{data.author.display_name ?? data.author.handle}</a></p>{/if}
-      {#if data.idea.claim}<p class="mt-3 italic" style="color:var(--body)">{data.idea.claim}</p>{/if}
-      {#if data.summary_html}<Markdown html={data.summary_html} class="mt-3" />{/if}
-      {#if data.categories.length}<div class="mt-4 flex flex-wrap gap-2">{#each data.categories as c}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--line); color:var(--muted)">{c.title}</span>{/each}</div>{/if}
-      {#if data.idea.source_url}<p class="mt-4 text-sm"><a href={data.idea.source_url} target="_blank" rel="noopener" style="color:var(--green-deep)">Source ↗</a></p>{/if}
+      <h1 class="idea-hero__title">{data.idea.title}</h1>
+      {#if data.author}
+        <p class="idea-hero__byline">by <a href="/u/{data.author.handle}">{data.author.display_name ?? data.author.handle}</a></p>
+      {/if}
+      {#if data.idea.claim}
+        <p class="idea-hero__claim font-serif">“{data.idea.claim}”</p>
+      {/if}
+      {#if data.summary_html}<Markdown html={data.summary_html} class="idea-hero__body" />{/if}
+      {#if data.categories.length}
+        <div class="idea-hero__cats">
+          {#each data.categories as c}<span class="chip chip-line">{c.title}</span>{/each}
+        </div>
+      {/if}
+      {#if data.idea.source_url}
+        <p class="idea-hero__source"><a href={data.idea.source_url} target="_blank" rel="noopener">Source&nbsp;↗</a></p>
+      {/if}
     </article>
 
-    <section class="mt-8">
-      <div class="mb-3 flex items-center justify-between">
-        <h2 class="text-xl font-bold" style="color:var(--ink)">Answers</h2>
-        {#if data.canSubmit}<a href="/ideas/{data.idea.slug}/answer" class="rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Submit an answer</a>{/if}
+    <section class="block">
+      <div class="block__head">
+        <h2 class="block__title">Answers <span class="block__count tnum">{data.answers.length}</span></h2>
+        {#if data.canSubmit}<a href="/ideas/{data.idea.slug}/answer" class="btn btn-primary btn-sm">Submit an answer</a>{/if}
       </div>
-      {#if data.answers.length === 0}<p style="color:var(--muted)">No answers yet.</p>{:else}
-        <div class="flex flex-col gap-3">{#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}</div>
+      {#if data.answers.length === 0}
+        <p class="block__empty">No answers yet{#if data.canSubmit} — be the first to respond.{/if}</p>
+      {:else}
+        <div class="stack">{#each data.answers as answer (answer.id)}<AnswerCard {answer} />{/each}</div>
       {/if}
     </section>
 
-    <section class="mt-8">
-      <h2 class="mb-3 text-xl font-bold" style="color:var(--ink)">Discussion</h2>
+    <section class="block">
+      <h2 class="block__title">Discussion <span class="block__count tnum">{data.comments.length}</span></h2>
       {#if data.canEngage}
-        <form method="POST" action="?/comment" class="mb-4 flex flex-col gap-2">
-          <textarea name="body_md" required placeholder="Add a comment (markdown)" rows="3" class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
-          <button class="self-start rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Comment</button>
+        <form method="POST" action="?/comment" class="comment-form">
+          <textarea name="body_md" required placeholder="Add a comment (markdown supported)" rows="3" class="textarea"></textarea>
+          <button class="btn btn-secondary btn-sm comment-form__btn">Comment</button>
         </form>
       {/if}
-      {#if data.comments.length === 0}<p style="color:var(--muted)">No comments yet.</p>{:else}
-        <ul class="flex flex-col gap-3">
+      {#if data.comments.length === 0}
+        <p class="block__empty">No comments yet.</p>
+      {:else}
+        <ul class="stack">
           {#each data.comments as c (c.id)}
-            <li class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-              <div class="mb-1 flex items-center justify-between">
-                <span class="text-sm" style="color:var(--faint)">{c.author?.display_name ?? c.author?.handle ?? 'Anonymous'}</span>
+            <li class="card comment">
+              <div class="comment__head">
+                <span class="comment__author">{c.author?.display_name ?? c.author?.handle ?? 'Anonymous'}</span>
                 {#if data.userId === c.author_id || data.isAdmin}
                   <form method="POST" action="?/delete_comment">
                     <input type="hidden" name="comment_id" value={c.id} />
-                    <button class="text-xs" style="color:var(--neg)">Delete</button>
+                    <button class="comment__delete">Delete</button>
                   </form>
                 {/if}
               </div>
@@ -65,51 +79,132 @@
     </section>
   </div>
 
-  <aside class="flex flex-col gap-4">
-    <BountyMeter potCents={data.pot.pot_cents} funderCount={data.pot.funder_count} currency={data.idea.currency ?? 'USD'} />
-
-    {#if data.canFund}
-      <form method="POST" action="?/pledge" class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-        <label class="text-xs uppercase tracking-wide" style="color:var(--faint)">Fund this idea ($)
-          <input name="amount" type="number" min="0.01" step="0.01" placeholder="0.00" required class="mt-1 block w-full rounded-xl border px-3 py-2" style="border-color:var(--line)" />
-        </label>
-        <button class="mt-3 w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">Pledge</button>
-        <p class="mt-2 text-xs" style="color:var(--faint)">A pledge is a commitment — no funds move yet.</p>
-      </form>
-    {/if}
-
-    <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-      <div class="flex items-baseline justify-between">
-        <span class="text-xs uppercase tracking-wide" style="color:var(--faint)">Interested</span>
-        <span class="text-sm tabular-nums" style="color:var(--ink)">{data.interestCount}</span>
-      </div>
-      {#if data.canEngage}
-        {#if data.myInterestId}
-          <form method="POST" action="?/uninterest" class="mt-2">
-            <button class="w-full rounded-xl border px-4 py-2 text-sm" style="border-color:var(--green); color:var(--green-deep)">Interested ✓ — withdraw</button>
-          </form>
+  <aside class="idea-aside">
+    <div class="idea-aside__sticky">
+      <!-- Bounty -->
+      <div class="card panel">
+        <div class="panel__row">
+          <span class="u-label">Bounty pledged</span>
+          <span class="panel__sub">{data.pot.funder_count} {data.pot.funder_count === 1 ? 'funder' : 'funders'}</span>
+        </div>
+        {#if data.pot.pot_cents > 0}
+          <div class="panel__amount tnum"><Money cents={data.pot.pot_cents} currency={data.idea.currency ?? 'USD'} /></div>
         {:else}
-          <form method="POST" action="?/interest" class="mt-2">
-            <button class="w-full rounded-xl px-4 py-2 text-sm font-medium" style="background:var(--ink); color:#fff">I'm interested</button>
+          <p class="panel__hint">Open for funding — be the first to back this question.</p>
+        {/if}
+
+        {#if data.canFund}
+          <form method="POST" action="?/pledge" class="fund">
+            <label class="fund__label" for="fund-amount">Pledge an amount</label>
+            <div class="fund__row">
+              <span class="fund__cur">$</span>
+              <input id="fund-amount" name="amount" type="number" min="0.01" step="0.01" placeholder="0.00" required class="input fund__input" />
+            </div>
+            <button class="btn btn-primary fund__btn">Pledge</button>
+            <p class="fund__note">A pledge is a commitment — no funds move yet.</p>
           </form>
         {/if}
-      {/if}
-    </div>
-
-    {#if data.funders.length}
-      <div class="rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-        <p class="mb-2 text-xs uppercase tracking-wide" style="color:var(--faint)">Funders</p>
-        <ul class="flex flex-col gap-1 text-sm">
-          {#each data.funders as f (f.key)}
-            <li class="flex justify-between gap-2">
-              <span style="color:var(--body)">{f.name}</span>
-              <span class="tabular-nums" style="color:var(--ink)"><Money cents={f.amount_cents} currency={f.currency} /></span>
-            </li>
-          {/each}
-        </ul>
       </div>
-    {/if}
 
-    {#if form?.message}<p class="text-sm" style="color:var(--neg)">{form.message}</p>{/if}
+      <!-- Interest -->
+      <div class="card panel">
+        <div class="panel__row">
+          <span class="u-label">Interested researchers</span>
+          <span class="panel__sub tnum">{data.interestCount}</span>
+        </div>
+        {#if data.canEngage}
+          {#if data.myInterestId}
+            <form method="POST" action="?/uninterest">
+              <button class="btn btn-secondary panel__action panel__action--on">Interested ✓ — withdraw</button>
+            </form>
+          {:else}
+            <form method="POST" action="?/interest">
+              <button class="btn btn-primary panel__action">I’m interested</button>
+            </form>
+          {/if}
+        {:else}
+          <a href={signinHref} class="btn btn-secondary panel__action">Sign in to follow</a>
+        {/if}
+      </div>
+
+      <!-- Funders -->
+      {#if data.funders.length}
+        <div class="card panel">
+          <span class="u-label">Funders</span>
+          <ul class="funders">
+            {#each data.funders as f (f.key)}
+              <li class="funders__row">
+                <span class="funders__name">{f.name}</span>
+                <span class="tnum funders__amt"><Money cents={f.amount_cents} currency={f.currency} /></span>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      {#if form?.message}<p class="idea-aside__err">{form.message}</p>{/if}
+    </div>
   </aside>
 </div>
+
+<style>
+  .idea-layout { display: grid; gap: 2rem; align-items: start; }
+  @media (min-width: 960px) { .idea-layout { grid-template-columns: 1fr 320px; } }
+
+  /* Hero card */
+  .idea-hero { padding: 1.75rem; background-color: var(--surface); }
+  .idea-hero__top { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  .idea-hero__meta { display: flex; align-items: center; gap: .6rem; }
+  .idea-hero__title { margin-top: 1rem; font-size: clamp(1.7rem, 3.5vw, 2.3rem); font-weight: 700; letter-spacing: -0.02em; line-height: 1.12; }
+  .idea-hero__byline { margin-top: .6rem; font-size: .9rem; color: var(--faint); }
+  .idea-hero__byline a { color: var(--green-deep); }
+  .idea-hero__byline a:hover { text-decoration: underline; text-underline-offset: 2px; }
+  .idea-hero__claim { margin-top: 1.1rem; font-size: 1.2rem; line-height: 1.5; color: var(--ink-2); font-style: italic; border-left: 3px solid var(--green); padding-left: 1rem; }
+  :global(.idea-hero__body) { margin-top: 1.1rem; }
+  .idea-hero__cats { margin-top: 1.4rem; display: flex; flex-wrap: wrap; gap: .5rem; }
+  .idea-hero__source { margin-top: 1.1rem; font-size: .9rem; }
+  .idea-hero__source a { color: var(--green-deep); }
+
+  /* Content blocks */
+  .block { margin-top: 2.5rem; }
+  .block__head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.1rem; }
+  .block__title { font-size: 1.3rem; font-weight: 700; color: var(--ink); }
+  .block__count { margin-left: .4rem; font-size: .95rem; font-weight: 600; color: var(--faint); }
+  .block__empty { color: var(--muted); font-size: .95rem; }
+  .stack { display: flex; flex-direction: column; gap: .9rem; }
+
+  /* Comments */
+  .comment-form { display: flex; flex-direction: column; gap: .65rem; margin-bottom: 1.25rem; }
+  .comment-form__btn { align-self: flex-start; }
+  .comment { padding: 1.1rem 1.2rem; }
+  .comment__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: .35rem; }
+  .comment__author { font-size: .88rem; font-weight: 600; color: var(--body); }
+  .comment__delete { font-size: .76rem; color: var(--neg); cursor: pointer; }
+  .comment__delete:hover { text-decoration: underline; }
+
+  /* Aside */
+  .idea-aside__sticky { display: flex; flex-direction: column; gap: 1rem; }
+  @media (min-width: 960px) { .idea-aside__sticky { position: sticky; top: 5rem; } }
+  .panel { padding: 1.2rem; }
+  .panel__row { display: flex; align-items: baseline; justify-content: space-between; gap: .75rem; }
+  .panel__sub { font-size: .8rem; color: var(--muted); }
+  .panel__amount { margin-top: .35rem; font-size: 1.85rem; font-weight: 700; color: var(--ink); letter-spacing: -0.02em; }
+  .panel__hint { margin-top: .5rem; font-size: .88rem; color: var(--muted); line-height: 1.5; }
+  .panel__action { width: 100%; margin-top: .9rem; }
+  .panel__action--on { color: var(--green-deep); border-color: color-mix(in srgb, var(--green) 55%, transparent); }
+
+  .fund { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--line); }
+  .fund__label { display: block; font-size: .82rem; font-weight: 600; color: var(--muted); margin-bottom: .45rem; }
+  .fund__row { position: relative; display: flex; align-items: center; }
+  .fund__cur { position: absolute; left: .8rem; color: var(--faint); font-weight: 600; pointer-events: none; }
+  .fund__input { padding-left: 1.6rem; }
+  .fund__btn { width: 100%; margin-top: .65rem; }
+  .fund__note { margin-top: .55rem; font-size: .76rem; color: var(--faint); line-height: 1.45; }
+
+  .funders { margin-top: .75rem; display: flex; flex-direction: column; gap: .5rem; }
+  .funders__row { display: flex; justify-content: space-between; gap: .75rem; font-size: .9rem; }
+  .funders__name { color: var(--body); }
+  .funders__amt { color: var(--ink); font-weight: 600; }
+
+  .idea-aside__err { font-size: .85rem; color: var(--neg); }
+</style>

--- a/src/routes/ideas/[slug]/+page.svelte
+++ b/src/routes/ideas/[slug]/+page.svelte
@@ -84,7 +84,7 @@
       <!-- Bounty -->
       <div class="card panel">
         <div class="panel__row">
-          <span class="u-label">Bounty pledged</span>
+          <span class="u-label">Pledged</span>
           <span class="panel__sub">{data.pot.funder_count} {data.pot.funder_count === 1 ? 'funder' : 'funders'}</span>
         </div>
         {#if data.pot.pot_cents > 0}

--- a/src/routes/ideas/ideas.test.ts
+++ b/src/routes/ideas/ideas.test.ts
@@ -4,10 +4,15 @@ import { load } from './+page.server';
 function mkLocals(rows: unknown[], totals: unknown[] = []) {
   const make = (table: string): any => {
     if (table === 'idea_vote_totals') return { select: () => Promise.resolve({ data: totals }) };
+    // enrichCards reads answers/comments via .select(...).in(...) — return no stats
+    if (table === 'answers' || table === 'comments') {
+      return { select: () => ({ in: () => Promise.resolve({ data: [] }) }) };
+    }
     // thenable builder: serves both `…order().range()` (new) and a directly-awaited `…order()` (top)
     const result = { data: rows, count: rows.length };
     const builder: any = {
-      select() { return this; }, neq() { return this; }, not() { return this; }, eq() { return this; }, order() { return this; },
+      select() { return this; }, neq() { return this; }, not() { return this; }, eq() { return this; },
+      order() { return this; }, in() { return this; },
       range() { return Promise.resolve(result); },
       then(resolve: any, reject: any) { return Promise.resolve(result).then(resolve, reject); }
     };
@@ -22,7 +27,9 @@ describe('ideas browse load', () => {
       url: new URL('http://x/ideas'),
       locals: mkLocals([{ id: '1', title: 'A' }], [{ idea_id: '1', score: 3 }])
     } as any)) as any;
-    expect(res.ideas).toEqual([{ id: '1', title: 'A', score: 3 }]);
+    expect(res.ideas).toEqual([
+      { id: '1', title: 'A', score: 3, answerCount: 0, commentCount: 0, verified: null }
+    ]);
     expect(res.count).toBe(1);
   });
   it('sort=top ranks by score desc', async () => {


### PR DESCRIPTION
A cohesive visual redesign on the existing `CLAUDE.md` brand (greyscale + the `#44ff98` accent, Sora/Lora, Linear-restraint + editorial research-lab texture). Built **page-by-page** — this PR will fill in as I go. **Draft** until all increments land.

> Stacked on #60 (currency fix) + #61 (ideas feed). Merge **#60 → #61 → this**. Once they're in `main`, this diff shrinks to just the design work.

### Root cause of the "generic" look
Sora/Lora were named in `app.css` but **never loaded** — no `@font-face`/import — so everything rendered in the browser default sans-serif. Now self-hosted via `@fontsource-variable` and bundled (woff2 emitted to the build).

## Increment 1 (this commit) — foundation + shell + landing
- **Design system in `app.css`**: real type scale, focus-visible green ring, brand `::selection`, dotted-grid/label/reveal utilities, and reusable `.btn` (ink pill / white-hairline), `.card`, `.chip`, `.meter` (green progress), `.prose-sm` markdown styles.
- **App shell**: a `Logo` mark (static brand orb) + sticky blurred header with wordmark/nav, and a real footer (mission, links, 501(c)(3) note).
- **Landing**: editorial full-bleed hero (dotted grid + soft green glow, Sora headline, Lora lede, staggered reveal, brand orb, ink-pill CTAs, tracked stats), refined how-it-works, recent bounties, neutral-dark closing CTA.

## Coming next on this branch
- **Increment 2** — Ideas list + `IdeaCard` (editorial cards: score ▲, status chip, type label, bounty hint; refined filter/sort; keeps infinite scroll).
- **Increment 3** — Idea detail (two-column: content + sticky bounty/fund panel with the green meter, funders, vote, answers, comments).

## Verify
- [x] `svelte-check` 0/0, `npm run build` clean, Sora+Lora woff2 emitted
- [ ] **Review the Vercel preview** (landing + header/footer) and react before I build the app pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)