### PR TITLE
feat: Ideas Lab — fast drafts + AI critique/refine loop + plans + gated publish

### DIFF
--- a/docs/superpowers/plans/2026-06-08-ideas-lab.md
+++ b/docs/superpowers/plans/2026-06-08-ideas-lab.md
@@ -1,0 +1,864 @@
+# Ideas Lab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A personal Ideas Lab in the dashboard — notes-app-fast draft capture, an AI critique↔refine loop that distills an ExecPlan + readable plan, copy-to-agent handoff, and a gated publish-to-platform path.
+
+**Architecture:** Drafts are `ideas` rows in `status='draft'` (real slug, author-only RLS), created optimistically. Per-draft tools come from a client-safe **expansion registry**; AI tools are server endpoints (`/api/lab/...`) behind one `generate()` seam (Vercel AI Gateway + Claude), writing JSON into `ideas.expansions`. Submission/publish gating lives in DB triggers (server-authoritative). AI access = approved expert · admin · active monthly supporter, rate-limited.
+
+**Tech Stack:** SvelteKit 2 + Svelte 5 runes, Supabase (RLS + triggers, pgTAP), `ai` (AI SDK) via Vercel AI Gateway, `zod` for structured output, vitest + Playwright.
+
+**Branch:** `feat-ideas-lab` off `redesign-public-face` (so Lab UI inherits the design system). Carries the committed `20260608081014_open_idea_submissions.sql` migration; this plan adds `20260608_add_ideas_lab.sql` on top.
+
+**Prereqs the owner must set before AI tools work live (not blocking the rest):** `AI_GATEWAY_API_KEY` + token budget in Vercel; apply both migrations to cloud.
+
+---
+
+## File Structure
+
+**DB**
+- `supabase/migrations/<ts>_add_ideas_lab.sql` — draft-exempt INSERT gate, BEFORE-UPDATE publish gate, `ideas.expansions jsonb`, `profiles.supporter_until`, `can_use_lab_ai()`, `ai_generate` rate bucket.
+- `supabase/tests/database/ideas_lab_test.sql` — pgTAP for the gates + access predicate.
+
+**Server libs**
+- `src/lib/server/ai.ts` — `generate()` / `generateStructured()` seam over the AI SDK gateway.
+- `src/lib/server/lab/access.ts` — `canUseLabAi(supabase)` (calls the `can_use_lab_ai` RPC).
+- `src/lib/lab/registry.ts` — client-safe expansion definitions (key/label/icon/gated/status).
+- `src/lib/lab/agent-prompt.ts` — pure formatter: draft (+plans) → handoff prompt string.
+- `src/lib/lab/critique.ts` — zod critique schema + `parseCritique()` guard + prompt builders.
+
+**APIs**
+- `src/routes/api/drafts/+server.ts` — `POST` create draft (optimistic target).
+- `src/routes/api/drafts/[id]/+server.ts` — `PATCH` autosave title/notes, `DELETE` draft.
+- `src/routes/api/lab/[id]/review/+server.ts` — `POST` one critique round.
+- `src/routes/api/lab/[id]/plan/+server.ts` — `POST {kind:'exec'|'readable'}` plan generation.
+
+**Dashboard Lab UI**
+- `src/routes/dashboard/+page.server.ts` — add Lab tab data (my drafts).
+- `src/routes/dashboard/+page.svelte` — Lab tab wiring.
+- `src/lib/components/lab/DraftCapture.svelte` — one-line optimistic capture.
+- `src/lib/components/lab/DraftList.svelte` + `DraftCard.svelte` — list + expandable card.
+- `src/lib/components/lab/ExpansionPanel.svelte` — renders registry tools per draft.
+- `src/lib/components/lab/CritiqueRounds.svelte` — stacked critique cards.
+- `src/lib/components/lab/PublishDialog.svelte` — make-into-full-idea confirm.
+- `src/lib/lab/draftsStore.svelte.ts` — client store: optimistic add/edit/delete + reconcile.
+
+**Publish & moderation**
+- `src/routes/ideas/[slug]/+page.server.ts` — allow author/admin to view draft/archived.
+- `src/routes/admin/ideas/+page.server.ts` + `+page.svelte` — promote archived submissions.
+
+**Carryovers**
+- `src/routes/u/[handle]/+page.server.ts` + `+page.svelte` — authored ideas + Verified badge.
+- `src/routes/experts/+page.svelte` — Verified badge, design-system restyle.
+
+---
+
+## Task 1: DB migration — gating extensions, expansions, supporter, AI access
+
+**Files:**
+- Create: `supabase/migrations/<ts>_add_ideas_lab.sql` (generate with `supabase migration new add_ideas_lab`)
+- Create: `supabase/tests/database/ideas_lab_test.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `supabase migration new add_ideas_lab` — note the generated path.
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- ideas.expansions: per-draft tool output, keyed by tool
+alter table public.ideas add column expansions jsonb not null default '{}'::jsonb;
+
+-- profiles.supporter_until: active monthly supporter when > now() (admin/billing set)
+alter table public.profiles add column supporter_until timestamptz;
+
+-- INSERT gate: exempt drafts (private scratchpad); else expert→open, other→archived.
+create or replace function public.enforce_idea_submission()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if new.status = 'draft' then
+    return new; -- a draft stays a private draft
+  end if;
+  if exists (select 1 from public.experts e where e.id = new.author_id and e.status = 'approved') then
+    new.status := 'open';
+  else
+    new.status := 'archived';
+  end if;
+  return new;
+end;
+$$;
+
+-- UPDATE (publish) gate: when status moves from a non-public to a public state, re-apply
+-- the expert check so a non-expert can't self-publish by editing a draft to 'open'.
+create or replace function public.enforce_idea_publish()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if new.status in ('open','resolved','closed') and old.status not in ('open','resolved','closed') then
+    if not exists (select 1 from public.experts e where e.id = new.author_id and e.status = 'approved')
+       and not public.is_admin() then
+      new.status := 'archived'; -- submitted for admin review
+    end if;
+  end if;
+  return new;
+end;
+$$;
+create trigger ideas_enforce_publish
+before update on public.ideas
+for each row when (old.status is distinct from new.status)
+execute function public.enforce_idea_publish();
+
+-- AI access predicate: admin OR approved expert OR active monthly supporter
+create or replace function public.can_use_lab_ai()
+returns boolean language sql security definer set search_path = '' stable as $$
+  select public.is_admin()
+      or exists (select 1 from public.experts e where e.id = auth.uid() and e.status = 'approved')
+      or exists (select 1 from public.profiles p where p.id = auth.uid() and p.supporter_until > now());
+$$;
+revoke all on function public.can_use_lab_ai() from public;
+grant execute on function public.can_use_lab_ai() to authenticated;
+```
+
+- [ ] **Step 3: Add the `ai_generate` rate-limit bucket**
+
+Open the current `consume_rate_limit` definition (`grep -rl "consume_rate_limit" supabase/migrations`). In the new migration, `create or replace` it with the same body plus a CASE arm:
+
+```sql
+-- in the limit CASE inside consume_rate_limit(p_bucket): add
+    when 'ai_generate' then 30   -- per hour
+```
+(Copy the existing function verbatim, add only this arm; keep the window/logic identical.)
+
+- [ ] **Step 4: Apply locally & smoke-test the gates**
+
+Run: `supabase migration up --local`
+Then with `/opt/homebrew/opt/libpq/bin/psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres"`:
+```sql
+-- draft stays draft (non-expert author)
+insert into public.ideas (title, type, status, author_id) values ('d','open_ended','draft',null) returning status; -- expect draft
+```
+Expected: `draft`.
+
+- [ ] **Step 5: Write pgTAP tests**
+
+`supabase/tests/database/ideas_lab_test.sql` — use the existing pgTAP test files as the pattern (plan(N), set local role, etc.):
+```sql
+begin;
+select plan(5);
+-- 1: INSERT with status draft stays draft
+-- 2: non-expert non-draft insert → archived
+-- 3: approved-expert non-draft insert → open
+-- 4: non-expert UPDATE draft→open → coerced archived
+-- 5: approved-expert UPDATE draft→open → open
+-- (model the role/seed setup on supabase/tests/database/ideas_test.sql)
+select * from finish();
+rollback;
+```
+Fill each assertion using `is(...)` against an inserted/updated row's status, mirroring `ideas_test.sql`'s fixtures (create an auth user + profile + expert row as needed).
+
+- [ ] **Step 6: Run pgTAP**
+
+Run: `supabase test db` (or the project's pgTAP runner). Expected: all assertions pass.
+
+- [ ] **Step 7: Regenerate types & commit**
+
+Run: `supabase gen types typescript --local > src/lib/types/database.ts`
+```bash
+git add supabase/migrations src/lib/types/database.ts supabase/tests/database/ideas_lab_test.sql
+git commit -m "feat(db): ideas-lab gating (draft exempt + publish gate), expansions, supporter, can_use_lab_ai"
+```
+
+---
+
+## Task 2: `canUseLabAi` server helper
+
+**Files:**
+- Create: `src/lib/server/lab/access.ts`
+- Test: `src/lib/server/lab/access.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { canUseLabAi } from './access';
+describe('canUseLabAi', () => {
+  it('returns the can_use_lab_ai RPC boolean', async () => {
+    const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: true, error: null }) };
+    expect(await canUseLabAi(supabase)).toBe(true);
+    expect(supabase.rpc).toHaveBeenCalledWith('can_use_lab_ai');
+  });
+  it('is false when the RPC errors or returns null', async () => {
+    const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: null, error: { message: 'x' } }) };
+    expect(await canUseLabAi(supabase)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails — module missing).** `npx vitest run src/lib/server/lab/access.test.ts`
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { SupabaseClient } from '@supabase/supabase-js';
+/** True if the caller may use AI Lab tools (admin · approved expert · active monthly supporter). */
+export async function canUseLabAi(supabase: SupabaseClient): Promise<boolean> {
+  const { data, error } = await supabase.rpc('can_use_lab_ai');
+  return !error && data === true;
+}
+```
+
+- [ ] **Step 4: Run it (passes).** Then commit: `git commit -am "feat(lab): canUseLabAi server helper"`
+
+---
+
+## Task 3: Agent-prompt formatter
+
+**Files:**
+- Create: `src/lib/lab/agent-prompt.ts`
+- Test: `src/lib/lab/agent-prompt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildAgentPrompt } from './agent-prompt';
+describe('buildAgentPrompt', () => {
+  it('includes title, notes, and plans when present', () => {
+    const p = buildAgentPrompt({
+      title: 'Scalable oversight', notes_md: 'via debate',
+      execPlan: '1. do X', readablePlan: 'We propose…'
+    });
+    expect(p).toContain('Scalable oversight');
+    expect(p).toContain('via debate');
+    expect(p).toContain('1. do X');
+    expect(p).toContain('We propose…');
+  });
+  it('omits plan sections that are absent', () => {
+    const p = buildAgentPrompt({ title: 'T', notes_md: '', execPlan: null, readablePlan: null });
+    expect(p).toContain('T');
+    expect(p).not.toMatch(/ExecPlan/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement**
+
+```ts
+export type AgentPromptInput = {
+  title: string; notes_md: string;
+  execPlan?: string | null; readablePlan?: string | null;
+};
+/** Format a draft (+ optional distilled plans) into a single agent handoff prompt. */
+export function buildAgentPrompt(i: AgentPromptInput): string {
+  const parts = [`# Research idea: ${i.title}`];
+  if (i.notes_md.trim()) parts.push(`## Notes\n${i.notes_md.trim()}`);
+  if (i.readablePlan?.trim()) parts.push(`## Plan (readable)\n${i.readablePlan.trim()}`);
+  if (i.execPlan?.trim()) parts.push(`## ExecPlan\n${i.execPlan.trim()}`);
+  parts.push('## Task\nBuild this out: produce the paper/artifacts described above.');
+  return parts.join('\n\n');
+}
+```
+
+- [ ] **Step 4: Run it (passes). Commit.** `git commit -am "feat(lab): agent-prompt formatter"`
+
+---
+
+## Task 4: Critique schema + guard
+
+**Files:**
+- Create: `src/lib/lab/critique.ts`
+- Test: `src/lib/lab/critique.test.ts`
+- Modify: install zod if absent — `npm i zod` (check `package.json` first).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CritiqueRoundSchema, REVIEWERS } from './critique';
+describe('critique schema', () => {
+  it('accepts a well-formed round and exposes the 4 reviewers', () => {
+    expect(REVIEWERS.map((r) => r.key)).toEqual(['skeptic', 'methods', 'impact', 'clarifying']);
+    const ok = CritiqueRoundSchema.safeParse({
+      reviewers: [{ persona: 'skeptic', comments: ['weak baseline'], questions: ['what control?'] }]
+    });
+    expect(ok.success).toBe(true);
+  });
+  it('rejects a malformed round', () => {
+    expect(CritiqueRoundSchema.safeParse({ reviewers: [{ persona: 'x' }] }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { z } from 'zod';
+export const REVIEWERS = [
+  { key: 'skeptic', label: 'Skeptic', brief: 'attack the weakest assumptions' },
+  { key: 'methods', label: 'Methods', brief: 'rigor, baselines, confounds, measurability' },
+  { key: 'impact', label: 'Impact', brief: 'why it matters for AI safety; who funds it' },
+  { key: 'clarifying', label: 'Clarifying', brief: 'what is underspecified' }
+] as const;
+
+export const CritiqueRoundSchema = z.object({
+  reviewers: z.array(z.object({
+    persona: z.enum(['skeptic', 'methods', 'impact', 'clarifying']),
+    comments: z.array(z.string()),
+    questions: z.array(z.string())
+  })).min(1)
+});
+export type CritiqueRound = z.infer<typeof CritiqueRoundSchema>;
+
+/** Prompt for one review round over a draft. */
+export function buildReviewPrompt(title: string, notes_md: string): string {
+  const panel = REVIEWERS.map((r) => `- ${r.label}: ${r.brief}`).join('\n');
+  return `You are a panel reviewing an early-stage AI-safety research idea.\n` +
+    `Idea: "${title}"\nNotes:\n${notes_md || '(none yet)'}\n\n` +
+    `Reviewers:\n${panel}\n\nReturn each reviewer's pointed comments and clarifying questions.`;
+}
+```
+
+- [ ] **Step 4: Run it (passes). Commit.** `git commit -am "feat(lab): critique schema + review prompt"`
+
+---
+
+## Task 5: AI seam (`generate` / `generateStructured`)
+
+**Files:**
+- Create: `src/lib/server/ai.ts`
+- Test: `src/lib/server/ai.test.ts`
+- Modify: `npm i ai` (AI SDK; provides `generateText`/`generateObject` + gateway resolution of `anthropic/...` model strings via `AI_GATEWAY_API_KEY`). Pin the version, commit lockfile.
+
+- [ ] **Step 1: Write the failing test (the seam is mockable)**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({ text: 'hello' }),
+  generateObject: vi.fn().mockResolvedValue({ object: { ok: true } })
+}));
+import { generate, generateStructured } from './ai';
+import { z } from 'zod';
+describe('ai seam', () => {
+  it('generate returns text', async () => { expect(await generate('hi')).toBe('hello'); });
+  it('generateStructured returns the parsed object', async () => {
+    expect(await generateStructured('hi', z.object({ ok: z.boolean() }))).toEqual({ ok: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement** (model string via gateway; read env at call time)
+
+```ts
+import { generateText, generateObject } from 'ai';
+import type { ZodSchema } from 'zod';
+import { env } from '$env/dynamic/private';
+
+const MODEL = 'anthropic/claude-sonnet-4-6'; // resolved by the Vercel AI Gateway
+
+function assertConfigured() {
+  if (!env.AI_GATEWAY_API_KEY) throw new Error('AI is not configured (missing AI_GATEWAY_API_KEY)');
+}
+export async function generate(prompt: string): Promise<string> {
+  assertConfigured();
+  const { text } = await generateText({ model: MODEL, prompt });
+  return text;
+}
+export async function generateStructured<T>(prompt: string, schema: ZodSchema<T>): Promise<T> {
+  assertConfigured();
+  const { object } = await generateObject({ model: MODEL, prompt, schema });
+  return object as T;
+}
+```
+
+- [ ] **Step 4: Run it (passes). Commit.** `git commit -am "feat(lab): AI generate seam (gateway + Claude)"`
+
+> Note: tests mock `ai`, so no live calls in CI. The `assertConfigured` guard makes missing-key failures explicit at runtime.
+
+---
+
+## Task 6: Expansion registry (client-safe)
+
+**Files:**
+- Create: `src/lib/lab/registry.ts`
+- Test: `src/lib/lab/registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { EXPANSIONS } from './registry';
+describe('expansion registry', () => {
+  it('has the ready tools and marks future ones coming-soon', () => {
+    const byKey = Object.fromEntries(EXPANSIONS.map((e) => [e.key, e]));
+    expect(byKey['copy_agent'].status).toBe('ready');
+    expect(byKey['review'].gated).toBe(true);
+    expect(byKey['github'].status).toBe('soon');
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement** (definitions only — no runtime deps; UI maps over these)
+
+```ts
+export type ExpansionStatus = 'ready' | 'soon';
+export type Expansion = {
+  key: string; label: string; icon: string; gated: boolean; status: ExpansionStatus;
+  kind: 'client' | 'review' | 'plan'; planKind?: 'exec' | 'readable';
+};
+export const EXPANSIONS: Expansion[] = [
+  { key: 'review', label: 'Run review', icon: '🔍', gated: true, status: 'ready', kind: 'review' },
+  { key: 'exec_plan', label: 'Generate ExecPlan', icon: '📐', gated: true, status: 'ready', kind: 'plan', planKind: 'exec' },
+  { key: 'readable_plan', label: 'Generate readable plan', icon: '📄', gated: true, status: 'ready', kind: 'plan', planKind: 'readable' },
+  { key: 'copy_agent', label: 'Copy to agent', icon: '🤖', gated: false, status: 'ready', kind: 'client' },
+  { key: 'github', label: 'Start GitHub repo', icon: '🐙', gated: true, status: 'soon', kind: 'client' },
+  { key: 'venues', label: 'Find venues', icon: '🎓', gated: true, status: 'soon', kind: 'client' },
+  { key: 'link_agent', label: 'Link an agent', icon: '🔗', gated: true, status: 'soon', kind: 'client' }
+];
+```
+
+- [ ] **Step 4: Run it (passes). Commit.** `git commit -am "feat(lab): expansion registry"`
+
+---
+
+## Task 7: Drafts API — create / autosave / delete
+
+**Files:**
+- Create: `src/routes/api/drafts/+server.ts`
+- Create: `src/routes/api/drafts/[id]/+server.ts`
+- Test: `src/routes/api/drafts/drafts.test.ts`
+
+- [ ] **Step 1: Write the failing test (rate-limit + auth wiring, mocked supabase)**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+function ev(rpcOk: boolean, user: any = { id: 'u1' }) {
+  const insert = vi.fn(() => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'i1', slug: 's' }, error: null }) }) }));
+  const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }), from: vi.fn(() => ({ insert })) };
+  return { request: { json: async () => ({ title: 'T' }) }, locals: { supabase, safeGetSession: async () => ({ user }) } } as any;
+}
+describe('POST /api/drafts', () => {
+  it('401 without a user', async () => { expect((await POST(ev(true, null))).status).toBe(401); });
+  it('429 when rate-limited', async () => { expect((await POST(ev(false))).status).toBe(429); });
+  it('creates a draft and returns id+slug', async () => {
+    const res = await POST(ev(true)); expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: 'i1', slug: 's' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement `POST /api/drafts`** (insert a draft; trigger keeps it `draft` + sets slug)
+
+```ts
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { rateLimit } from '$lib/server/rate-limit';
+
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return json({ message: 'Sign in' }, { status: 401 });
+  if (!(await rateLimit(supabase, 'idea_create')).ok) return json({ message: 'Slow down' }, { status: 429 });
+  const body = await request.json().catch(() => ({}));
+  const title = String(body.title ?? '').trim() || 'Untitled idea';
+  const { data, error: e } = await supabase
+    .from('ideas').insert({ author_id: user.id, title, type: 'open_ended', status: 'draft' })
+    .select('id, slug').single();
+  if (e || !data) return json({ message: e?.message ?? 'Failed' }, { status: 400 });
+  return json({ id: data.id, slug: data.slug });
+};
+```
+
+- [ ] **Step 4: Implement `PATCH`/`DELETE` in `[id]/+server.ts`** (RLS enforces own-row)
+
+```ts
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const PATCH: RequestHandler = async ({ params, request, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return json({ message: 'Sign in' }, { status: 401 });
+  const body = await request.json().catch(() => ({}));
+  const patch: Record<string, unknown> = {};
+  if (typeof body.title === 'string') patch.title = body.title.trim() || 'Untitled idea';
+  if (typeof body.notes_md === 'string') patch.summary_md = body.notes_md; // notes reuse summary_md
+  if (!Object.keys(patch).length) return json({ ok: true });
+  const { error: e } = await supabase.from('ideas').update(patch).eq('id', params.id).eq('status', 'draft');
+  if (e) return json({ message: e.message }, { status: 400 });
+  return json({ ok: true });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return json({ message: 'Sign in' }, { status: 401 });
+  const { error: e } = await supabase.from('ideas').delete().eq('id', params.id).eq('status', 'draft');
+  if (e) return json({ message: e.message }, { status: 400 });
+  return json({ ok: true });
+};
+```
+
+- [ ] **Step 5: Run tests (pass). Commit.** `git commit -am "feat(lab): drafts create/autosave/delete API"`
+
+---
+
+## Task 8: Lab AI endpoints — review & plans
+
+**Files:**
+- Create: `src/routes/api/lab/[id]/review/+server.ts`
+- Create: `src/routes/api/lab/[id]/plan/+server.ts`
+- Test: `src/routes/api/lab/lab.test.ts`
+
+- [ ] **Step 1: Write the failing test (guards + persistence; mock ai + access)**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('$lib/server/ai', () => ({ generateStructured: vi.fn().mockResolvedValue({ reviewers: [{ persona: 'skeptic', comments: ['c'], questions: ['q'] }] }), generate: vi.fn() }));
+vi.mock('$lib/server/lab/access', () => ({ canUseLabAi: vi.fn().mockResolvedValue(true) }));
+import { POST } from './[id]/review/+server';
+function ev(rpcOk = true) {
+  const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
+  const single = () => Promise.resolve({ data: idea, error: null });
+  const supabase: any = {
+    rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }),
+    from: vi.fn(() => ({ select: () => ({ eq: () => ({ single }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) }))
+  };
+  return { params: { id: 'i1' }, locals: { supabase, safeGetSession: async () => ({ user: { id: 'u1' } }) } } as any;
+}
+describe('POST /api/lab/[id]/review', () => {
+  it('appends a critique round', async () => {
+    const res = await POST(ev()); expect(res.status).toBe(200);
+    const j = await res.json(); expect(j.round.reviewers[0].persona).toBe('skeptic');
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement `review/+server.ts`**
+
+```ts
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { canUseLabAi } from '$lib/server/lab/access';
+import { generateStructured } from '$lib/server/ai';
+import { rateLimit } from '$lib/server/rate-limit';
+import { CritiqueRoundSchema, buildReviewPrompt } from '$lib/lab/critique';
+
+export const POST: RequestHandler = async ({ params, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return json({ message: 'Sign in' }, { status: 401 });
+  if (!(await canUseLabAi(supabase))) return json({ message: 'AI Lab is for experts, admins, and supporters' }, { status: 403 });
+  if (!(await rateLimit(supabase, 'ai_generate')).ok) return json({ message: 'AI rate limit reached' }, { status: 429 });
+
+  const { data: idea, error: ge } = await supabase.from('ideas')
+    .select('id, title, summary_md, expansions').eq('id', params.id).single();
+  if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
+
+  let round;
+  try {
+    round = await generateStructured(buildReviewPrompt(idea.title, idea.summary_md ?? ''), CritiqueRoundSchema);
+  } catch (e) {
+    return json({ message: (e as Error).message || 'AI failed' }, { status: 502 });
+  }
+  const prev = Array.isArray((idea.expansions as any)?.critiques) ? (idea.expansions as any).critiques : [];
+  const entry = { round: prev.length + 1, reviewers: round.reviewers };
+  const expansions = { ...(idea.expansions as any), critiques: [...prev, entry] };
+  const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+  if (ue) return json({ message: ue.message }, { status: 400 });
+  return json({ round: entry });
+};
+```
+
+- [ ] **Step 4: Implement `plan/+server.ts`** (exec | readable; same guards)
+
+```ts
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { canUseLabAi } from '$lib/server/lab/access';
+import { generate } from '$lib/server/ai';
+import { rateLimit } from '$lib/server/rate-limit';
+
+const PROMPTS = {
+  exec: (t: string, n: string) => `Write a concise, agent-EXECUTABLE plan (markdown) to investigate this AI-safety idea.\nSections: Objective, Method (numbered steps), Artifacts, Success criteria, Risks.\nIdea: "${t}"\nNotes:\n${n}`,
+  readable: (t: string, n: string) => `Write a readable proto-paper plan (markdown): motivation, approach, expected contribution.\nIdea: "${t}"\nNotes:\n${n}`
+};
+
+export const POST: RequestHandler = async ({ params, request, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return json({ message: 'Sign in' }, { status: 401 });
+  if (!(await canUseLabAi(supabase))) return json({ message: 'AI Lab is for experts, admins, and supporters' }, { status: 403 });
+  if (!(await rateLimit(supabase, 'ai_generate')).ok) return json({ message: 'AI rate limit reached' }, { status: 429 });
+  const body = await request.json().catch(() => ({}));
+  const kind: 'exec' | 'readable' = body.kind === 'readable' ? 'readable' : 'exec';
+
+  const { data: idea, error: ge } = await supabase.from('ideas').select('id, title, summary_md, expansions').eq('id', params.id).single();
+  if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
+
+  let md: string;
+  try { md = await generate(PROMPTS[kind](idea.title, idea.summary_md ?? '')); }
+  catch (e) { return json({ message: (e as Error).message || 'AI failed' }, { status: 502 }); }
+
+  const key = kind === 'exec' ? 'exec_plan_md' : 'readable_plan_md';
+  const expansions = { ...(idea.expansions as any), [key]: { md, at: new Date().toISOString() } };
+  const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+  if (ue) return json({ message: ue.message }, { status: 400 });
+  return json({ kind, md });
+};
+```
+
+- [ ] **Step 5: Run tests (pass). Commit.** `git commit -am "feat(lab): AI review + plan endpoints (gated, rate-limited)"`
+
+---
+
+## Task 9: Drafts client store (optimistic)
+
+**Files:**
+- Create: `src/lib/lab/draftsStore.svelte.ts`
+- Test: `src/lib/lab/draftsStore.test.ts`
+
+- [ ] **Step 1: Write the failing test** (pure logic: optimistic add + reconcile + remove)
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createDraftsStore } from './draftsStore.svelte';
+beforeEach(() => { vi.restoreAllMocks(); });
+describe('draftsStore', () => {
+  it('adds optimistically then reconciles to the server id/slug', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'real', slug: 'sl' }) }));
+    const s = createDraftsStore([]);
+    const tmp = s.add('My idea');
+    expect(s.drafts[0].title).toBe('My idea');
+    expect(s.drafts[0].pending).toBe(true);
+    await tmp;
+    expect(s.drafts[0].id).toBe('real');
+    expect(s.drafts[0].slug).toBe('sl');
+    expect(s.drafts[0].pending).toBe(false);
+  });
+  it('marks errored on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({ message: 'x' }) }));
+    const s = createDraftsStore([]);
+    await s.add('X');
+    expect(s.drafts[0].errored).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it (fails).**
+
+- [ ] **Step 3: Implement** (Svelte 5 `$state` rune store; temp id via index counter — no Math.random/Date in module init)
+
+```ts
+export type DraftRow = {
+  id: string; slug: string | null; title: string; pending: boolean; errored: boolean;
+};
+let tmpSeq = 0;
+export function createDraftsStore(initial: { id: string; slug: string; title: string }[]) {
+  const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, pending: false, errored: false })));
+  async function add(title: string) {
+    const tmpId = `tmp-${tmpSeq++}`;
+    drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false });
+    const row = drafts[0];
+    try {
+      const res = await fetch('/api/drafts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ title }) });
+      if (!res.ok) throw new Error((await res.json()).message);
+      const { id, slug } = await res.json();
+      row.id = id; row.slug = slug; row.pending = false;
+    } catch { row.errored = true; row.pending = false; }
+  }
+  function remove(id: string) {
+    const i = drafts.findIndex((d) => d.id === id);
+    if (i >= 0) { const [r] = drafts.splice(i, 1); fetch(`/api/drafts/${id}`, { method: 'DELETE' }); return r; }
+  }
+  return { drafts, add, remove };
+}
+```
+(If the `.svelte.ts` rune store is awkward to unit-test under vitest, test the pure reconcile/remove logic by extracting it; keep the public surface `{ drafts, add, remove }`.)
+
+- [ ] **Step 4: Run it (passes). Commit.** `git commit -am "feat(lab): optimistic drafts store"`
+
+---
+
+## Task 10: Lab UI — capture, list, card, expansion panel
+
+**Files:**
+- Create: `src/lib/components/lab/DraftCapture.svelte`, `DraftList.svelte`, `DraftCard.svelte`, `ExpansionPanel.svelte`, `CritiqueRounds.svelte`
+- Modify: `src/routes/dashboard/+page.server.ts` (load my drafts for the Lab tab), `src/routes/dashboard/+page.svelte` (Lab tab)
+
+- [ ] **Step 1: Dashboard loader — add drafts**
+
+In `dashboard/+page.server.ts` load, add (only when the user is present):
+```ts
+const { data: drafts } = await supabase
+  .from('ideas').select('id, slug, title, summary_md, expansions')
+  .eq('author_id', user.id).eq('status', 'draft')
+  .order('created_at', { ascending: false });
+// return { ..., drafts: drafts ?? [] }
+```
+
+- [ ] **Step 2: `DraftCapture.svelte`** — one always-focused input; on Enter calls `store.add(value)` then clears. Uses `.input` + design-system classes. (Bind to a local `let value = $state('')`.)
+
+- [ ] **Step 3: `DraftCard.svelte`** — collapsed row (title + a small badge if `pending`/`errored`); expands to: inline title `<input>` + notes `<textarea>` (both autosave-debounced via `PATCH /api/drafts/[id]`), the `ExpansionPanel`, and a Publish button (opens `PublishDialog`, Task 12). Debounce helper: a 600ms `setTimeout` cleared on each keystroke.
+
+- [ ] **Step 4: `ExpansionPanel.svelte`** — maps `EXPANSIONS` (Task 6). For each: `status==='soon'` → disabled chip "Soon"; `kind==='client' && key==='copy_agent'` → button that builds `buildAgentPrompt(...)` from the draft + stored plans and writes to `navigator.clipboard`; `kind==='review'` → POST `/api/lab/[id]/review`, append returned round to local state (also render `CritiqueRounds`); `kind==='plan'` → POST `/api/lab/[id]/plan` with `{kind: planKind==='exec'?'exec':'readable'}`, show returned markdown via the `Markdown` component. Show a `Spinner` while a call is in flight; on 403 show "AI Lab is for experts/admins/supporters", on 429 show the limit message.
+
+- [ ] **Step 5: `CritiqueRounds.svelte`** — render `expansions.critiques[]` as stacked cards: per round, per reviewer (label from `REVIEWERS`), `comments` (list) + `questions` (list, styled as clarifying). Newest round on top.
+
+- [ ] **Step 6: `DraftList.svelte`** — `DraftCapture` on top, then `{#each store.drafts}` `DraftCard`. Empty state: "Capture your first idea — type a line and hit Enter."
+
+- [ ] **Step 7: Dashboard Lab tab** — add a `Lab` option to the existing tab nav; when active, render `DraftList` seeded from `data.drafts`. Initialize the store: `const store = createDraftsStore(data.drafts)`.
+
+- [ ] **Step 8: Verify build + typecheck**
+
+Run: `npm run check` (expect 0/0) and `npm run build` (expect success).
+
+- [ ] **Step 9: Commit.** `git commit -am "feat(lab): dashboard Lab tab — capture, drafts list, expansion panel, critique rounds"`
+
+---
+
+## Task 11: Publish flow + admin moderation + author/admin draft view
+
+**Files:**
+- Create: `src/lib/components/lab/PublishDialog.svelte`
+- Modify: `src/routes/dashboard/+page.server.ts` (add `?/publish` action OR reuse a PATCH; see step 1), `src/routes/ideas/[slug]/+page.server.ts` (view gate), 
+- Create: `src/routes/admin/ideas/+page.server.ts`, `src/routes/admin/ideas/+page.svelte`
+
+- [ ] **Step 1: Publish action** — add to `dashboard/+page.server.ts` actions a `publish`:
+```ts
+publish: async ({ request, locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) return fail(401, { message: 'Sign in' });
+  const fd = await request.formData();
+  const id = String(fd.get('id'));
+  const type = fd.get('type') === 'hypothesis' ? 'hypothesis' : 'open_ended';
+  const patch = { type, claim: type === 'hypothesis' ? String(fd.get('claim') ?? '') : null,
+    summary_md: String(fd.get('summary_md') ?? ''), status: 'open', published_at: new Date().toISOString() };
+  const { data, error: e } = await supabase.from('ideas').update(patch).eq('id', id).eq('status', 'draft').select('slug, status').single();
+  if (e || !data) return fail(400, { message: e?.message ?? 'Publish failed' });
+  if (data.status === 'open') redirect(303, `/ideas/${data.slug}`);
+  return { submitted: true }; // archived → pending admin review
+}
+```
+(The `enforce_idea_publish` trigger coerces non-expert publishes to `archived`, so `data.status` tells us which message to show.)
+
+- [ ] **Step 2: `PublishDialog.svelte`** — a small modal: type select, hypothesis claim (if hypothesis), summary textarea prefilled from notes; posts the `?/publish` form with the draft `id`. On `form.submitted`, show "Submitted for admin review."
+
+- [ ] **Step 3: Detail view gate** — in `ideas/[slug]/+page.server.ts`, replace the unconditional draft/archived 404 with author/admin allowance:
+```ts
+const isAuthor = !!user && user.id === idea.author_id;
+// isAdmin already computed later; hoist the admin check above this point, or fetch it here
+if ((idea.status === 'archived' || idea.status === 'draft') && !isAuthor && !isAdminEarly) error(404, 'Idea not found');
+```
+(Hoist the existing `is_admin` profile read so it's available before this check.)
+
+- [ ] **Step 4: Admin moderation page** — `admin/ideas/+page.server.ts`:
+```ts
+export const load = async ({ locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) redirect(303, '/login?next=/admin/ideas');
+  const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+  if (!me?.is_admin) error(403, 'Admins only');
+  const { data: archived } = await supabase.from('ideas')
+    .select('id, slug, title, summary_md, author:profiles!ideas_author_id_fkey(handle, display_name)')
+    .eq('status', 'archived').order('created_at', { ascending: false });
+  return { archived: archived ?? [] };
+};
+export const actions = {
+  promote: async ({ request, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, {});
+    const fd = await request.formData();
+    const { error: e } = await supabase.from('ideas').update({ status: 'open', published_at: new Date().toISOString() }).eq('id', String(fd.get('id')));
+    if (e) return fail(400, { message: e.message });
+    return { promoted: true };
+  }
+};
+```
+(`admins manage ideas` RLS + `is_admin()` in the publish trigger allow an admin to set `open`.) `+page.svelte`: list each archived idea (title, author, summary preview, a link to its slug — admins can now view it) + a "Promote to open" form button.
+
+- [ ] **Step 5: Verify** `npm run check`, `npm run build`. **Commit.** `git commit -am "feat(lab): publish flow + admin archived-idea moderation + author/admin draft view"`
+
+---
+
+## Task 12: Carryovers — expert profile authored ideas + Verified badge
+
+**Files:**
+- Modify: `src/routes/u/[handle]/+page.server.ts` (+ authored ideas, expert status), `src/routes/u/[handle]/+page.svelte`
+- Modify: `src/routes/experts/+page.svelte` (Verified badge + design-system restyle)
+
+- [ ] **Step 1: Profile loader** — in `u/[handle]/+page.server.ts` load, after fetching `profile`, add:
+```ts
+const { data: expert } = await supabase.from('experts').select('status').eq('id', profile.id).maybeSingle();
+const { data: authored } = await supabase.from('ideas')
+  .select('id, slug, title, summary_md, type, status')
+  .eq('author_id', profile.id).not('status', 'in', '(draft,archived)')
+  .order('created_at', { ascending: false }).limit(50);
+// return { ..., isVerifiedExpert: expert?.status === 'approved', authored: authored ?? [] }
+```
+
+- [ ] **Step 2: Profile page** — show a "Verified expert" chip when `isVerifiedExpert`; add an "Ideas by {name}" section rendering `authored` via `IdeaCard` (grid). Hide the section when empty.
+
+- [ ] **Step 3: Experts list** — restyle `experts/+page.svelte` to the design system (`.card`, `.u-label`); add a "Verified" chip to each (all are approved). Fix copy ("post ideas").
+
+- [ ] **Step 4: Verify** `npm run check`, `npm run build`. **Commit.** `git commit -am "feat(experts): authored ideas on profiles + Verified badge"`
+
+---
+
+## Task 13: E2E — drafts capture → publish; experts profile
+
+**Files:**
+- Create: `e2e/lab.spec.ts`
+
+- [ ] **Step 1: Write the spec** (authed as the expert role; AI endpoints are NOT exercised here — they need a key; the loop is unit-tested with mocks)
+
+```ts
+import { test, expect } from '@playwright/test';
+import { ROLES } from './auth';
+test('capture a draft, then publish it as an expert', async ({ browser }) => {
+  const ctx = await browser.newContext({ storageState: ROLES.expert.state });
+  const page = await ctx.newPage();
+  await page.goto('/dashboard?tab=lab');
+  const title = `Lab Draft ${crypto.randomUUID().slice(0, 8)}`;
+  await page.getByPlaceholder('New idea…').fill(title);
+  await page.getByPlaceholder('New idea…').press('Enter');
+  await expect(page.getByText(title)).toBeVisible();            // optimistic row
+  await page.getByText(title).click();                          // expand
+  await page.getByRole('button', { name: /Publish/ }).click();
+  await page.getByRole('button', { name: /Publish idea|Confirm/ }).click();
+  await page.waitForURL(/\/ideas\/[a-z0-9-]+$/);                // expert publishes straight to open
+  await expect(page.getByRole('heading', { name: title })).toBeVisible();
+  await ctx.close();
+});
+```
+
+- [ ] **Step 2: Add `idea_create` reset to `e2e/fixtures/seed.sql`** if needed (so repeated runs don't hit the rate limit) — mirror how other buckets are reset there.
+
+- [ ] **Step 3: Run e2e** (with the local stack + preview server up per the project's e2e setup). Expected: pass (plus the existing suite still green).
+
+- [ ] **Step 4: Commit.** `git commit -am "test(e2e): lab draft capture → expert publish"`
+
+---
+
+## Task 14: Final verification & PR
+
+- [ ] **Step 1:** `npm run check` → 0/0; `npx vitest run` → all pass; `npm run build` → clean.
+- [ ] **Step 2:** Full e2e green (AI endpoints mocked/untouched).
+- [ ] **Step 3:** `supabase test db` pgTAP green.
+- [ ] **Step 4:** Open the PR. Body must call out owner prerequisites: set `AI_GATEWAY_API_KEY` + budget in Vercel; apply `20260608081014_open_idea_submissions.sql` **and** `<ts>_add_ideas_lab.sql` to the cloud DB (SQL Editor); merge order after #62.
+
+---
+
+## Notes for the implementer
+- **No service-role client** anywhere — all DB access goes through the RLS-scoped request `supabase`. Gating is server-authoritative via triggers, not app code.
+- **AI cost**: every AI endpoint guards `canUseLabAi` + `rateLimit('ai_generate')` before calling `generate*`. Persist to `expansions` only on success.
+- **`expansions` is author-writable only** (RLS `authors update own ideas`); never trust it from the client for gating decisions.
+- **Svelte 5 runes**: prop-seeded `$state` needs `// svelte-ignore state_referenced_locally` (project precedent). Debounced autosave: clear the prior timer each keystroke.
+- **Reduced motion**: spinners/shimmer already handle it via `app.css`.

--- a/docs/superpowers/specs/2026-06-08-ideas-lab-design.md
+++ b/docs/superpowers/specs/2026-06-08-ideas-lab-design.md
@@ -1,0 +1,165 @@
+# Ideas Lab — Design Spec
+
+> **Status:** Approved for planning (2026-06-08). Single PR. Builds on the redesigned public
+> face (PR #62) and the submission-gating work started on `feat-open-submissions`.
+
+## 1. Overview
+
+A personal **Ideas Lab** in the dashboard: capture research ideas at notes-app speed, then
+incubate each one through an AI-powered **critique ↔ refine loop**, distill it into an
+**ExecPlan** + a **readable plan**, and hand both off to an agent — or publish the idea to the
+platform. Each draft behaves like a to-do with expandable tools.
+
+**The cool part:** simulated peer review. You write a rough idea; a panel of AI "reviewers"
+(skeptic, methods, impact, clarifying questions) pokes holes and asks questions; you refine;
+re-run; the idea visibly levels up each pass. When it's tight, generate the plans and ship them
+to an agent that builds the paper.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Add a draft in < 1s, perceived-instant (optimistic), synced (not browser-local).
+- Each draft is a real `ideas` row in `draft` status (real slug, private to the author).
+- A uniform, extensible per-draft **expansion registry** so new tools drop in cleanly.
+- AI critique↔refine loop with stored rounds; ExecPlan + readable-plan generation; copy-to-agent.
+- "Make it a full idea" → publish through existing submission gating.
+- AI features gated to **approved experts · admins · active monthly supporters**, rate-limited.
+
+**Non-goals (this PR)**
+- Real recurring billing / Stripe subscriptions (Phase 2). The supporter flag exists; it's
+  populated by an admin for now and by billing later.
+- GitHub repo scaffolding, venue/conference discovery, "link up agents" — registered as
+  visible **"coming soon"** tools to prove extensibility; not implemented.
+- Streaming token UI (responses render on completion; streaming is a later polish).
+
+## 3. Data model & migrations
+
+A single migration `add_ideas_lab` extending the in-progress `open_idea_submissions` work:
+
+**`ideas` table**
+- `expansions jsonb not null default '{}'` — per-draft tool output, keyed by tool:
+  - `agent_prompt`: `{ text, at }`
+  - `critiques`: `[ { round, at, reviewers: [{ persona, comments[], questions[] }] } ]`
+  - `exec_plan_md`: `{ md, at }`
+  - `readable_plan_md`: `{ md, at }`
+  Published ideas simply carry whatever they had; the field is harmless there.
+
+**`profiles` table**
+- `supporter_until timestamptz` — null = not a supporter; a future timestamp = active monthly
+  supporter. Set by admin today; by billing in Phase 2. (No new RLS; profiles already
+  readable; only admin/self/ billing may update — covered by existing update policy + admin.)
+
+**Submission gating (extends `enforce_idea_submission`)**
+- *INSERT:* if `new.status = 'draft'` → leave as draft (private scratchpad, not published).
+  Otherwise keep the rule: approved expert → `open`, else → `archived`.
+- *UPDATE (publish) — new `BEFORE UPDATE` trigger `enforce_idea_publish`:* when `status`
+  changes **to a public status** (`open`/`resolved`/`closed`) from a non-public one, re-apply
+  the expert check — approved expert/admin author → `open`; otherwise coerce to `archived`
+  (submitted for admin review). Prevents the "create draft → edit to open" self-publish bypass.
+  Status changes *between* public states by the author are unaffected.
+
+**AI access predicate — `public.can_use_lab_ai()`** (SECURITY DEFINER, pinned search_path):
+```
+returns is_admin()
+     OR exists(approved expert where id = auth.uid())
+     OR exists(profile where id = auth.uid() and supporter_until > now())
+```
+Used by the AI endpoints (defense in depth; the endpoints also check it in app code).
+
+**Rate limit:** add an `ai_generate` bucket to `consume_rate_limit` (server-authoritative,
+e.g. 30/hour) — the existing zero-policy `rate_limits` table + RPC.
+
+## 4. Drafts capture & list (optimistic, no AI)
+
+**Location:** a **Lab** tab on `/dashboard` (alongside Feed / Discover).
+
+**Capture:** one always-focused input at top. On Enter:
+1. Optimistically prepend a row with a temp id + the typed title (status `draft`).
+2. `POST /api/drafts` (or a form action) inserts `{ author_id, title, status: 'draft' }`;
+   the slug + status triggers run; the response returns `{ id, slug }`.
+3. Reconcile the temp row to the real id/slug. On failure: mark the row errored + offer retry.
+
+**List:** the author's `ideas` where `status='draft'`, newest first (SSR initial load; author-only
+RLS). Each row collapses/expands. **Draft notes reuse `ideas.summary_md`** (no new column) — the
+freeform markdown you write under a draft; capture leaves it empty, expanding reveals the notes
+editor. Title + notes inline-editable; edits autosave debounced (~600ms, optimistic) via
+`PATCH /api/drafts/[id]`. Delete with a brief undo window.
+
+**Drafts are edited only in the Lab** — the public `/ideas/<slug>` page stays 404 for `draft`
+(and `archived`) status, except the author/admin may preview (needed for moderation; see §7).
+
+## 5. Expansion registry
+
+A registry of tool definitions, each: `key`, `label`, `icon`, `gated` (needs `can_use_lab_ai`?),
+`status` ('ready' | 'soon'), and a runner. The expanded-draft panel renders every tool uniformly:
+a button → runs → shows the stored output (from `ideas.expansions[key]`) + timestamp, re-runnable.
+
+- Client tools (no server): **Copy to agent** — formats title + notes + latest ExecPlan/readable
+  plan into a clean handoff prompt → clipboard. Always available.
+- Server tools (write to `expansions`): the AI tools in §6.
+- "Coming soon" (registered, disabled): **GitHub repo**, **Find venues**, **Link agent**.
+
+Adding a tool = one registry entry + (for server tools) one endpoint. The panel needs no changes.
+
+## 6. The Lab — AI critique↔refine loop & plans
+
+**Engine:** Vercel AI Gateway + Claude via the AI SDK, behind a single server seam
+`generate(prompt, schema?)` in `$lib/server/ai.ts` (model string `anthropic/claude-...`; reads
+`AI_GATEWAY_API_KEY`). All AI runs are server-side endpoints under `/api/lab/...`, each:
+guard `can_use_lab_ai()` → `consume_rate_limit('ai_generate')` → call `generate()` → persist
+into `ideas.expansions[...]` (RLS: author-only update) → return JSON.
+
+**Reviewer panel (critique round):** `POST /api/lab/[id]/review` →
+`generate()` with a structured-output schema returning, per persona (Skeptic, Methods, Impact,
+Clarifying), `comments[]` + `questions[]`. Appended as a new entry to `expansions.critiques[]`
+with an incrementing `round`. The panel shows rounds as stacked cards; the user edits notes to
+answer, then re-runs → next round. History is kept so progress is visible.
+
+**Distill:**
+- `POST /api/lab/[id]/exec-plan` → a structured, agent-executable ExecPlan in markdown
+  (objective, method/steps, artifacts, success criteria, risks) → `expansions.exec_plan_md`.
+- `POST /api/lab/[id]/readable-plan` → a narrative proto-paper (motivation, approach, expected
+  contribution) → `expansions.readable_plan_md`.
+Both prompts are fed the title + notes + the latest critique round so they reflect the refinement.
+
+**Hand off:** Copy-to-agent (client) bundles notes + ExecPlan + readable plan into one prompt.
+
+**Cost & failure:** rate-limited per §3; AI errors return a clear message and never corrupt
+stored expansions (write only on success). Timeouts surface a retry.
+
+## 7. Publish ("make it a full idea")
+
+A **Publish** action on a draft opens a small confirm (type, optional hypothesis claim, summary
+prefilled from notes) → `PATCH` the row's `type/claim/summary_md` + set `status` toward `open`.
+The `enforce_idea_publish` UPDATE trigger decides the outcome: expert/admin → live at its slug;
+non-expert → `archived` + "submitted for review" toast. The row *becomes* the idea (same slug).
+
+**Admin moderation (closes the gating loop):** the detail loader allows the **author or an admin**
+to view `archived`/`draft` ideas (others still 404), and `/admin/ideas` lists `archived`
+submissions with a **Promote to open** action (RLS `admins manage ideas` already allows it).
+
+## 8. Security & RLS
+
+- Drafts: `authors read own ideas` (existing) keeps them private; `authenticated insert own
+  ideas` (from the gating migration) + the INSERT trigger force `draft`/`archived` correctly.
+- Publish bypass: closed by the `enforce_idea_publish` UPDATE trigger (server-authoritative,
+  not just app code).
+- AI endpoints: `can_use_lab_ai()` + rate limit, both server-side. `AI_GATEWAY_API_KEY` is
+  server-only (never `PUBLIC_`). No service-role client anywhere (owner principle).
+- `expansions` is author-writable only (covered by `authors update own ideas`); never trusted
+  from the client for gating.
+
+## 9. Testing
+
+- **pgTAP:** INSERT-draft stays `draft`; non-expert publish (draft→open) coerced to `archived`;
+  expert/admin publish → `open`; `can_use_lab_ai()` truth table (admin / approved expert /
+  supporter_until future vs past / none).
+- **vitest:** expansion registry; agent-prompt formatter; critique-JSON schema parse/guard;
+  `can_use_lab_ai` app-side mirror. AI `generate()` is stubbed — **no live model calls in CI.**
+- **e2e:** quick-add a draft (optimistic → appears) → publish as expert → reachable at slug;
+  AI tools mocked at the endpoint.
+
+## 10. Out of scope / follow-ups
+
+Real subscription billing (Phase 2) populating `supporter_until`; GitHub/venue/agent-link tools;
+streaming responses; multi-draft bulk ops.

--- a/e2e/lab.spec.ts
+++ b/e2e/lab.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { ROLES } from './auth';
+
+test('capture a draft, then publish it as an expert', async ({ browser }) => {
+  const ctx = await browser.newContext({ storageState: ROLES.expert.state });
+  const page = await ctx.newPage();
+
+  await page.goto('/dashboard?tab=lab');
+
+  // SvelteKit SSR delivers the shell immediately; Svelte 5 hydration (loading the JS
+  // bundle + running it) happens asynchronously.  The DraftCapture input's onkeydown
+  // handler is registered via Svelte 5's event-delegation mechanism, which stores the
+  // handler on the element via a Symbol(events) property.  We wait until that symbol
+  // is present — meaning Svelte has fully mounted and wired up the keydown handler —
+  // before we start typing.
+  await page.waitForFunction(() => {
+    const input = document.querySelector('input[placeholder="New idea…"]');
+    if (!input) return false;
+    return Object.getOwnPropertySymbols(input).some(s => s.toString() === 'Symbol(events)');
+  }, { timeout: 10_000 });
+
+  // ── Capture a draft ──
+  const title = `Lab Draft ${crypto.randomUUID().slice(0, 8)}`;
+  await page.getByPlaceholder('New idea…').pressSequentially(title);
+  await page.getByPlaceholder('New idea…').press('Enter');
+
+  // Optimistic row appears immediately
+  await expect(page.getByText(title)).toBeVisible();
+
+  // ── Expand the card by clicking its header ──
+  await page.getByText(title).click();
+
+  // Wait for the draft to reconcile (id transitions from tmp-* → real UUID, Publish button enables)
+  const publishBtn = page.getByRole('button', { name: 'Publish' });
+  await expect(publishBtn).toBeEnabled({ timeout: 10_000 });
+
+  // ── Open the publish dialog ──
+  await publishBtn.click();
+
+  // Dialog is now open; fill in the required summary field
+  await page.getByLabel('Summary').fill('A non-empty summary written during the e2e test.');
+
+  // ── Submit ──
+  await page.getByRole('button', { name: 'Publish idea' }).click();
+
+  // Expert publishes straight to open → action redirects 303 to /ideas/<slug>
+  await page.waitForURL(/\/ideas\/[a-z0-9-]+$/, { timeout: 15_000 });
+
+  // The idea detail page shows the heading
+  await expect(page.getByRole('heading', { name: title })).toBeVisible();
+
+  await ctx.close();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
 				"@fontsource-variable/sora": "^5.2.8",
 				"@supabase/ssr": "^0.10.3",
 				"@supabase/supabase-js": "^2.107.0",
+				"ai": "^6.0.197",
 				"marked": "^18.0.5",
-				"sanitize-html": "^2.17.4"
+				"sanitize-html": "^2.17.4",
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
@@ -35,6 +37,52 @@
 			},
 			"engines": {
 				"node": ">=22"
+			}
+		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "3.0.125",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.125.tgz",
+			"integrity": "sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.10",
+				"@ai-sdk/provider-utils": "4.0.27",
+				"@vercel/oidc": "3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+			"integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.27",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+			"integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.10",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.8"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -892,6 +940,15 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.133.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -1234,7 +1291,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@supabase/auth-js": {
@@ -2384,6 +2440,15 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/@vercel/oidc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+			"integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.8",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -2548,6 +2613,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/ai": {
+			"version": "6.0.197",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.197.tgz",
+			"integrity": "sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "3.0.125",
+				"@ai-sdk/provider": "3.0.10",
+				"@ai-sdk/provider-utils": "4.0.27",
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -3018,6 +3101,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3243,6 +3335,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -4647,6 +4745,15 @@
 			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
 		"@fontsource-variable/sora": "^5.2.8",
 		"@supabase/ssr": "^0.10.3",
 		"@supabase/supabase-js": "^2.107.0",
+		"ai": "^6.0.197",
 		"marked": "^18.0.5",
-		"sanitize-html": "^2.17.4"
+		"sanitize-html": "^2.17.4",
+		"zod": "^4.4.3"
 	}
 }

--- a/src/lib/components/lab/CritiqueRounds.svelte
+++ b/src/lib/components/lab/CritiqueRounds.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { REVIEWERS } from '$lib/lab/critique';
+
+  let { rounds }: { rounds: any[] } = $props();
+
+  // Newest first
+  const sorted = $derived([...rounds].reverse());
+</script>
+
+{#if sorted.length > 0}
+  <div class="rounds">
+    {#each sorted as round (round.round)}
+      <div class="round card">
+        <p class="u-label round__label">Review round {round.round}</p>
+        {#each round.reviewers as reviewer}
+          {@const label = REVIEWERS.find((r) => r.key === reviewer.persona)?.label ?? reviewer.persona}
+          <div class="reviewer">
+            <p class="reviewer__name">{label}</p>
+            {#if reviewer.comments?.length}
+              <ul class="reviewer__list">
+                {#each reviewer.comments as comment}
+                  <li class="reviewer__item">{comment}</li>
+                {/each}
+              </ul>
+            {/if}
+            {#if reviewer.questions?.length}
+              <ul class="reviewer__list reviewer__list--questions">
+                {#each reviewer.questions as question}
+                  <li class="reviewer__item reviewer__item--question">
+                    <span class="reviewer__q-mark" aria-hidden="true">?</span>
+                    {question}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .rounds { display: flex; flex-direction: column; gap: .75rem; margin-top: .75rem; }
+
+  .round { padding: 1rem; }
+  .round__label { margin-bottom: .75rem; }
+
+  .reviewer { margin-bottom: .75rem; }
+  .reviewer:last-child { margin-bottom: 0; }
+  .reviewer__name {
+    font-size: .8rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
+    color: var(--faint); margin-bottom: .35rem;
+  }
+
+  .reviewer__list { list-style: none; padding: 0; margin: 0 0 .35rem; display: flex; flex-direction: column; gap: .25rem; }
+  .reviewer__list:last-child { margin-bottom: 0; }
+
+  .reviewer__item { font-size: .88rem; color: var(--body); line-height: 1.5; padding-left: .9rem; position: relative; }
+  .reviewer__item::before { content: '·'; position: absolute; left: 0; color: var(--faint); }
+
+  .reviewer__list--questions .reviewer__item { color: var(--muted); font-style: italic; }
+  .reviewer__item--question { padding-left: 1.2rem; }
+  .reviewer__item--question::before { content: ''; }
+  .reviewer__q-mark {
+    position: absolute; left: 0; font-size: .72rem; font-weight: 800; font-style: normal;
+    color: var(--green-deep); line-height: 1.5;
+  }
+</style>

--- a/src/lib/components/lab/DraftCapture.svelte
+++ b/src/lib/components/lab/DraftCapture.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  let { store }: { store: { add: (title: string) => Promise<void> } } = $props();
+  let value = $state('');
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && value.trim()) {
+      store.add(value.trim());
+      value = '';
+    }
+  }
+</script>
+
+<input
+  class="input"
+  placeholder="New idea…"
+  bind:value
+  onkeydown={onKeydown}
+  autofocus
+  aria-label="Capture new draft idea"
+/>

--- a/src/lib/components/lab/DraftCapture.svelte
+++ b/src/lib/components/lab/DraftCapture.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   let { store }: { store: { add: (title: string) => Promise<void> } } = $props();
   let value = $state('');
+  let el: HTMLInputElement | undefined;
+
+  $effect(() => {
+    el?.focus();
+  });
 
   function onKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && value.trim()) {
@@ -14,7 +19,7 @@
   class="input"
   placeholder="New idea…"
   bind:value
+  bind:this={el}
   onkeydown={onKeydown}
-  autofocus
   aria-label="Capture new draft idea"
 />

--- a/src/lib/components/lab/DraftCard.svelte
+++ b/src/lib/components/lab/DraftCard.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  // svelte-ignore state_referenced_locally
+  import ExpansionPanel from './ExpansionPanel.svelte';
+  import type { DraftRow } from '$lib/lab/draftsStore.svelte';
+
+  let {
+    draft = $bindable(),
+    onremove,
+  }: {
+    draft: DraftRow;
+    onremove: (id: string) => void;
+  } = $props();
+
+  let expanded = $state(false);
+
+  // Local editable copies seeded from prop — svelte-ignore state_referenced_locally
+  // svelte-ignore state_referenced_locally
+  let localTitle = $state(draft.title);
+  // svelte-ignore state_referenced_locally
+  let localNotes = $state(draft.summary_md ?? '');
+
+  let titleTimer: ReturnType<typeof setTimeout> | null = null;
+  let notesTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function saveTitle(val: string) {
+    draft.title = val;
+    if (titleTimer) clearTimeout(titleTimer);
+    if (draft.id.startsWith('tmp-')) return;
+    titleTimer = setTimeout(() => {
+      fetch(`/api/drafts/${draft.id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: val }),
+      });
+    }, 600);
+  }
+
+  function saveNotes(val: string) {
+    draft.summary_md = val;
+    if (notesTimer) clearTimeout(notesTimer);
+    if (draft.id.startsWith('tmp-')) return;
+    notesTimer = setTimeout(() => {
+      fetch(`/api/drafts/${draft.id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ notes_md: val }),
+      });
+    }, 600);
+  }
+
+  function toggle() { expanded = !expanded; }
+</script>
+
+<article class="draft-card card card-hover" class:draft-card--expanded={expanded}>
+  <!-- Collapsed header — click anywhere on header row to expand -->
+  <div class="draft-card__header" role="button" tabindex="0"
+       onclick={toggle} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }}>
+    <span class="draft-card__title-text" title={draft.title}>
+      {draft.title || 'Untitled idea'}
+    </span>
+    <span class="draft-card__meta">
+      {#if draft.pending}
+        <span class="chip chip-muted">Saving…</span>
+      {:else if draft.errored}
+        <span class="chip" style="color:var(--neg); background:color-mix(in srgb,var(--neg) 10%,transparent); border:1px solid color-mix(in srgb,var(--neg) 20%,transparent)">Error</span>
+      {/if}
+      <span class="draft-card__chevron" aria-hidden="true">{expanded ? '▲' : '▼'}</span>
+    </span>
+  </div>
+
+  <!-- Expanded body -->
+  {#if expanded}
+    <div class="draft-card__body">
+      <div class="draft-card__field">
+        <label class="u-label draft-card__field-label" for="draft-title-{draft.id}">Title</label>
+        <input
+          id="draft-title-{draft.id}"
+          class="input"
+          value={localTitle}
+          oninput={(e) => { localTitle = (e.currentTarget as HTMLInputElement).value; saveTitle(localTitle); }}
+          placeholder="Idea title"
+        />
+      </div>
+
+      <div class="draft-card__field">
+        <label class="u-label draft-card__field-label" for="draft-notes-{draft.id}">Notes</label>
+        <textarea
+          id="draft-notes-{draft.id}"
+          class="textarea"
+          value={localNotes}
+          oninput={(e) => { localNotes = (e.currentTarget as HTMLTextAreaElement).value; saveNotes(localNotes); }}
+          placeholder="Describe your idea, hypotheses, context…"
+          rows={5}
+        ></textarea>
+      </div>
+
+      <ExpansionPanel
+        draftId={draft.id}
+        title={draft.title}
+        notes_md={draft.summary_md ?? ''}
+        bind:expansions={draft.expansions}
+      />
+
+      <div class="draft-card__actions">
+        <button
+          class="btn btn-primary btn-sm"
+          disabled={draft.pending || draft.id.startsWith('tmp-')}
+          title="Publish this draft as a public idea"
+        >
+          Publish
+        </button>
+        <button
+          class="btn btn-ghost btn-sm draft-card__delete"
+          onclick={() => onremove(draft.id)}
+          title="Delete draft"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  {/if}
+</article>
+
+<style>
+  .draft-card { padding: 0; overflow: hidden; }
+  .draft-card--expanded { box-shadow: var(--shadow-2); }
+
+  .draft-card__header {
+    display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+    padding: .85rem 1rem; cursor: pointer; user-select: none;
+    transition: background var(--dur-fast) var(--ease-snappy);
+  }
+  .draft-card__header:hover { background: var(--surface-2); }
+
+  .draft-card__title-text {
+    flex: 1; font-weight: 600; font-size: .95rem; color: var(--ink);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .draft-card__meta { display: flex; align-items: center; gap: .5rem; flex: none; }
+  .draft-card__chevron { color: var(--faint); font-size: .7rem; }
+
+  .draft-card__body {
+    padding: 0 1rem 1rem; border-top: 1px solid var(--line);
+    display: flex; flex-direction: column; gap: .8rem;
+  }
+
+  .draft-card__field { display: flex; flex-direction: column; gap: .35rem; padding-top: .8rem; }
+  .draft-card__field:first-child { padding-top: .9rem; }
+  .draft-card__field-label { display: block; }
+
+  .draft-card__actions {
+    display: flex; align-items: center; gap: .6rem; padding-top: .4rem;
+  }
+
+  .draft-card__delete { color: var(--neg); }
+  .draft-card__delete:hover { color: var(--neg); background: color-mix(in srgb, var(--neg) 8%, transparent); }
+</style>

--- a/src/lib/components/lab/DraftCard.svelte
+++ b/src/lib/components/lab/DraftCard.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
-  // svelte-ignore state_referenced_locally
   import ExpansionPanel from './ExpansionPanel.svelte';
+  import PublishDialog from './PublishDialog.svelte';
   import type { DraftRow } from '$lib/lab/draftsStore.svelte';
 
   let {
     draft = $bindable(),
     onremove,
+    form = null,
   }: {
     draft: DraftRow;
     onremove: (id: string) => void;
+    form?: { submitted?: boolean; message?: string } | null;
   } = $props();
 
   let expanded = $state(false);
+  let publishOpen = $state(false);
 
   // Local editable copies seeded from prop — svelte-ignore state_referenced_locally
   // svelte-ignore state_referenced_locally
@@ -105,6 +108,7 @@
         <button
           class="btn btn-primary btn-sm"
           disabled={draft.pending || draft.id.startsWith('tmp-')}
+          onclick={() => { publishOpen = true; }}
           title="Publish this draft as a public idea"
         >
           Publish
@@ -120,6 +124,12 @@
     </div>
   {/if}
 </article>
+
+<PublishDialog
+  bind:open={publishOpen}
+  draft={{ id: draft.id, title: draft.title, summary_md: draft.summary_md ?? '' }}
+  {form}
+/>
 
 <style>
   .draft-card { padding: 0; overflow: hidden; }

--- a/src/lib/components/lab/DraftList.svelte
+++ b/src/lib/components/lab/DraftList.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import DraftCapture from './DraftCapture.svelte';
+  import DraftCard from './DraftCard.svelte';
+
+  let {
+    store,
+  }: {
+    store: { drafts: any[]; add: (title: string) => Promise<void>; remove: (id: string) => void };
+  } = $props();
+</script>
+
+<div class="draft-list">
+  <DraftCapture {store} />
+
+  {#if store.drafts.length === 0}
+    <p class="draft-list__empty">Capture your first idea — type a line and hit Enter.</p>
+  {:else}
+    <ul class="draft-list__items">
+      {#each store.drafts as draft, i (draft.id)}
+        <li>
+          <DraftCard bind:draft={store.drafts[i]} onremove={store.remove} />
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .draft-list { display: flex; flex-direction: column; gap: .75rem; }
+
+  .draft-list__empty {
+    text-align: center; padding: 2.5rem 1rem; color: var(--muted); font-size: .95rem;
+  }
+
+  .draft-list__items { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: .6rem; }
+</style>

--- a/src/lib/components/lab/DraftList.svelte
+++ b/src/lib/components/lab/DraftList.svelte
@@ -4,8 +4,10 @@
 
   let {
     store,
+    form = null,
   }: {
     store: { drafts: any[]; add: (title: string) => Promise<void>; remove: (id: string) => void };
+    form?: { submitted?: boolean; message?: string } | null;
   } = $props();
 </script>
 
@@ -16,9 +18,9 @@
     <p class="draft-list__empty">Capture your first idea — type a line and hit Enter.</p>
   {:else}
     <ul class="draft-list__items">
-      {#each store.drafts as draft, i (draft.id)}
+      {#each store.drafts as draft, i (draft.key)}
         <li>
-          <DraftCard bind:draft={store.drafts[i]} onremove={store.remove} />
+          <DraftCard bind:draft={store.drafts[i]} onremove={store.remove} {form} />
         </li>
       {/each}
     </ul>

--- a/src/lib/components/lab/ExpansionPanel.svelte
+++ b/src/lib/components/lab/ExpansionPanel.svelte
@@ -35,11 +35,15 @@
           execPlan: expansions.exec_plan_md?.md ?? null,
           readablePlan: expansions.readable_plan_md?.md ?? null,
         });
-        await navigator.clipboard.writeText(prompt);
-        // transient copied feedback
-        if (copyTimer) clearTimeout(copyTimer);
-        copied = true;
-        copyTimer = setTimeout(() => { copied = false; }, 2000);
+        try {
+          await navigator.clipboard.writeText(prompt);
+          // transient copied feedback
+          if (copyTimer) clearTimeout(copyTimer);
+          copied = true;
+          copyTimer = setTimeout(() => { copied = false; }, 2000);
+        } catch {
+          errors['copy_agent'] = 'Clipboard unavailable';
+        }
         return;
       }
       if (kind === 'review') {
@@ -87,7 +91,7 @@
         <button
           class="chip chip-line exp-btn"
           class:exp-btn--loading={loading[exp.key]}
-          disabled={loading[exp.key] || (exp.key === 'copy_agent' && false)}
+          disabled={loading[exp.key]}
           onclick={() => runExpansion(exp.key, exp.kind, exp.planKind)}
           title={exp.label}
         >

--- a/src/lib/components/lab/ExpansionPanel.svelte
+++ b/src/lib/components/lab/ExpansionPanel.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { EXPANSIONS } from '$lib/lab/registry';
+  import { buildAgentPrompt } from '$lib/lab/agent-prompt';
+  import Spinner from '$lib/components/Spinner.svelte';
+  import CritiqueRounds from './CritiqueRounds.svelte';
+
+  let {
+    draftId,
+    title,
+    notes_md,
+    expansions = $bindable(),
+  }: {
+    draftId: string;
+    title: string;
+    notes_md: string;
+    expansions: Record<string, any>;
+  } = $props();
+
+  // Per-expansion in-flight state
+  let loading = $state<Record<string, boolean>>({});
+  let errors = $state<Record<string, string>>({});
+  // Clipboard feedback
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function runExpansion(key: string, kind: string, planKind?: string) {
+    if (loading[key]) return;
+    errors[key] = '';
+    loading[key] = true;
+    try {
+      if (kind === 'client' && key === 'copy_agent') {
+        const prompt = buildAgentPrompt({
+          title,
+          notes_md,
+          execPlan: expansions.exec_plan_md?.md ?? null,
+          readablePlan: expansions.readable_plan_md?.md ?? null,
+        });
+        await navigator.clipboard.writeText(prompt);
+        // transient copied feedback
+        if (copyTimer) clearTimeout(copyTimer);
+        copied = true;
+        copyTimer = setTimeout(() => { copied = false; }, 2000);
+        return;
+      }
+      if (kind === 'review') {
+        const res = await fetch(`/api/lab/${draftId}/review`, { method: 'POST' });
+        const data = await res.json();
+        if (!res.ok) { errors[key] = data.message ?? 'Error'; return; }
+        const prev = Array.isArray(expansions.critiques) ? expansions.critiques : [];
+        expansions = { ...expansions, critiques: [...prev, data.round] };
+        return;
+      }
+      if (kind === 'plan') {
+        const pk = planKind === 'exec' ? 'exec' : 'readable';
+        const res = await fetch(`/api/lab/${draftId}/plan`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ kind: pk }),
+        });
+        const data = await res.json();
+        if (!res.ok) { errors[key] = data.message ?? 'Error'; return; }
+        const storeKey = pk === 'exec' ? 'exec_plan_md' : 'readable_plan_md';
+        expansions = { ...expansions, [storeKey]: { md: data.md, at: new Date().toISOString() } };
+        return;
+      }
+    } finally {
+      loading[key] = false;
+    }
+  }
+
+  const critiques = $derived(Array.isArray(expansions.critiques) ? expansions.critiques : []);
+  const execPlan = $derived(expansions.exec_plan_md?.md ?? null);
+  const readablePlan = $derived(expansions.readable_plan_md?.md ?? null);
+</script>
+
+<div class="exp-panel">
+  <p class="u-label exp-panel__label">Expansion tools</p>
+  <div class="exp-panel__grid">
+    {#each EXPANSIONS as exp (exp.key)}
+      {#if exp.status === 'soon'}
+        <span class="chip chip-muted exp-btn exp-btn--soon" title="Coming soon">
+          <span class="exp-btn__icon" aria-hidden="true">{exp.icon}</span>
+          {exp.label}
+          <span class="exp-btn__soon">Soon</span>
+        </span>
+      {:else}
+        <button
+          class="chip chip-line exp-btn"
+          class:exp-btn--loading={loading[exp.key]}
+          disabled={loading[exp.key] || (exp.key === 'copy_agent' && false)}
+          onclick={() => runExpansion(exp.key, exp.kind, exp.planKind)}
+          title={exp.label}
+        >
+          {#if loading[exp.key]}
+            <Spinner size={13} label={exp.label} />
+          {:else}
+            <span class="exp-btn__icon" aria-hidden="true">{exp.icon}</span>
+          {/if}
+          {#if exp.key === 'copy_agent' && copied}Copied{:else}{exp.label}{/if}
+        </button>
+      {/if}
+    {/each}
+  </div>
+
+  <!-- Per-expansion errors -->
+  {#each EXPANSIONS as exp (exp.key)}
+    {#if errors[exp.key]}
+      <p class="exp-error">{errors[exp.key]}</p>
+    {/if}
+  {/each}
+
+  <!-- Critique rounds output -->
+  {#if critiques.length > 0}
+    <CritiqueRounds rounds={critiques} />
+  {/if}
+
+  <!-- Plan outputs (raw markdown from AI — rendered as preformatted text; no HTML injection) -->
+  {#if execPlan}
+    <div class="exp-plan">
+      <p class="u-label exp-plan__label">ExecPlan</p>
+      <pre class="exp-plan__pre">{execPlan}</pre>
+    </div>
+  {/if}
+  {#if readablePlan}
+    <div class="exp-plan">
+      <p class="u-label exp-plan__label">Readable plan</p>
+      <pre class="exp-plan__pre">{readablePlan}</pre>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .exp-panel { margin-top: 1rem; }
+  .exp-panel__label { margin-bottom: .6rem; }
+
+  .exp-panel__grid {
+    display: flex; flex-wrap: wrap; gap: .4rem;
+  }
+
+  .exp-btn {
+    cursor: pointer; font-size: .75rem; font-family: inherit;
+    transition: background var(--dur-fast) var(--ease-snappy),
+                border-color var(--dur-fast) var(--ease-snappy),
+                color var(--dur-fast);
+    user-select: none;
+  }
+  .exp-btn:not(.exp-btn--soon):not(:disabled):hover {
+    background: var(--surface-2); border-color: var(--ink); color: var(--ink);
+  }
+  .exp-btn:disabled { opacity: .55; cursor: default; }
+  .exp-btn--soon { cursor: default; }
+
+  .exp-btn__icon { font-size: .85em; }
+  .exp-btn__soon {
+    font-size: .65rem; text-transform: uppercase; letter-spacing: .06em;
+    color: var(--faint); margin-left: .2rem;
+  }
+
+  .exp-error {
+    margin-top: .5rem; font-size: .82rem; color: var(--neg);
+  }
+
+  .exp-plan { margin-top: 1rem; }
+  .exp-plan__label { margin-bottom: .4rem; }
+  .exp-plan__pre {
+    font-family: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+    font-size: .82rem; line-height: 1.6; color: var(--body);
+    background: var(--surface-2); border: 1px solid var(--line);
+    border-radius: var(--r-ctrl); padding: .75rem 1rem;
+    white-space: pre-wrap; word-break: break-word; overflow-x: auto;
+  }
+</style>

--- a/src/lib/components/lab/PublishDialog.svelte
+++ b/src/lib/components/lab/PublishDialog.svelte
@@ -8,7 +8,7 @@
   }: {
     open: boolean;
     draft: { id: string; title: string; summary_md: string };
-    form: { submitted?: boolean; message?: string } | null;
+    form: { submitted?: boolean; id?: string; message?: string } | null;
   } = $props();
 
   // svelte-ignore state_referenced_locally
@@ -46,7 +46,7 @@
         <button class="pd-close" onclick={close} aria-label="Close">✕</button>
       </div>
 
-      {#if form?.submitted}
+      {#if form?.submitted && form?.id === draft.id}
         <div class="pd-submitted">
           <p class="pd-submitted__msg">Submitted for admin review.</p>
           <p class="pd-submitted__sub">You'll be notified when your idea goes live.</p>

--- a/src/lib/components/lab/PublishDialog.svelte
+++ b/src/lib/components/lab/PublishDialog.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+
+  let {
+    open = $bindable(false),
+    draft,
+    form,
+  }: {
+    open: boolean;
+    draft: { id: string; title: string; summary_md: string };
+    form: { submitted?: boolean; message?: string } | null;
+  } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let type = $state<'open_ended' | 'hypothesis'>('open_ended');
+  // svelte-ignore state_referenced_locally
+  let claim = $state('');
+  // svelte-ignore state_referenced_locally
+  let summaryMd = $state(draft.summary_md ?? '');
+  let submitting = $state(false);
+
+  function close() { open = false; }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+  }
+</script>
+
+{#if open}
+  <!-- Backdrop -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="pd-backdrop"
+    role="dialog"
+    tabindex="-1"
+    aria-modal="true"
+    aria-labelledby="publish-dialog-title"
+    onkeydown={handleKeydown}
+  >
+    <!-- Click-outside to close -->
+    <div class="pd-overlay" role="presentation" onclick={close}></div>
+
+    <div class="pd-panel card">
+      <div class="pd-header">
+        <h2 class="pd-title" id="publish-dialog-title">Publish idea</h2>
+        <button class="pd-close" onclick={close} aria-label="Close">✕</button>
+      </div>
+
+      {#if form?.submitted}
+        <div class="pd-submitted">
+          <p class="pd-submitted__msg">Submitted for admin review.</p>
+          <p class="pd-submitted__sub">You'll be notified when your idea goes live.</p>
+          <button class="btn btn-primary btn-sm" onclick={close}>Done</button>
+        </div>
+      {:else}
+        {#if form?.message}
+          <p class="pd-error">{form.message}</p>
+        {/if}
+
+        <form
+          method="POST"
+          action="?/publish"
+          use:enhance={() => {
+            submitting = true;
+            return async ({ update }) => {
+              await update({ reset: false });
+              submitting = false;
+            };
+          }}
+          class="pd-form"
+        >
+          <input type="hidden" name="id" value={draft.id} />
+
+          <div class="pd-field">
+            <label class="u-label" for="pd-type">Type</label>
+            <select
+              id="pd-type"
+              name="type"
+              class="select"
+              bind:value={type}
+            >
+              <option value="open_ended">Open-ended question</option>
+              <option value="hypothesis">Hypothesis</option>
+            </select>
+          </div>
+
+          {#if type === 'hypothesis'}
+            <div class="pd-field">
+              <label class="u-label" for="pd-claim">Hypothesis claim</label>
+              <input
+                id="pd-claim"
+                name="claim"
+                class="input"
+                bind:value={claim}
+                placeholder="State your hypothesis clearly…"
+                required
+              />
+            </div>
+          {/if}
+
+          <div class="pd-field">
+            <label class="u-label" for="pd-summary">Summary</label>
+            <textarea
+              id="pd-summary"
+              name="summary_md"
+              class="textarea"
+              bind:value={summaryMd}
+              rows={5}
+              placeholder="Describe your idea for the public listing…"
+            ></textarea>
+          </div>
+
+          <div class="pd-actions">
+            <button
+              type="submit"
+              class="btn btn-primary btn-sm"
+              disabled={submitting}
+            >
+              {submitting ? 'Publishing…' : 'Publish idea'}
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm"
+              onclick={close}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .pd-backdrop {
+    position: fixed; inset: 0; z-index: 200;
+    display: flex; align-items: center; justify-content: center;
+    padding: 1rem;
+    animation: pd-fade-in var(--dur-base) var(--ease-snappy) both;
+  }
+
+  .pd-overlay {
+    position: absolute; inset: 0;
+    background: rgba(20, 24, 22, 0.4);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+
+  .pd-panel {
+    position: relative; z-index: 1;
+    width: 100%; max-width: 480px;
+    padding: 1.5rem;
+    box-shadow: var(--shadow-pop);
+    animation: pd-panel-in var(--dur-slow) var(--ease-emphasized) both;
+  }
+
+  .pd-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 1.25rem;
+  }
+  .pd-title { font-size: 1.05rem; font-weight: 700; color: var(--ink); margin: 0; }
+
+  .pd-close {
+    background: none; border: none; cursor: pointer;
+    color: var(--muted); font-size: .9rem; padding: .25rem .4rem;
+    border-radius: var(--r-chip);
+    transition: color var(--dur-fast) var(--ease-snappy),
+                background var(--dur-fast) var(--ease-snappy);
+  }
+  .pd-close:hover { color: var(--ink); background: var(--surface-2); }
+
+  .pd-form { display: flex; flex-direction: column; gap: 1rem; }
+
+  .pd-field { display: flex; flex-direction: column; gap: .35rem; }
+
+  .pd-actions {
+    display: flex; align-items: center; gap: .6rem;
+    padding-top: .25rem;
+  }
+
+  .pd-error {
+    font-size: .85rem; color: var(--neg);
+    margin-bottom: .75rem;
+  }
+
+  .pd-submitted {
+    display: flex; flex-direction: column; gap: .6rem; padding: .5rem 0;
+  }
+  .pd-submitted__msg {
+    font-weight: 600; color: var(--ink); font-size: 1rem; margin: 0;
+  }
+  .pd-submitted__sub {
+    color: var(--muted); font-size: .875rem; margin: 0;
+  }
+
+  @keyframes pd-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes pd-panel-in {
+    from { opacity: 0; transform: scale(.96) translateY(8px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pd-backdrop, .pd-panel { animation: none !important; }
+  }
+</style>

--- a/src/lib/lab/agent-prompt.test.ts
+++ b/src/lib/lab/agent-prompt.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { buildAgentPrompt } from './agent-prompt';
+describe('buildAgentPrompt', () => {
+  it('includes title, notes, and plans when present', () => {
+    const p = buildAgentPrompt({
+      title: 'Scalable oversight', notes_md: 'via debate',
+      execPlan: '1. do X', readablePlan: 'We propose…'
+    });
+    expect(p).toContain('Scalable oversight');
+    expect(p).toContain('via debate');
+    expect(p).toContain('1. do X');
+    expect(p).toContain('We propose…');
+  });
+  it('omits plan sections that are absent', () => {
+    const p = buildAgentPrompt({ title: 'T', notes_md: '', execPlan: null, readablePlan: null });
+    expect(p).toContain('T');
+    expect(p).not.toMatch(/ExecPlan/i);
+  });
+});

--- a/src/lib/lab/agent-prompt.ts
+++ b/src/lib/lab/agent-prompt.ts
@@ -1,0 +1,14 @@
+export type AgentPromptInput = {
+  title: string; notes_md: string;
+  execPlan?: string | null; readablePlan?: string | null;
+};
+
+/** Format a draft (+ optional distilled plans) into a single agent handoff prompt. */
+export function buildAgentPrompt(i: AgentPromptInput): string {
+  const parts = [`# Research idea: ${i.title}`];
+  if (i.notes_md.trim()) parts.push(`## Notes\n${i.notes_md.trim()}`);
+  if (i.readablePlan?.trim()) parts.push(`## Plan (readable)\n${i.readablePlan.trim()}`);
+  if (i.execPlan?.trim()) parts.push(`## ExecPlan\n${i.execPlan.trim()}`);
+  parts.push('## Task\nBuild this out: produce the paper/artifacts described above.');
+  return parts.join('\n\n');
+}

--- a/src/lib/lab/critique.test.ts
+++ b/src/lib/lab/critique.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { CritiqueRoundSchema, REVIEWERS } from './critique';
+describe('critique schema', () => {
+  it('accepts a well-formed round and exposes the 4 reviewers', () => {
+    expect(REVIEWERS.map((r) => r.key)).toEqual(['skeptic', 'methods', 'impact', 'clarifying']);
+    const ok = CritiqueRoundSchema.safeParse({
+      reviewers: [{ persona: 'skeptic', comments: ['weak baseline'], questions: ['what control?'] }]
+    });
+    expect(ok.success).toBe(true);
+  });
+  it('rejects a malformed round', () => {
+    expect(CritiqueRoundSchema.safeParse({ reviewers: [{ persona: 'x' }] }).success).toBe(false);
+  });
+});

--- a/src/lib/lab/critique.ts
+++ b/src/lib/lab/critique.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const REVIEWERS = [
+  { key: 'skeptic', label: 'Skeptic', brief: 'attack the weakest assumptions' },
+  { key: 'methods', label: 'Methods', brief: 'rigor, baselines, confounds, measurability' },
+  { key: 'impact', label: 'Impact', brief: 'why it matters for AI safety; who funds it' },
+  { key: 'clarifying', label: 'Clarifying', brief: 'what is underspecified' }
+] as const;
+
+export const CritiqueRoundSchema = z.object({
+  reviewers: z.array(z.object({
+    persona: z.enum(['skeptic', 'methods', 'impact', 'clarifying']),
+    comments: z.array(z.string()),
+    questions: z.array(z.string())
+  })).min(1)
+});
+export type CritiqueRound = z.infer<typeof CritiqueRoundSchema>;
+
+/** Prompt for one review round over a draft. */
+export function buildReviewPrompt(title: string, notes_md: string): string {
+  const panel = REVIEWERS.map((r) => `- ${r.label}: ${r.brief}`).join('\n');
+  return `You are a panel reviewing an early-stage AI-safety research idea.\n` +
+    `Idea: "${title}"\nNotes:\n${notes_md || '(none yet)'}\n\n` +
+    `Reviewers:\n${panel}\n\nReturn each reviewer's pointed comments and clarifying questions.`;
+}

--- a/src/lib/lab/draftsStore.svelte.ts
+++ b/src/lib/lab/draftsStore.svelte.ts
@@ -21,7 +21,11 @@ export function createDraftsStore(initial: { id: string; slug: string; title: st
 
 	function remove(id: string) {
 		const i = drafts.findIndex((d) => d.id === id);
-		if (i >= 0) { const [r] = drafts.splice(i, 1); fetch(`/api/drafts/${id}`, { method: 'DELETE' }); return r; }
+		if (i >= 0) {
+			const [r] = drafts.splice(i, 1);
+			if (!id.startsWith('tmp-')) fetch(`/api/drafts/${id}`, { method: 'DELETE' });
+			return r;
+		}
 	}
 
 	return { drafts, add, remove };

--- a/src/lib/lab/draftsStore.svelte.ts
+++ b/src/lib/lab/draftsStore.svelte.ts
@@ -1,0 +1,28 @@
+export type DraftRow = {
+	id: string; slug: string | null; title: string; pending: boolean; errored: boolean;
+};
+
+let tmpSeq = 0;
+
+export function createDraftsStore(initial: { id: string; slug: string; title: string }[]) {
+	const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, pending: false, errored: false })));
+
+	async function add(title: string) {
+		const tmpId = `tmp-${tmpSeq++}`;
+		drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false });
+		const row = drafts[0];
+		try {
+			const res = await fetch('/api/drafts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ title }) });
+			if (!res.ok) throw new Error((await res.json()).message);
+			const { id, slug } = await res.json();
+			row.id = id; row.slug = slug; row.pending = false;
+		} catch { row.errored = true; row.pending = false; }
+	}
+
+	function remove(id: string) {
+		const i = drafts.findIndex((d) => d.id === id);
+		if (i >= 0) { const [r] = drafts.splice(i, 1); fetch(`/api/drafts/${id}`, { method: 'DELETE' }); return r; }
+	}
+
+	return { drafts, add, remove };
+}

--- a/src/lib/lab/draftsStore.svelte.ts
+++ b/src/lib/lab/draftsStore.svelte.ts
@@ -1,15 +1,16 @@
 export type DraftRow = {
 	id: string; slug: string | null; title: string; pending: boolean; errored: boolean;
+	summary_md: string; expansions: any;
 };
 
 let tmpSeq = 0;
 
-export function createDraftsStore(initial: { id: string; slug: string; title: string }[]) {
-	const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, pending: false, errored: false })));
+export function createDraftsStore(initial: { id: string; slug: string; title: string; summary_md?: string | null; expansions?: any }[]) {
+	const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, summary_md: d.summary_md ?? '', expansions: d.expansions ?? {}, pending: false, errored: false })));
 
 	async function add(title: string) {
 		const tmpId = `tmp-${tmpSeq++}`;
-		drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false });
+		drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false, summary_md: '', expansions: {} });
 		const row = drafts[0];
 		try {
 			const res = await fetch('/api/drafts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ title }) });

--- a/src/lib/lab/draftsStore.svelte.ts
+++ b/src/lib/lab/draftsStore.svelte.ts
@@ -1,21 +1,24 @@
 export type DraftRow = {
 	id: string; slug: string | null; title: string; pending: boolean; errored: boolean;
 	summary_md: string; expansions: any;
+	/** Stable identity for keying {#each} — never changes after insertion (survives id reconcile). */
+	key: string;
 };
 
 let tmpSeq = 0;
 
 export function createDraftsStore(initial: { id: string; slug: string; title: string; summary_md?: string | null; expansions?: any }[]) {
-	const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, summary_md: d.summary_md ?? '', expansions: d.expansions ?? {}, pending: false, errored: false })));
+	const drafts = $state<DraftRow[]>(initial.map((d) => ({ ...d, summary_md: d.summary_md ?? '', expansions: d.expansions ?? {}, pending: false, errored: false, key: d.id })));
 
 	async function add(title: string) {
 		const tmpId = `tmp-${tmpSeq++}`;
-		drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false, summary_md: '', expansions: {} });
+		drafts.unshift({ id: tmpId, slug: null, title, pending: true, errored: false, summary_md: '', expansions: {}, key: tmpId });
 		const row = drafts[0];
 		try {
 			const res = await fetch('/api/drafts', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ title }) });
 			if (!res.ok) throw new Error((await res.json()).message);
 			const { id, slug } = await res.json();
+			// Reconcile id/slug but never touch key — it stays as tmpId to preserve DOM identity
 			row.id = id; row.slug = slug; row.pending = false;
 		} catch { row.errored = true; row.pending = false; }
 	}

--- a/src/lib/lab/draftsStore.test.ts
+++ b/src/lib/lab/draftsStore.test.ts
@@ -10,10 +10,17 @@ describe('draftsStore', () => {
 		const tmp = s.add('My idea');
 		expect(s.drafts[0].title).toBe('My idea');
 		expect(s.drafts[0].pending).toBe(true);
+		const keyBefore = s.drafts[0].key;
 		await tmp;
 		expect(s.drafts[0].id).toBe('real');
 		expect(s.drafts[0].slug).toBe('sl');
 		expect(s.drafts[0].pending).toBe(false);
+		// key must remain stable after id reconcile (prevents expand-collapse DOM reset)
+		expect(s.drafts[0].key).toBe(keyBefore);
+	});
+	it('seed rows get key === id', () => {
+		const s = createDraftsStore([{ id: 'seed-1', slug: 'sl', title: 'Seeded' }]);
+		expect(s.drafts[0].key).toBe('seed-1');
 	});
 	it('marks errored on failure', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({ message: 'x' }) }));

--- a/src/lib/lab/draftsStore.test.ts
+++ b/src/lib/lab/draftsStore.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createDraftsStore } from './draftsStore.svelte';
+
+beforeEach(() => { vi.restoreAllMocks(); });
+
+describe('draftsStore', () => {
+	it('adds optimistically then reconciles to the server id/slug', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'real', slug: 'sl' }) }));
+		const s = createDraftsStore([]);
+		const tmp = s.add('My idea');
+		expect(s.drafts[0].title).toBe('My idea');
+		expect(s.drafts[0].pending).toBe(true);
+		await tmp;
+		expect(s.drafts[0].id).toBe('real');
+		expect(s.drafts[0].slug).toBe('sl');
+		expect(s.drafts[0].pending).toBe(false);
+	});
+	it('marks errored on failure', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({ message: 'x' }) }));
+		const s = createDraftsStore([]);
+		await s.add('X');
+		expect(s.drafts[0].errored).toBe(true);
+	});
+});

--- a/src/lib/lab/draftsStore.test.ts
+++ b/src/lib/lab/draftsStore.test.ts
@@ -21,4 +21,23 @@ describe('draftsStore', () => {
 		await s.add('X');
 		expect(s.drafts[0].errored).toBe(true);
 	});
+	it('remove(tmp-*) splices locally without calling DELETE', () => {
+		const mockFetch = vi.fn();
+		vi.stubGlobal('fetch', mockFetch);
+		const s = createDraftsStore([]);
+		// manually push a tmp row (simulates the in-flight state)
+		(s.drafts as any).push({ id: 'tmp-0', slug: null, title: 'Unsaved', pending: true, errored: false });
+		expect(s.drafts.length).toBe(1);
+		s.remove('tmp-0');
+		expect(s.drafts.length).toBe(0);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+	it('remove(real-id) calls DELETE and splices', () => {
+		const mockFetch = vi.fn().mockResolvedValue({});
+		vi.stubGlobal('fetch', mockFetch);
+		const s = createDraftsStore([{ id: 'real-1', slug: 'sl', title: 'Saved' }]);
+		s.remove('real-1');
+		expect(s.drafts.length).toBe(0);
+		expect(mockFetch).toHaveBeenCalledWith('/api/drafts/real-1', { method: 'DELETE' });
+	});
 });

--- a/src/lib/lab/registry.test.ts
+++ b/src/lib/lab/registry.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { EXPANSIONS } from './registry';
+describe('expansion registry', () => {
+  it('has the ready tools and marks future ones coming-soon', () => {
+    const byKey = Object.fromEntries(EXPANSIONS.map((e) => [e.key, e]));
+    expect(byKey['copy_agent'].status).toBe('ready');
+    expect(byKey['review'].gated).toBe(true);
+    expect(byKey['github'].status).toBe('soon');
+  });
+});

--- a/src/lib/lab/registry.ts
+++ b/src/lib/lab/registry.ts
@@ -1,0 +1,15 @@
+export type ExpansionStatus = 'ready' | 'soon';
+export type Expansion = {
+  key: string; label: string; icon: string; gated: boolean; status: ExpansionStatus;
+  kind: 'client' | 'review' | 'plan'; planKind?: 'exec' | 'readable';
+};
+
+export const EXPANSIONS: Expansion[] = [
+  { key: 'review', label: 'Run review', icon: '🔍', gated: true, status: 'ready', kind: 'review' },
+  { key: 'exec_plan', label: 'Generate ExecPlan', icon: '📐', gated: true, status: 'ready', kind: 'plan', planKind: 'exec' },
+  { key: 'readable_plan', label: 'Generate readable plan', icon: '📄', gated: true, status: 'ready', kind: 'plan', planKind: 'readable' },
+  { key: 'copy_agent', label: 'Copy to agent', icon: '🤖', gated: false, status: 'ready', kind: 'client' },
+  { key: 'github', label: 'Start GitHub repo', icon: '🐙', gated: true, status: 'soon', kind: 'client' },
+  { key: 'venues', label: 'Find venues', icon: '🎓', gated: true, status: 'soon', kind: 'client' },
+  { key: 'link_agent', label: 'Link an agent', icon: '🔗', gated: true, status: 'soon', kind: 'client' }
+];

--- a/src/lib/server/ai.test.ts
+++ b/src/lib/server/ai.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('ai', () => ({
   generateText: vi.fn().mockResolvedValue({ text: 'hello' }),
-  generateObject: vi.fn().mockResolvedValue({ object: { ok: true } })
+  generateObject: vi.fn().mockResolvedValue({ object: { ok: true } }),
+  gateway: vi.fn(() => 'mock-model')
 }));
 vi.mock('$env/dynamic/private', () => ({ env: { AI_GATEWAY_API_KEY: 'test-key' } }));
 import { generate, generateStructured } from './ai';

--- a/src/lib/server/ai.test.ts
+++ b/src/lib/server/ai.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({ text: 'hello' }),
+  generateObject: vi.fn().mockResolvedValue({ object: { ok: true } })
+}));
+vi.mock('$env/dynamic/private', () => ({ env: { AI_GATEWAY_API_KEY: 'test-key' } }));
+import { generate, generateStructured } from './ai';
+import { z } from 'zod';
+describe('ai seam', () => {
+  it('generate returns text', async () => { expect(await generate('hi')).toBe('hello'); });
+  it('generateStructured returns the parsed object', async () => {
+    expect(await generateStructured('hi', z.object({ ok: z.boolean() }))).toEqual({ ok: true });
+  });
+});

--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -1,21 +1,23 @@
-import { generateText, generateObject } from 'ai';
+import { generateText, generateObject, gateway } from 'ai';
 import type { ZodSchema } from 'zod';
 import { env } from '$env/dynamic/private';
-
-const MODEL = 'anthropic/claude-sonnet-4-6'; // resolved by the Vercel AI Gateway
 
 function assertConfigured() {
   if (!env.AI_GATEWAY_API_KEY) throw new Error('AI is not configured (missing AI_GATEWAY_API_KEY)');
 }
 
+function model() {
+  return gateway('anthropic/claude-sonnet-4-6');
+}
+
 export async function generate(prompt: string): Promise<string> {
   assertConfigured();
-  const { text } = await generateText({ model: MODEL as any, prompt });
+  const { text } = await generateText({ model: model(), prompt });
   return text;
 }
 
 export async function generateStructured<T>(prompt: string, schema: ZodSchema<T>): Promise<T> {
   assertConfigured();
-  const { object } = await generateObject({ model: MODEL as any, prompt, schema });
+  const { object } = await generateObject({ model: model(), prompt, schema });
   return object as T;
 }

--- a/src/lib/server/ai.ts
+++ b/src/lib/server/ai.ts
@@ -1,0 +1,21 @@
+import { generateText, generateObject } from 'ai';
+import type { ZodSchema } from 'zod';
+import { env } from '$env/dynamic/private';
+
+const MODEL = 'anthropic/claude-sonnet-4-6'; // resolved by the Vercel AI Gateway
+
+function assertConfigured() {
+  if (!env.AI_GATEWAY_API_KEY) throw new Error('AI is not configured (missing AI_GATEWAY_API_KEY)');
+}
+
+export async function generate(prompt: string): Promise<string> {
+  assertConfigured();
+  const { text } = await generateText({ model: MODEL as any, prompt });
+  return text;
+}
+
+export async function generateStructured<T>(prompt: string, schema: ZodSchema<T>): Promise<T> {
+  assertConfigured();
+  const { object } = await generateObject({ model: MODEL as any, prompt, schema });
+  return object as T;
+}

--- a/src/lib/server/lab/access.test.ts
+++ b/src/lib/server/lab/access.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { canUseLabAi } from './access';
+describe('canUseLabAi', () => {
+  it('returns the can_use_lab_ai RPC boolean', async () => {
+    const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: true, error: null }) };
+    expect(await canUseLabAi(supabase)).toBe(true);
+    expect(supabase.rpc).toHaveBeenCalledWith('can_use_lab_ai');
+  });
+  it('is false when the RPC errors or returns null', async () => {
+    const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: null, error: { message: 'x' } }) };
+    expect(await canUseLabAi(supabase)).toBe(false);
+  });
+});

--- a/src/lib/server/lab/access.ts
+++ b/src/lib/server/lab/access.ts
@@ -1,0 +1,7 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** True if the caller may use AI Lab tools (admin · approved expert · active monthly supporter). */
+export async function canUseLabAi(supabase: SupabaseClient): Promise<boolean> {
+  const { data, error } = await supabase.rpc('can_use_lab_ai');
+  return !error && data === true;
+}

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -8,7 +8,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
  */
 export const BUCKETS = [
   'comment', 'comment_delete', 'engage', 'pledge', 'answer',
-  'idea_create', 'review', 'profile', 'admin'
+  'idea_create', 'review', 'profile', 'admin', 'ai_generate'
 ] as const;
 export type Bucket = (typeof BUCKETS)[number];
 

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -1,4 +1,3 @@
-Connecting to db 5432
 export type Json =
   | string
   | number
@@ -1137,5 +1136,3 @@ export const Constants = {
   },
 } as const
 
-A new version of Supabase CLI is available: v2.105.0 (currently installed v2.75.0)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -1,3 +1,4 @@
+Connecting to db 5432
 export type Json =
   | string
   | number
@@ -566,6 +567,7 @@ export type Database = {
           created_at: string
           currency: string
           estimated_hours: number | null
+          expansions: Json
           from_date: string | null
           id: string
           importance: number | null
@@ -590,6 +592,7 @@ export type Database = {
           created_at?: string
           currency?: string
           estimated_hours?: number | null
+          expansions?: Json
           from_date?: string | null
           id?: string
           importance?: number | null
@@ -614,6 +617,7 @@ export type Database = {
           created_at?: string
           currency?: string
           estimated_hours?: number | null
+          expansions?: Json
           from_date?: string | null
           id?: string
           importance?: number | null
@@ -695,6 +699,7 @@ export type Database = {
           id: string
           is_admin: boolean
           links: Json
+          supporter_until: string | null
         }
         Insert: {
           avatar_url?: string | null
@@ -706,6 +711,7 @@ export type Database = {
           id: string
           is_admin?: boolean
           links?: Json
+          supporter_until?: string | null
         }
         Update: {
           avatar_url?: string | null
@@ -717,6 +723,7 @@ export type Database = {
           id?: string
           is_admin?: boolean
           links?: Json
+          supporter_until?: string | null
         }
         Relationships: []
       }
@@ -836,6 +843,7 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      can_use_lab_ai: { Args: never; Returns: boolean }
       consume_rate_limit: { Args: { p_bucket: string }; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
       reject_answer: {
@@ -1129,3 +1137,5 @@ export const Constants = {
   },
 } as const
 
+A new version of Supabase CLI is available: v2.105.0 (currently installed v2.75.0)
+We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/src/routes/admin/ideas/+page.server.ts
+++ b/src/routes/admin/ideas/+page.server.ts
@@ -29,7 +29,8 @@ export const actions: Actions = {
     const { error: e } = await supabase
       .from('ideas')
       .update({ status: 'open', published_at: new Date().toISOString() })
-      .eq('id', String(fd.get('id')));
+      .eq('id', String(fd.get('id')))
+      .eq('status', 'archived');
     if (e) return fail(400, { message: e.message });
     return { promoted: true };
   }

--- a/src/routes/admin/ideas/+page.server.ts
+++ b/src/routes/admin/ideas/+page.server.ts
@@ -1,0 +1,36 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+
+export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession } }) => {
+  const { user } = await safeGetSession();
+  if (!user) redirect(303, '/login?next=/admin/ideas');
+  const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+  if (!me?.is_admin) error(403, 'Admins only');
+
+  const { data: archived } = await supabase
+    .from('ideas')
+    .select('id, slug, title, summary_md, author:profiles!ideas_author_id_fkey(handle, display_name)')
+    .eq('status', 'archived')
+    .order('created_at', { ascending: false });
+
+  return { archived: (archived ?? []).map((row: any) => ({
+    ...row,
+    author: Array.isArray(row.author) ? (row.author[0] ?? null) : row.author
+  })) };
+};
+
+export const actions: Actions = {
+  promote: async ({ request, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, {});
+    const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+    if (!me?.is_admin) return fail(403, { message: 'Admins only' });
+    const fd = await request.formData();
+    const { error: e } = await supabase
+      .from('ideas')
+      .update({ status: 'open', published_at: new Date().toISOString() })
+      .eq('id', String(fd.get('id')));
+    if (e) return fail(400, { message: e.message });
+    return { promoted: true };
+  }
+};

--- a/src/routes/admin/ideas/+page.svelte
+++ b/src/routes/admin/ideas/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+
+  let { data, form } = $props();
+
+  let promoting = $state<Record<string, boolean>>({});
+  let promoted = $state<Record<string, boolean>>({});
+</script>
+
+<h1 class="page-title">Idea submissions</h1>
+<p class="page-sub">Archived ideas submitted by non-experts, awaiting admin review. Promote to make them publicly visible.</p>
+
+{#if (form as any)?.message}
+  <p class="form-error">{(form as any).message}</p>
+{/if}
+
+{#if data.archived.length === 0}
+  <p class="empty-state">Nothing awaiting review.</p>
+{:else}
+  <div class="ideas-table-wrap">
+    <table class="ideas-table">
+      <thead>
+        <tr>
+          <th class="col-title">Title</th>
+          <th class="col-author">Author</th>
+          <th class="col-summary">Summary preview</th>
+          <th class="col-actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.archived as idea (idea.id)}
+          <tr class:row-promoted={promoted[idea.id]}>
+            <td class="col-title">
+              <a href="/ideas/{idea.slug}" class="idea-link">{idea.title}</a>
+            </td>
+            <td class="col-author">
+              {#if idea.author}
+                <a href="/u/{idea.author.handle}" class="author-link">
+                  {idea.author.display_name ?? idea.author.handle}
+                </a>
+              {:else}
+                <span class="u-muted">Unknown</span>
+              {/if}
+            </td>
+            <td class="col-summary">
+              <span class="summary-preview">
+                {(idea.summary_md ?? '').slice(0, 120)}{(idea.summary_md ?? '').length > 120 ? '…' : ''}
+              </span>
+            </td>
+            <td class="col-actions">
+              {#if promoted[idea.id]}
+                <span class="promoted-badge">Promoted</span>
+              {:else}
+                <form
+                  method="POST"
+                  action="?/promote"
+                  class="inline-form"
+                  use:enhance={() => {
+                    promoting = { ...promoting, [idea.id]: true };
+                    return async ({ update }) => {
+                      await update({ reset: false });
+                      promoting = { ...promoting, [idea.id]: false };
+                      if (form?.promoted !== false) promoted = { ...promoted, [idea.id]: true };
+                    };
+                  }}
+                >
+                  <input type="hidden" name="id" value={idea.id} />
+                  <button
+                    class="btn btn-sm"
+                    style="color: var(--green-deep); border-color: color-mix(in srgb, var(--green-deep) 30%, transparent);"
+                    disabled={promoting[idea.id]}
+                  >
+                    {promoting[idea.id] ? 'Promoting…' : 'Promote to open'}
+                  </button>
+                </form>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<style>
+  .page-title {
+    font-size: 1.35rem; font-weight: 700; color: var(--ink); margin: 0 0 .4rem;
+  }
+  .page-sub {
+    font-size: .875rem; color: var(--muted); margin: 0 0 1.5rem;
+  }
+  .form-error {
+    font-size: .875rem; color: var(--neg); margin-bottom: 1rem;
+  }
+  .empty-state {
+    color: var(--muted); font-size: .95rem;
+  }
+
+  .ideas-table-wrap { overflow-x: auto; }
+
+  .ideas-table {
+    width: 100%; border-collapse: collapse; font-size: .875rem;
+  }
+  .ideas-table thead tr {
+    border-bottom: 1px solid var(--line-strong);
+  }
+  .ideas-table th {
+    text-align: left; padding: .5rem .75rem;
+    font-size: .7rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: .06em; color: var(--faint);
+  }
+  .ideas-table td {
+    padding: .65rem .75rem; border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  .ideas-table tr:last-child td { border-bottom: none; }
+
+  .col-title { width: 25%; }
+  .col-author { width: 15%; }
+  .col-summary { width: 45%; }
+  .col-actions { width: 15%; text-align: right; }
+
+  .idea-link {
+    color: var(--ink); font-weight: 600; text-decoration: none;
+  }
+  .idea-link:hover { color: var(--green-deep); text-decoration: underline; }
+
+  .author-link {
+    color: var(--muted); text-decoration: none;
+  }
+  .author-link:hover { color: var(--ink); text-decoration: underline; }
+
+  .summary-preview { color: var(--muted); line-height: 1.5; }
+
+  .inline-form { display: inline; }
+
+  .promoted-badge {
+    font-size: .75rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: .06em; color: var(--green-deep);
+    padding: .2rem .5rem;
+    background: color-mix(in srgb, var(--green-deep) 10%, transparent);
+    border-radius: var(--r-chip);
+  }
+
+  .row-promoted td { opacity: .6; }
+
+  .u-muted { color: var(--muted); }
+</style>

--- a/src/routes/admin/ideas/+page.svelte
+++ b/src/routes/admin/ideas/+page.svelte
@@ -60,7 +60,7 @@
                     return async ({ update }) => {
                       await update({ reset: false });
                       promoting = { ...promoting, [idea.id]: false };
-                      if (form?.promoted !== false) promoted = { ...promoted, [idea.id]: true };
+                      if (form?.promoted === true) promoted = { ...promoted, [idea.id]: true };
                     };
                   }}
                 >

--- a/src/routes/api/drafts/+server.ts
+++ b/src/routes/api/drafts/+server.ts
@@ -1,0 +1,16 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { rateLimit } from '$lib/server/rate-limit';
+
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json({ message: 'Sign in' }, { status: 401 });
+	if (!(await rateLimit(supabase, 'idea_create')).ok) return json({ message: 'Slow down' }, { status: 429 });
+	const body = await request.json().catch(() => ({}));
+	const title = String(body.title ?? '').trim() || 'Untitled idea';
+	const { data, error: e } = await supabase
+		.from('ideas').insert({ author_id: user.id, title, type: 'open_ended', status: 'draft' })
+		.select('id, slug').single();
+	if (e || !data) return json({ message: e?.message ?? 'Failed' }, { status: 400 });
+	return json({ id: data.id, slug: data.slug });
+};

--- a/src/routes/api/drafts/[id]/+server.ts
+++ b/src/routes/api/drafts/[id]/+server.ts
@@ -1,0 +1,23 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const PATCH: RequestHandler = async ({ params, request, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json({ message: 'Sign in' }, { status: 401 });
+	const body = await request.json().catch(() => ({}));
+	const patch: { title?: string; summary_md?: string } = {};
+	if (typeof body.title === 'string') patch.title = body.title.trim() || 'Untitled idea';
+	if (typeof body.notes_md === 'string') patch.summary_md = body.notes_md; // notes reuse summary_md
+	if (!Object.keys(patch).length) return json({ ok: true });
+	const { error: e } = await supabase.from('ideas').update(patch).eq('id', params.id).eq('status', 'draft');
+	if (e) return json({ message: e.message }, { status: 400 });
+	return json({ ok: true });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json({ message: 'Sign in' }, { status: 401 });
+	const { error: e } = await supabase.from('ideas').delete().eq('id', params.id).eq('status', 'draft');
+	if (e) return json({ message: e.message }, { status: 400 });
+	return json({ ok: true });
+};

--- a/src/routes/api/drafts/drafts.test.ts
+++ b/src/routes/api/drafts/drafts.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from './+server';
+
+function ev(rpcOk: boolean, user: any = { id: 'u1' }) {
+	const insert = vi.fn(() => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'i1', slug: 's' }, error: null }) }) }));
+	const supabase: any = { rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }), from: vi.fn(() => ({ insert })) };
+	return { request: { json: async () => ({ title: 'T' }) }, locals: { supabase, safeGetSession: async () => ({ user }) } } as any;
+}
+
+describe('POST /api/drafts', () => {
+	it('401 without a user', async () => { expect((await POST(ev(true, null))).status).toBe(401); });
+	it('429 when rate-limited', async () => { expect((await POST(ev(false))).status).toBe(429); });
+	it('creates a draft and returns id+slug', async () => {
+		const res = await POST(ev(true)); expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ id: 'i1', slug: 's' });
+	});
+});

--- a/src/routes/api/lab/[id]/plan/+server.ts
+++ b/src/routes/api/lab/[id]/plan/+server.ts
@@ -17,7 +17,7 @@ export const POST: RequestHandler = async ({ params, request, locals: { supabase
 	const body = await request.json().catch(() => ({}));
 	const kind: 'exec' | 'readable' = body.kind === 'readable' ? 'readable' : 'exec';
 
-	const { data: idea, error: ge } = await supabase.from('ideas').select('id, title, summary_md, expansions').eq('id', params.id).single();
+	const { data: idea, error: ge } = await supabase.from('ideas').select('id, title, summary_md, expansions').eq('id', params.id).eq('author_id', user.id).eq('status', 'draft').single();
 	if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
 
 	let md: string;

--- a/src/routes/api/lab/[id]/plan/+server.ts
+++ b/src/routes/api/lab/[id]/plan/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { canUseLabAi } from '$lib/server/lab/access';
+import { generate } from '$lib/server/ai';
+import { rateLimit } from '$lib/server/rate-limit';
+
+const PROMPTS = {
+	exec: (t: string, n: string) => `Write a concise, agent-EXECUTABLE plan (markdown) to investigate this AI-safety idea.\nSections: Objective, Method (numbered steps), Artifacts, Success criteria, Risks.\nIdea: "${t}"\nNotes:\n${n}`,
+	readable: (t: string, n: string) => `Write a readable proto-paper plan (markdown): motivation, approach, expected contribution.\nIdea: "${t}"\nNotes:\n${n}`
+};
+
+export const POST: RequestHandler = async ({ params, request, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json({ message: 'Sign in' }, { status: 401 });
+	if (!(await canUseLabAi(supabase))) return json({ message: 'AI Lab is for experts, admins, and supporters' }, { status: 403 });
+	if (!(await rateLimit(supabase, 'ai_generate')).ok) return json({ message: 'AI rate limit reached' }, { status: 429 });
+	const body = await request.json().catch(() => ({}));
+	const kind: 'exec' | 'readable' = body.kind === 'readable' ? 'readable' : 'exec';
+
+	const { data: idea, error: ge } = await supabase.from('ideas').select('id, title, summary_md, expansions').eq('id', params.id).single();
+	if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
+
+	let md: string;
+	try { md = await generate(PROMPTS[kind](idea.title, idea.summary_md ?? '')); }
+	catch (e) { return json({ message: (e as Error).message || 'AI failed' }, { status: 502 }); }
+
+	const key = kind === 'exec' ? 'exec_plan_md' : 'readable_plan_md';
+	const expansions = { ...(idea.expansions as any), [key]: { md, at: new Date().toISOString() } };
+	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+	if (ue) return json({ message: ue.message }, { status: 400 });
+	return json({ kind, md });
+};

--- a/src/routes/api/lab/[id]/plan/+server.ts
+++ b/src/routes/api/lab/[id]/plan/+server.ts
@@ -26,7 +26,7 @@ export const POST: RequestHandler = async ({ params, request, locals: { supabase
 
 	const key = kind === 'exec' ? 'exec_plan_md' : 'readable_plan_md';
 	const expansions = { ...(idea.expansions as any), [key]: { md, at: new Date().toISOString() } };
-	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id).eq('status', 'draft');
 	if (ue) return json({ message: ue.message }, { status: 400 });
 	return json({ kind, md });
 };

--- a/src/routes/api/lab/[id]/review/+server.ts
+++ b/src/routes/api/lab/[id]/review/+server.ts
@@ -24,7 +24,7 @@ export const POST: RequestHandler = async ({ params, locals: { supabase, safeGet
 	const prev = Array.isArray((idea.expansions as any)?.critiques) ? (idea.expansions as any).critiques : [];
 	const entry = { round: prev.length + 1, reviewers: round.reviewers };
 	const expansions = { ...(idea.expansions as any), critiques: [...prev, entry] };
-	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id).eq('status', 'draft');
 	if (ue) return json({ message: ue.message }, { status: 400 });
 	return json({ round: entry });
 };

--- a/src/routes/api/lab/[id]/review/+server.ts
+++ b/src/routes/api/lab/[id]/review/+server.ts
@@ -1,0 +1,30 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { canUseLabAi } from '$lib/server/lab/access';
+import { generateStructured } from '$lib/server/ai';
+import { rateLimit } from '$lib/server/rate-limit';
+import { CritiqueRoundSchema, buildReviewPrompt } from '$lib/lab/critique';
+
+export const POST: RequestHandler = async ({ params, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json({ message: 'Sign in' }, { status: 401 });
+	if (!(await canUseLabAi(supabase))) return json({ message: 'AI Lab is for experts, admins, and supporters' }, { status: 403 });
+	if (!(await rateLimit(supabase, 'ai_generate')).ok) return json({ message: 'AI rate limit reached' }, { status: 429 });
+
+	const { data: idea, error: ge } = await supabase.from('ideas')
+		.select('id, title, summary_md, expansions').eq('id', params.id).single();
+	if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
+
+	let round;
+	try {
+		round = await generateStructured(buildReviewPrompt(idea.title, idea.summary_md ?? ''), CritiqueRoundSchema);
+	} catch (e) {
+		return json({ message: (e as Error).message || 'AI failed' }, { status: 502 });
+	}
+	const prev = Array.isArray((idea.expansions as any)?.critiques) ? (idea.expansions as any).critiques : [];
+	const entry = { round: prev.length + 1, reviewers: round.reviewers };
+	const expansions = { ...(idea.expansions as any), critiques: [...prev, entry] };
+	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id);
+	if (ue) return json({ message: ue.message }, { status: 400 });
+	return json({ round: entry });
+};

--- a/src/routes/api/lab/[id]/review/+server.ts
+++ b/src/routes/api/lab/[id]/review/+server.ts
@@ -12,7 +12,7 @@ export const POST: RequestHandler = async ({ params, locals: { supabase, safeGet
 	if (!(await rateLimit(supabase, 'ai_generate')).ok) return json({ message: 'AI rate limit reached' }, { status: 429 });
 
 	const { data: idea, error: ge } = await supabase.from('ideas')
-		.select('id, title, summary_md, expansions').eq('id', params.id).single();
+		.select('id, title, summary_md, expansions').eq('id', params.id).eq('author_id', user.id).eq('status', 'draft').single();
 	if (ge || !idea) return json({ message: 'Draft not found' }, { status: 404 });
 
 	let round;
@@ -22,7 +22,7 @@ export const POST: RequestHandler = async ({ params, locals: { supabase, safeGet
 		return json({ message: (e as Error).message || 'AI failed' }, { status: 502 });
 	}
 	const prev = Array.isArray((idea.expansions as any)?.critiques) ? (idea.expansions as any).critiques : [];
-	const entry = { round: prev.length + 1, reviewers: round.reviewers };
+	const entry = { round: prev.length + 1, at: new Date().toISOString(), reviewers: round.reviewers };
 	const expansions = { ...(idea.expansions as any), critiques: [...prev, entry] };
 	const { error: ue } = await supabase.from('ideas').update({ expansions }).eq('id', params.id).eq('status', 'draft');
 	if (ue) return json({ message: ue.message }, { status: 400 });

--- a/src/routes/api/lab/lab.test.ts
+++ b/src/routes/api/lab/lab.test.ts
@@ -2,25 +2,72 @@ import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('$lib/server/ai', () => ({
 	generateStructured: vi.fn().mockResolvedValue({ reviewers: [{ persona: 'skeptic', comments: ['c'], questions: ['q'] }] }),
-	generate: vi.fn()
+	generate: vi.fn().mockResolvedValue('PLAN')
 }));
 vi.mock('$lib/server/lab/access', () => ({ canUseLabAi: vi.fn().mockResolvedValue(true) }));
 
 import { POST } from './[id]/review/+server';
+import { POST as planPOST } from './[id]/plan/+server';
+import { canUseLabAi } from '$lib/server/lab/access';
+import { generateStructured } from '$lib/server/ai';
 
 function ev(rpcOk = true) {
 	const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
 	const single = () => Promise.resolve({ data: idea, error: null });
 	const supabase: any = {
 		rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }),
-		from: vi.fn(() => ({ select: () => ({ eq: () => ({ single }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) }))
+		from: vi.fn(() => ({
+			select: () => ({ eq: () => ({ single }) }),
+			update: () => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) })
+		}))
 	};
 	return { params: { id: 'i1' }, locals: { supabase, safeGetSession: async () => ({ user: { id: 'u1' } }) } } as any;
+}
+
+function planEv(body: object = { kind: 'exec' }) {
+	const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
+	const single = () => Promise.resolve({ data: idea, error: null });
+	let capturedExpansions: any;
+	const supabase: any = {
+		rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
+		from: vi.fn(() => ({
+			select: () => ({ eq: () => ({ single }) }),
+			update: (upd: any) => { capturedExpansions = upd.expansions; return { eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }; }
+		}))
+	};
+	(supabase as any).__getExpansions = () => capturedExpansions;
+	return {
+		params: { id: 'i1' },
+		request: { json: async () => body, clone: () => ({ json: async () => body }) } as any,
+		locals: { supabase, safeGetSession: async () => ({ user: { id: 'u1' } }) }
+	} as any;
 }
 
 describe('POST /api/lab/[id]/review', () => {
 	it('appends a critique round', async () => {
 		const res = await POST(ev()); expect(res.status).toBe(200);
 		const j = await res.json(); expect(j.round.reviewers[0].persona).toBe('skeptic');
+	});
+
+	it('returns 403 and does not call generateStructured when canUseLabAi is false', async () => {
+		vi.mocked(canUseLabAi).mockResolvedValueOnce(false);
+		vi.mocked(generateStructured).mockClear();
+		const res = await POST(ev());
+		expect(res.status).toBe(403);
+		expect(generateStructured).not.toHaveBeenCalled();
+	});
+});
+
+describe('POST /api/lab/[id]/plan', () => {
+	it('returns 200 with kind and md, and stores exec_plan_md in expansions', async () => {
+		const event = planEv({ kind: 'exec' });
+		const res = await planPOST(event);
+		expect(res.status).toBe(200);
+		const j = await res.json();
+		expect(j.kind).toBe('exec');
+		expect(j.md).toBe('PLAN');
+		const expansions = event.locals.supabase.__getExpansions();
+		expect(expansions).toHaveProperty('exec_plan_md');
+		expect(expansions.exec_plan_md.md).toBe('PLAN');
 	});
 });

--- a/src/routes/api/lab/lab.test.ts
+++ b/src/routes/api/lab/lab.test.ts
@@ -5,19 +5,26 @@ vi.mock('$lib/server/ai', () => ({
 	generate: vi.fn().mockResolvedValue('PLAN')
 }));
 vi.mock('$lib/server/lab/access', () => ({ canUseLabAi: vi.fn().mockResolvedValue(true) }));
+vi.mock('$lib/server/rate-limit', () => ({ rateLimit: vi.fn().mockResolvedValue({ ok: true }) }));
 
 import { POST } from './[id]/review/+server';
 import { POST as planPOST } from './[id]/plan/+server';
 import { canUseLabAi } from '$lib/server/lab/access';
 import { generateStructured } from '$lib/server/ai';
+import { rateLimit } from '$lib/server/rate-limit';
+
+/** Returns an infinitely chainable eq/single stub. */
+function eqChain(leaf: () => any): any {
+	const chain: any = { eq: () => chain, single: leaf };
+	return chain;
+}
 
 function ev(rpcOk = true) {
 	const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
-	const single = () => Promise.resolve({ data: idea, error: null });
 	const supabase: any = {
 		rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }),
 		from: vi.fn(() => ({
-			select: () => ({ eq: () => ({ single }) }),
+			select: () => eqChain(() => Promise.resolve({ data: idea, error: null })),
 			update: () => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) })
 		}))
 	};
@@ -26,12 +33,11 @@ function ev(rpcOk = true) {
 
 function planEv(body: object = { kind: 'exec' }) {
 	const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
-	const single = () => Promise.resolve({ data: idea, error: null });
 	let capturedExpansions: any;
 	const supabase: any = {
 		rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
 		from: vi.fn(() => ({
-			select: () => ({ eq: () => ({ single }) }),
+			select: () => eqChain(() => Promise.resolve({ data: idea, error: null })),
 			update: (upd: any) => { capturedExpansions = upd.expansions; return { eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }; }
 		}))
 	};
@@ -54,6 +60,14 @@ describe('POST /api/lab/[id]/review', () => {
 		vi.mocked(generateStructured).mockClear();
 		const res = await POST(ev());
 		expect(res.status).toBe(403);
+		expect(generateStructured).not.toHaveBeenCalled();
+	});
+
+	it('returns 429 and does not call generateStructured when rateLimit returns ok:false', async () => {
+		vi.mocked(rateLimit).mockResolvedValueOnce({ ok: false });
+		vi.mocked(generateStructured).mockClear();
+		const res = await POST(ev());
+		expect(res.status).toBe(429);
 		expect(generateStructured).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/api/lab/lab.test.ts
+++ b/src/routes/api/lab/lab.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$lib/server/ai', () => ({
+	generateStructured: vi.fn().mockResolvedValue({ reviewers: [{ persona: 'skeptic', comments: ['c'], questions: ['q'] }] }),
+	generate: vi.fn()
+}));
+vi.mock('$lib/server/lab/access', () => ({ canUseLabAi: vi.fn().mockResolvedValue(true) }));
+
+import { POST } from './[id]/review/+server';
+
+function ev(rpcOk = true) {
+	const idea = { id: 'i1', title: 'T', summary_md: 'n', expansions: {} };
+	const single = () => Promise.resolve({ data: idea, error: null });
+	const supabase: any = {
+		rpc: vi.fn().mockResolvedValue({ data: rpcOk, error: null }),
+		from: vi.fn(() => ({ select: () => ({ eq: () => ({ single }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) }))
+	};
+	return { params: { id: 'i1' }, locals: { supabase, safeGetSession: async () => ({ user: { id: 'u1' } }) } } as any;
+}
+
+describe('POST /api/lab/[id]/review', () => {
+	it('appends a critique round', async () => {
+		const res = await POST(ev()); expect(res.status).toBe(200);
+		const j = await res.json(); expect(j.round.reviewers[0].persona).toBe('skeptic');
+	});
+});

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -67,6 +67,28 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 };
 
 export const actions: Actions = {
+  publish: async ({ request, locals: { supabase, safeGetSession } }) => {
+    const { user } = await safeGetSession();
+    if (!user) return fail(401, { message: 'Sign in' });
+    const fd = await request.formData();
+    const id = String(fd.get('id'));
+    if (!id) return fail(400, { message: 'Missing idea id' });
+    const type = fd.get('type') === 'hypothesis' ? 'hypothesis' : 'open_ended';
+    const patch = {
+      type,
+      claim: type === 'hypothesis' ? String(fd.get('claim') ?? '') : null,
+      summary_md: String(fd.get('summary_md') ?? ''),
+      status: 'open',
+      published_at: new Date().toISOString()
+    };
+    const { data, error: e } = await supabase
+      .from('ideas').update(patch).eq('id', id).eq('status', 'draft')
+      .select('slug, status').single();
+    if (e || !data) return fail(400, { message: e?.message ?? 'Publish failed' });
+    if (data.status === 'open') redirect(303, `/ideas/${data.slug}`);
+    return { submitted: true };
+  },
+
   follow: async ({ request, locals: { supabase, safeGetSession } }) => {
     const { user } = await safeGetSession();
     if (!user) return fail(401, { message: 'Sign in' });

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -74,10 +74,14 @@ export const actions: Actions = {
     const id = String(fd.get('id'));
     if (!id) return fail(400, { message: 'Missing idea id' });
     const type = fd.get('type') === 'hypothesis' ? 'hypothesis' : 'open_ended';
+    const claim = String(fd.get('claim') ?? '').trim();
+    const summary_md = String(fd.get('summary_md') ?? '').trim();
+    if (type === 'hypothesis' && !claim) return fail(400, { message: 'A hypothesis needs a claim' });
+    if (!summary_md) return fail(400, { message: 'Add a short summary before publishing' });
     const patch = {
       type,
-      claim: type === 'hypothesis' ? String(fd.get('claim') ?? '') : null,
-      summary_md: String(fd.get('summary_md') ?? ''),
+      claim: type === 'hypothesis' ? claim : null,
+      summary_md,
       status: 'open',
       published_at: new Date().toISOString()
     };
@@ -86,7 +90,7 @@ export const actions: Actions = {
       .select('slug, status').single();
     if (e || !data) return fail(400, { message: e?.message ?? 'Publish failed' });
     if (data.status === 'open') redirect(303, `/ideas/${data.slug}`);
-    return { submitted: true };
+    return { submitted: true, id };
   },
 
   follow: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -5,7 +5,8 @@ import { rateLimit, RATE_LIMIT_MESSAGE } from '$lib/server/rate-limit';
 export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSession } }) => {
   const { user } = await safeGetSession();
   if (!user) redirect(303, '/login?next=/dashboard');
-  const tab = url.searchParams.get('tab') === 'discover' ? 'discover' : 'feed';
+  const rawTab = url.searchParams.get('tab');
+  const tab = rawTab === 'discover' ? 'discover' : rawTab === 'lab' ? 'lab' : 'feed';
 
   const { data: follows } = await supabase.from('follows').select('expert_id').eq('follower_id', user.id);
   const followedIds = (follows ?? []).map((f) => f.expert_id);
@@ -56,7 +57,13 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
   const chart = [...byIdea.values()];
   const totalCommittedCents = chart.reduce((sum, c) => sum + c.value, 0);
 
-  return { tab, hasFollows: followedIds.length > 0, feed, experts, myPledges, chart, totalCommittedCents };
+  // Lab tab: my drafts
+  const { data: drafts } = await supabase
+    .from('ideas').select('id, slug, title, summary_md, expansions')
+    .eq('author_id', user.id).eq('status', 'draft')
+    .order('created_at', { ascending: false });
+
+  return { tab, hasFollows: followedIds.length > 0, feed, experts, myPledges, chart, totalCommittedCents, drafts: drafts ?? [] };
 };
 
 export const actions: Actions = {

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -2,8 +2,14 @@
   import IdeaCard from '$lib/components/IdeaCard.svelte';
   import BarChart from '$lib/components/BarChart.svelte';
   import Money from '$lib/components/Money.svelte';
+  import DraftList from '$lib/components/lab/DraftList.svelte';
+  import { createDraftsStore } from '$lib/lab/draftsStore.svelte';
+
   let { data, form } = $props();
   const money = (cents: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+
+  // svelte-ignore state_referenced_locally
+  const draftsStore = createDraftsStore(data.drafts);
 </script>
 <h1 class="mb-4 text-2xl font-bold" style="color:var(--ink)">Dashboard</h1>
 {#if form?.message}<p class="mb-3 text-sm" style="color:var(--neg)">{form.message}</p>{/if}
@@ -11,59 +17,64 @@
 <nav class="mb-6 flex gap-2 text-sm">
   <a href="/dashboard" style="color:{data.tab === 'feed' ? 'var(--green-deep)' : 'var(--muted)'}">Feed</a>
   <a href="/dashboard?tab=discover" style="color:{data.tab === 'discover' ? 'var(--green-deep)' : 'var(--muted)'}">Discover</a>
+  <a href="/dashboard?tab=lab" style="color:{data.tab === 'lab' ? 'var(--green-deep)' : 'var(--muted)'}">Lab</a>
 </nav>
 
-{#if data.tab === 'discover' || !data.hasFollows}
-  {#if !data.hasFollows && data.tab === 'feed'}
-    <p class="mb-4" style="color:var(--muted)">Follow experts to build your feed of new bounties.</p>
-  {/if}
-  <div class="mb-8 grid gap-3 sm:grid-cols-2">
-    {#each data.experts as e (e.id)}
-      <div class="flex items-center justify-between gap-3 rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-        <div>
-          <a href="/u/{e.profile?.handle}" class="font-medium" style="color:var(--ink)">{e.profile?.display_name ?? e.profile?.handle ?? 'Expert'}</a>
-          {#if e.specialty}<p class="text-xs" style="color:var(--faint)">{e.specialty}</p>{/if}
+{#if data.tab === 'lab'}
+  <DraftList store={draftsStore} />
+{:else}
+  {#if data.tab === 'discover' || !data.hasFollows}
+    {#if !data.hasFollows && data.tab === 'feed'}
+      <p class="mb-4" style="color:var(--muted)">Follow experts to build your feed of new bounties.</p>
+    {/if}
+    <div class="mb-8 grid gap-3 sm:grid-cols-2">
+      {#each data.experts as e (e.id)}
+        <div class="flex items-center justify-between gap-3 rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+          <div>
+            <a href="/u/{e.profile?.handle}" class="font-medium" style="color:var(--ink)">{e.profile?.display_name ?? e.profile?.handle ?? 'Expert'}</a>
+            {#if e.specialty}<p class="text-xs" style="color:var(--faint)">{e.specialty}</p>{/if}
+          </div>
+          <form method="POST" action={e.following ? '?/unfollow' : '?/follow'}>
+            <input type="hidden" name="expert_id" value={e.id} />
+            <button class="rounded-xl px-3 py-1 text-sm font-medium"
+                    style={e.following ? 'border:1px solid var(--line); color:var(--muted)' : 'background:var(--ink); color:#fff'}>
+              {e.following ? 'Following' : 'Follow'}
+            </button>
+          </form>
         </div>
-        <form method="POST" action={e.following ? '?/unfollow' : '?/follow'}>
-          <input type="hidden" name="expert_id" value={e.id} />
-          <button class="rounded-xl px-3 py-1 text-sm font-medium"
-                  style={e.following ? 'border:1px solid var(--line); color:var(--muted)' : 'background:var(--ink); color:#fff'}>
-            {e.following ? 'Following' : 'Follow'}
-          </button>
-        </form>
-      </div>
-    {/each}
-  </div>
-{:else}
-  <div class="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-    {#each data.feed as idea (idea.id)}<IdeaCard {idea} />{/each}
-  </div>
-  {#if data.feed.length === 0}<p class="mb-8" style="color:var(--muted)">No new open bounties from the experts you follow.</p>{/if}
-{/if}
+      {/each}
+    </div>
+  {:else}
+    <div class="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {#each data.feed as idea (idea.id)}<IdeaCard {idea} />{/each}
+    </div>
+    {#if data.feed.length === 0}<p class="mb-8" style="color:var(--muted)">No new open bounties from the experts you follow.</p>{/if}
+  {/if}
 
-<h2 class="mb-3 text-xl font-bold" style="color:var(--ink)">My funding</h2>
-{#if data.myPledges.length === 0}
-  <p style="color:var(--muted)">You haven't pledged to any ideas yet.</p>
-{:else}
-  <p class="mb-3 text-sm" style="color:var(--muted)">Total committed <span class="text-base font-bold" style="color:var(--ink)"><Money cents={data.totalCommittedCents} /></span> <span style="color:var(--faint)">· no funds moved yet</span></p>
-  <div class="mb-4 rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
-    <BarChart series={data.chart} format={money} />
-  </div>
-  <ul class="flex flex-col gap-2">
-    {#each data.myPledges as p (p.id)}
-      <li class="flex items-center justify-between gap-3 rounded-xl border p-3" style="border-color:var(--line); background:var(--surface)">
-        <a href="/ideas/{p.idea?.slug ?? p.idea_id}" style="color:var(--green-deep)">{p.idea?.title ?? 'Idea'}</a>
-        <span class="flex items-center gap-3">
-          <span class="tabular-nums" style="color:var(--ink)"><Money cents={p.amount_cents} currency={p.currency} /></span>
-          <span class="text-xs" style="color:var(--faint)">{p.status}</span>
-          {#if p.status === 'committed'}
-            <form method="POST" action="?/withdraw">
-              <input type="hidden" name="pledge_id" value={p.id} />
-              <button class="text-xs" style="color:var(--neg)">Withdraw</button>
-            </form>
-          {/if}
-        </span>
-      </li>
-    {/each}
-  </ul>
+  <h2 class="mb-3 text-xl font-bold" style="color:var(--ink)">My funding</h2>
+  {#if data.myPledges.length === 0}
+    <p style="color:var(--muted)">You haven't pledged to any ideas yet.</p>
+  {:else}
+    <p class="mb-3 text-sm" style="color:var(--muted)">Total committed <span class="text-base font-bold" style="color:var(--ink)"><Money cents={data.totalCommittedCents} /></span> <span style="color:var(--faint)">· no funds moved yet</span></p>
+    <div class="mb-4 rounded-2xl border p-4" style="border-color:var(--line); background:var(--surface)">
+      <BarChart series={data.chart} format={money} />
+    </div>
+    <ul class="flex flex-col gap-2">
+      {#each data.myPledges as p (p.id)}
+        <li class="flex items-center justify-between gap-3 rounded-xl border p-3" style="border-color:var(--line); background:var(--surface)">
+          <a href="/ideas/{p.idea?.slug ?? p.idea_id}" style="color:var(--green-deep)">{p.idea?.title ?? 'Idea'}</a>
+          <span class="flex items-center gap-3">
+            <span class="tabular-nums" style="color:var(--ink)"><Money cents={p.amount_cents} currency={p.currency} /></span>
+            <span class="text-xs" style="color:var(--faint)">{p.status}</span>
+            {#if p.status === 'committed'}
+              <form method="POST" action="?/withdraw">
+                <input type="hidden" name="pledge_id" value={p.id} />
+                <button class="text-xs" style="color:var(--neg)">Withdraw</button>
+              </form>
+            {/if}
+          </span>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 {/if}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -21,7 +21,7 @@
 </nav>
 
 {#if data.tab === 'lab'}
-  <DraftList store={draftsStore} />
+  <DraftList store={draftsStore} {form} />
 {:else}
   {#if data.tab === 'discover' || !data.hasFollows}
     {#if !data.hasFollows && data.tab === 'feed'}

--- a/src/routes/experts/+page.svelte
+++ b/src/routes/experts/+page.svelte
@@ -2,18 +2,30 @@
   let { data } = $props();
 </script>
 <h1 class="mb-1 text-2xl font-bold" style="color:var(--ink)">Experts</h1>
-<p class="mb-6 text-sm" style="color:var(--muted)">Vetted researchers who post bounties on AI Safety Ideas.</p>
+<p class="mb-6 text-sm" style="color:var(--muted)">Vetted researchers who post ideas on AI Safety Ideas.</p>
 {#if data.experts.length === 0}
   <p style="color:var(--muted)">No experts yet.</p>
 {:else}
-  <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+  <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
     {#each data.experts as e (e.id)}
-      <a href="/u/{e.profile?.handle}" class="block rounded-2xl border p-5 transition" style="border-color:var(--line); background:var(--surface); box-shadow:var(--shadow-1)">
-        <div class="flex items-center justify-between gap-2">
+      <a href="/u/{e.profile?.handle}" class="card card-hover block p-5">
+        <div class="flex items-start justify-between gap-2">
           <h2 class="font-bold" style="color:var(--ink)">{e.profile?.display_name ?? e.profile?.handle ?? 'Expert'}</h2>
-          {#if e.featured}<span class="rounded-full px-2 py-0.5 text-xs" style="border:1px solid var(--green); color:var(--green-deep)">Featured</span>{/if}
+          <div class="flex flex-wrap gap-1.5 shrink-0">
+            {#if e.featured}
+              <span class="chip chip-open">Featured</span>
+            {/if}
+            <span class="chip" style="color:var(--green-deep);background:color-mix(in srgb,var(--green) 12%,transparent);border:1px solid color-mix(in srgb,var(--green) 30%,transparent)">
+              <span aria-hidden="true">✓</span> Verified
+            </span>
+          </div>
         </div>
-        {#if e.specialty}<p class="mt-1 text-sm" style="color:var(--muted)">{e.specialty}</p>{/if}
+        {#if e.specialty}
+          <p class="mt-2 text-sm" style="color:var(--muted)">{e.specialty}</p>
+        {/if}
+        {#if e.profile?.handle}
+          <p class="mt-2 u-label">@{e.profile.handle}</p>
+        {/if}
       </a>
     {/each}
   </div>

--- a/src/routes/ideas/[slug]/+page.server.ts
+++ b/src/routes/ideas/[slug]/+page.server.ts
@@ -12,8 +12,20 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
     .eq(ideaParamColumn(params.slug), params.slug)
     .single();
   if (!idea) error(404, 'Idea not found');
-  // archived (admin-hidden) and draft (unpublished) ideas are not publicly reachable
-  if (idea.status === 'archived' || idea.status === 'draft') error(404, 'Idea not found');
+
+  // Determine admin status early — needed for the draft/archived gate below.
+  let isAdminEarly = false;
+  if (user) {
+    const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
+    isAdminEarly = me?.is_admin === true;
+  }
+
+  // Draft/archived ideas are only visible to their author or an admin.
+  if (idea.status === 'archived' || idea.status === 'draft') {
+    const isAuthor = !!user && user.id === idea.author_id;
+    if (!isAuthor && !isAdminEarly) error(404, 'Idea not found');
+  }
+
   // legacy /ideas/<uuid> URL → permanent-redirect to the canonical slug URL
   if (isUuid(params.slug)) redirect(301, `/ideas/${idea.slug}`);
 
@@ -76,14 +88,12 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
   const { count: interestCount } = await supabase
     .from('interest').select('id', { count: 'exact', head: true }).eq('idea_id', idea.id);
   let myInterestId: string | null = null;
-  let isAdmin = false;
+  // isAdminEarly was already fetched above; reuse it here (avoids a second profile fetch)
+  let isAdmin = isAdminEarly;
   if (user) {
     const { data: mine } = await supabase
       .from('interest').select('id').eq('idea_id', idea.id).eq('profile_id', user.id).maybeSingle();
     myInterestId = mine?.id ?? null;
-    // real admin status (from the DB, never user_metadata) so an admin sees the moderation delete control
-    const { data: me } = await supabase.from('profiles').select('is_admin').eq('id', user.id).maybeSingle();
-    isAdmin = me?.is_admin === true;
   }
 
   // votes: totals + the caller's own vote

--- a/src/routes/u/[handle]/+page.server.ts
+++ b/src/routes/u/[handle]/+page.server.ts
@@ -10,7 +10,24 @@ export const load: PageServerLoad = async ({ params, locals: { supabase } }) => 
     .eq('handle', params.handle)
     .single();
   if (!profile) error(404, 'Profile not found');
-  return { profile, bio_html: renderMarkdown(profile.bio_md) };
+
+  const [{ data: expert }, { data: authored }] = await Promise.all([
+    supabase.from('experts').select('status').eq('id', profile.id).maybeSingle(),
+    supabase
+      .from('ideas')
+      .select('id, slug, title, summary_md, type, status')
+      .eq('author_id', profile.id)
+      .not('status', 'in', '(draft,archived)')
+      .order('created_at', { ascending: false })
+      .limit(50)
+  ]);
+
+  return {
+    profile,
+    bio_html: renderMarkdown(profile.bio_md),
+    isVerifiedExpert: expert?.status === 'approved',
+    authored: authored ?? []
+  };
 };
 
 export const actions: Actions = {

--- a/src/routes/u/[handle]/+page.svelte
+++ b/src/routes/u/[handle]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Markdown from '$lib/components/Markdown.svelte';
+  import IdeaCard from '$lib/components/IdeaCard.svelte';
   let { data, form } = $props();
   let isSelf = $derived(data.user?.id === data.profile.id);
   // Local state + bind:value so a background re-render mid-edit can't reset the fields (seeded from
@@ -11,9 +12,20 @@
   // svelte-ignore state_referenced_locally
   let bioMd = $state(data.profile.bio_md ?? '');
 </script>
-<article class="rounded-2xl border p-6" style="border-color:var(--line);background:var(--surface);box-shadow:var(--shadow-1)">
-  <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.profile.display_name ?? data.profile.handle}</h1>
-  <p style="color:var(--faint)">@{data.profile.handle}{#if data.profile.career_stage} · {data.profile.career_stage}{/if}</p>
+<article class="card" style="padding:1.5rem">
+  <div class="flex flex-wrap items-start gap-3">
+    <div class="flex-1 min-w-0">
+      <div class="flex flex-wrap items-center gap-2">
+        <h1 class="text-2xl font-bold" style="color:var(--ink)">{data.profile.display_name ?? data.profile.handle}</h1>
+        {#if data.isVerifiedExpert}
+          <span class="chip" style="color:var(--green-deep);background:color-mix(in srgb,var(--green) 12%,transparent);border:1px solid color-mix(in srgb,var(--green) 30%,transparent)">
+            <span aria-hidden="true">✓</span> Verified expert
+          </span>
+        {/if}
+      </div>
+      <p class="mt-0.5" style="color:var(--faint)">@{data.profile.handle}{#if data.profile.career_stage} · {data.profile.career_stage}{/if}</p>
+    </div>
+  </div>
   <Markdown html={data.bio_html} class="mt-3" />
 
   {#if isSelf}
@@ -24,9 +36,22 @@
              class="rounded-xl border px-3 py-2" style="border-color:var(--line)" />
       <textarea name="bio_md" placeholder="Bio (markdown)" bind:value={bioMd}
              class="rounded-xl border px-3 py-2" style="border-color:var(--line)"></textarea>
-      <button class="self-start rounded-xl px-4 py-2 font-medium" style="background:var(--ink);color:#fff">Save</button>
+      <button class="self-start btn btn-primary btn-sm">Save</button>
       {#if form?.saved}<span style="color:var(--green-deep)">Saved.</span>{/if}
       {#if form?.message}<span style="color:var(--neg)">{form.message}</span>{/if}
     </form>
   {/if}
 </article>
+
+{#if data.authored.length > 0}
+  <section class="mt-8">
+    <h2 class="mb-4 text-lg font-bold" style="color:var(--ink)">
+      Ideas by {data.profile.display_name ?? data.profile.handle}
+    </h2>
+    <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {#each data.authored as idea (idea.id)}
+        <IdeaCard {idea} />
+      {/each}
+    </div>
+  </section>
+{/if}

--- a/src/routes/u/[handle]/profile.test.ts
+++ b/src/routes/u/[handle]/profile.test.ts
@@ -1,9 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import { load } from './+page.server';
 
-function mkLocals(profile: unknown) {
+/** Builds a chainable query builder that resolves with `result` at any terminal call or when awaited directly. */
+function mkQuery(result: unknown) {
+  const resolved = { data: result, error: null };
+  const q: any = {
+    select: () => q,
+    eq: () => q,
+    not: () => q,
+    order: () => q,
+    limit: () => q,
+    single: async () => resolved,
+    maybeSingle: async () => resolved,
+    // Make the builder itself thenable so `await builder` works (for queries that end with .limit() etc.)
+    then: (resolve: (v: unknown) => void) => Promise.resolve(resolved).then(resolve)
+  };
+  return q;
+}
+
+function mkLocals(profile: unknown, expert: unknown = null, authored: unknown = []) {
   return {
-    supabase: { from: () => ({ select: () => ({ eq: () => ({ single: async () => ({ data: profile }) }) }) }) },
+    supabase: {
+      from: (table: string) => {
+        if (table === 'experts') return mkQuery(expert);
+        if (table === 'ideas') return mkQuery(authored);
+        // profiles table — profile query
+        return mkQuery(profile);
+      }
+    },
     safeGetSession: async () => ({ session: null, user: null })
   } as any;
 }
@@ -14,6 +38,36 @@ describe('profile load', () => {
     const res = await load({ params: { handle: 'alice' }, locals: mkLocals(profile) } as any) as any;
     expect(res.profile.handle).toBe('alice');
   });
+
+  it('returns isVerifiedExpert=true for an approved expert', async () => {
+    const profile = { id: 'p1', handle: 'alice', display_name: 'Alice' };
+    const res = await load({
+      params: { handle: 'alice' },
+      locals: mkLocals(profile, { status: 'approved' }, [])
+    } as any) as any;
+    expect(res.isVerifiedExpert).toBe(true);
+  });
+
+  it('returns isVerifiedExpert=false for a non-expert', async () => {
+    const profile = { id: 'p1', handle: 'alice', display_name: 'Alice' };
+    const res = await load({
+      params: { handle: 'alice' },
+      locals: mkLocals(profile, null, [])
+    } as any) as any;
+    expect(res.isVerifiedExpert).toBe(false);
+  });
+
+  it('returns authored ideas array', async () => {
+    const profile = { id: 'p1', handle: 'alice', display_name: 'Alice' };
+    const ideas = [{ id: 'i1', slug: 'my-idea', title: 'My Idea', type: 'open_ended', status: 'open' }];
+    const res = await load({
+      params: { handle: 'alice' },
+      locals: mkLocals(profile, null, ideas)
+    } as any) as any;
+    expect(res.authored).toHaveLength(1);
+    expect(res.authored[0].slug).toBe('my-idea');
+  });
+
   it('404s when not found', async () => {
     await expect(load({ params: { handle: 'nope' }, locals: mkLocals(null) } as any)).rejects.toMatchObject({ status: 404 });
   });

--- a/supabase/migrations/20260608081014_open_idea_submissions.sql
+++ b/supabase/migrations/20260608081014_open_idea_submissions.sql
@@ -1,0 +1,34 @@
+-- Open idea submission to everyone, but auto-archive non-experts' ideas for admin review.
+-- Approved experts publish straight to 'open'; everyone else's submission is forced to 'archived'
+-- (hidden from public listings + 404 on the detail page) until an admin promotes it.
+
+-- 1) Anyone signed in may insert their OWN idea (was: approved experts only).
+drop policy if exists "approved experts insert own ideas" on public.ideas;
+create policy "authenticated insert own ideas" on public.ideas for insert to authenticated
+  with check ((select auth.uid()) = author_id);
+
+-- 2) Server-side status gate (BEFORE INSERT) so the rule can't be bypassed via the Data API.
+--    INVOKER + pinned search_path; reads public.experts which is "readable by everyone".
+create or replace function public.enforce_idea_submission()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if exists (
+    select 1 from public.experts e
+    where e.id = new.author_id and e.status = 'approved'
+  ) then
+    -- approved expert: keep an explicit draft, otherwise publish open
+    if new.status is distinct from 'draft' then new.status := 'open'; end if;
+  else
+    -- everyone else: auto-archived pending admin promotion (overrides any client-supplied status)
+    new.status := 'archived';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger ideas_enforce_submission
+before insert on public.ideas
+for each row execute function public.enforce_idea_submission();

--- a/supabase/migrations/20260608095408_add_ideas_lab.sql
+++ b/supabase/migrations/20260608095408_add_ideas_lab.sql
@@ -1,0 +1,104 @@
+-- ============ Ideas Lab: expansions, supporter, gating extensions, AI access, rate bucket ============
+
+-- 1) ideas.expansions: per-draft tool output, keyed by tool
+alter table public.ideas add column expansions jsonb not null default '{}'::jsonb;
+
+-- 2) profiles.supporter_until: active monthly supporter when > now() (admin/billing set)
+alter table public.profiles add column supporter_until timestamptz;
+
+-- 3) INSERT gate: exempt drafts (private scratchpad); else expert→open, other→archived.
+--    create or replace — replaces the version from 20260608081014_open_idea_submissions.sql
+create or replace function public.enforce_idea_submission()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if new.status = 'draft' then
+    return new; -- a draft stays a private draft
+  end if;
+  if exists (select 1 from public.experts e where e.id = new.author_id and e.status = 'approved') then
+    new.status := 'open';
+  else
+    new.status := 'archived';
+  end if;
+  return new;
+end;
+$$;
+
+-- 4) UPDATE (publish) gate: when status moves from a non-public to a public state, re-apply
+--    the expert check so a non-expert can't self-publish by editing a draft to 'open'.
+create or replace function public.enforce_idea_publish()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if new.status in ('open','resolved','closed') and old.status not in ('open','resolved','closed') then
+    if not exists (select 1 from public.experts e where e.id = new.author_id and e.status = 'approved')
+       and not public.is_admin() then
+      new.status := 'archived'; -- submitted for admin review
+    end if;
+  end if;
+  return new;
+end;
+$$;
+create trigger ideas_enforce_publish
+before update on public.ideas
+for each row when (old.status is distinct from new.status)
+execute function public.enforce_idea_publish();
+
+-- 5) AI access predicate: admin OR approved expert OR active monthly supporter
+create or replace function public.can_use_lab_ai()
+returns boolean language sql security definer set search_path = '' stable as $$
+  select public.is_admin()
+      or exists (select 1 from public.experts e where e.id = auth.uid() and e.status = 'approved')
+      or exists (select 1 from public.profiles p where p.id = auth.uid() and p.supporter_until > now());
+$$;
+revoke all on function public.can_use_lab_ai() from public;
+grant execute on function public.can_use_lab_ai() to authenticated;
+
+-- 6) Add ai_generate bucket to consume_rate_limit (copy function verbatim + new CASE arm).
+--    Source: supabase/migrations/20260607102806_rate_limits.sql — only the CASE arm is new.
+create or replace function public.consume_rate_limit(p_bucket text)
+returns boolean
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  v_uid uuid := (select auth.uid());
+  v_max int;
+  v_window_secs int;
+  v_window timestamptz;
+  v_count int;
+begin
+  if v_uid is null then
+    return true;   -- anon callers are not tracked here (login uses the app's in-memory limiter)
+  end if;
+
+  -- authoritative limit table; keep in sync with BUCKETS in $lib/server/rate-limit.ts
+  case p_bucket
+    when 'comment'        then v_max := 10;  v_window_secs := 300;
+    when 'comment_delete' then v_max := 30;  v_window_secs := 300;
+    when 'engage'         then v_max := 60;  v_window_secs := 300;
+    when 'pledge'         then v_max := 10;  v_window_secs := 300;
+    when 'answer'         then v_max := 5;   v_window_secs := 3600;
+    when 'idea_create'    then v_max := 10;  v_window_secs := 3600;
+    when 'review'         then v_max := 60;  v_window_secs := 300;
+    when 'profile'        then v_max := 10;  v_window_secs := 3600;
+    when 'admin'          then v_max := 120; v_window_secs := 300;
+    when 'ai_generate'    then v_max := 30;  v_window_secs := 3600;
+    else raise exception 'unknown rate-limit bucket: %', p_bucket;  -- dev bug → fail-open + logged
+  end case;
+
+  v_window := to_timestamp(floor(extract(epoch from now()) / v_window_secs) * v_window_secs);
+
+  -- prune this caller's stale rows for this bucket (definer-owned; no client DELETE path exists)
+  delete from public.rate_limits
+    where key = 'user:' || v_uid::text and bucket = p_bucket
+      and window_start < now() - make_interval(secs => 2 * v_window_secs);
+
+  insert into public.rate_limits as r (key, bucket, window_start)
+    values ('user:' || v_uid::text, p_bucket, v_window)
+    on conflict (key, bucket, window_start)
+    do update set count = r.count + 1
+    returning count into v_count;
+
+  return v_count <= v_max;
+end $$;
+
+revoke execute on function public.consume_rate_limit(text) from public, anon;
+grant execute on function public.consume_rate_limit(text) to authenticated;

--- a/supabase/migrations/20260608095408_add_ideas_lab.sql
+++ b/supabase/migrations/20260608095408_add_ideas_lab.sql
@@ -102,3 +102,8 @@ end $$;
 
 revoke execute on function public.consume_rate_limit(text) from public, anon;
 grant execute on function public.consume_rate_limit(text) to authenticated;
+
+-- 7) Authors may delete their own draft ideas (only drafts; published rows are immutable by authors).
+create policy "authors delete own draft ideas" on public.ideas
+  for delete to authenticated
+  using ((select auth.uid()) = author_id and status = 'draft');

--- a/supabase/tests/database/ideas_lab_test.sql
+++ b/supabase/tests/database/ideas_lab_test.sql
@@ -1,13 +1,14 @@
 begin;
-select plan(12);
+select plan(14);
 
 -- ============ fixtures ============
--- Seed three users; the on_auth_user_created trigger auto-creates their profiles.
+-- Seed four users; the on_auth_user_created trigger auto-creates their profiles.
 insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
 values
   ('00000000-0000-0000-0000-000000000000','aaaa0001-0000-0000-0000-000000000001','authenticated','authenticated','lab_alice@example.com','x', now(), now(), now()),
   ('00000000-0000-0000-0000-000000000000','aaaa0002-0000-0000-0000-000000000002','authenticated','authenticated','lab_bob@example.com','x', now(), now(), now()),
-  ('00000000-0000-0000-0000-000000000000','aaaa0003-0000-0000-0000-000000000003','authenticated','authenticated','lab_charlie@example.com','x', now(), now(), now());
+  ('00000000-0000-0000-0000-000000000000','aaaa0003-0000-0000-0000-000000000003','authenticated','authenticated','lab_charlie@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','aaaa0004-0000-0000-0000-000000000004','authenticated','authenticated','lab_diana@example.com','x', now(), now(), now());
 
 -- alice = approved expert
 insert into public.experts (id, status) values ('aaaa0001-0000-0000-0000-000000000001', 'approved');
@@ -15,6 +16,11 @@ insert into public.experts (id, status) values ('aaaa0001-0000-0000-0000-0000000
 -- charlie = active supporter (supporter_until in the future)
 update public.profiles set supporter_until = now() + interval '30 days'
   where id = 'aaaa0003-0000-0000-0000-000000000003';
+
+-- diana = admin (no expert record, no supporter_until)
+reset role;
+update public.profiles set is_admin = true
+  where id = 'aaaa0004-0000-0000-0000-000000000004';
 
 -- ============ INSERT gate tests ============
 
@@ -125,6 +131,26 @@ select is(
   1,
   '11: author cannot delete a non-draft idea (archived row survives)'
 );
+
+-- ============ admin override tests ============
+
+-- 12: admin publishing a draft → open (admins bypass the expert check)
+set local role authenticated;
+set local "request.jwt.claims" = '{"sub":"aaaa0004-0000-0000-0000-000000000004","role":"authenticated"}';
+
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0012-0000-0000-0000-000000000012','aaaa0004-0000-0000-0000-000000000004','open_ended','diana draft','draft');
+
+update public.ideas set status = 'open' where id = 'bbbb0012-0000-0000-0000-000000000012';
+select is(
+  (select status from public.ideas where id = 'bbbb0012-0000-0000-0000-000000000012'),
+  'open',
+  '12: admin UPDATE draft→open → stays open (admin bypasses expert check)'
+);
+
+-- 13: can_use_lab_ai() returns true for admin (no expert record, no supporter_until)
+set local "request.jwt.claims" = '{"sub":"aaaa0004-0000-0000-0000-000000000004","role":"authenticated"}';
+select ok(public.can_use_lab_ai(), '13: admin can use lab AI');
 
 select * from finish();
 rollback;

--- a/supabase/tests/database/ideas_lab_test.sql
+++ b/supabase/tests/database/ideas_lab_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(9);
+select plan(12);
 
 -- ============ fixtures ============
 -- Seed three users; the on_auth_user_created trigger auto-creates their profiles.
@@ -97,6 +97,34 @@ update public.profiles set supporter_until = now() - interval '1 day'
 set local role authenticated;
 set local "request.jwt.claims" = '{"sub":"aaaa0003-0000-0000-0000-000000000003","role":"authenticated"}';
 select ok(not public.can_use_lab_ai(), '9: expired supporter cannot use lab AI');
+
+-- ============ draft-delete policy tests ============
+
+-- 10: non-expert author can delete their own draft
+--     bob already has a draft (bbbb0002 was coerced to archived; use a fresh draft)
+set local "request.jwt.claims" = '{"sub":"aaaa0002-0000-0000-0000-000000000002","role":"authenticated"}';
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0010-0000-0000-0000-000000000010','aaaa0002-0000-0000-0000-000000000002','open_ended','bob draft to delete','draft');
+
+select lives_ok(
+  $$ delete from public.ideas where id = 'bbbb0010-0000-0000-0000-000000000010' $$,
+  '10: author can delete their own draft idea'
+);
+select is(
+  (select count(*)::int from public.ideas where id = 'bbbb0010-0000-0000-0000-000000000010'),
+  0,
+  '10b: draft row is gone after author delete'
+);
+
+-- 11: author cannot delete a non-draft of theirs (silently 0 rows, no error)
+--     bbbb0002 was coerced to archived; bob cannot delete it
+set local "request.jwt.claims" = '{"sub":"aaaa0002-0000-0000-0000-000000000002","role":"authenticated"}';
+delete from public.ideas where id = 'bbbb0002-0000-0000-0000-000000000002';
+select is(
+  (select count(*)::int from public.ideas where id = 'bbbb0002-0000-0000-0000-000000000002'),
+  1,
+  '11: author cannot delete a non-draft idea (archived row survives)'
+);
 
 select * from finish();
 rollback;

--- a/supabase/tests/database/ideas_lab_test.sql
+++ b/supabase/tests/database/ideas_lab_test.sql
@@ -1,0 +1,102 @@
+begin;
+select plan(9);
+
+-- ============ fixtures ============
+-- Seed three users; the on_auth_user_created trigger auto-creates their profiles.
+insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000','aaaa0001-0000-0000-0000-000000000001','authenticated','authenticated','lab_alice@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','aaaa0002-0000-0000-0000-000000000002','authenticated','authenticated','lab_bob@example.com','x', now(), now(), now()),
+  ('00000000-0000-0000-0000-000000000000','aaaa0003-0000-0000-0000-000000000003','authenticated','authenticated','lab_charlie@example.com','x', now(), now(), now());
+
+-- alice = approved expert
+insert into public.experts (id, status) values ('aaaa0001-0000-0000-0000-000000000001', 'approved');
+
+-- charlie = active supporter (supporter_until in the future)
+update public.profiles set supporter_until = now() + interval '30 days'
+  where id = 'aaaa0003-0000-0000-0000-000000000003';
+
+-- ============ INSERT gate tests ============
+
+-- 1: non-expert INSERT with status='draft' → stays draft
+set local role authenticated;
+set local "request.jwt.claims" = '{"sub":"aaaa0002-0000-0000-0000-000000000002","role":"authenticated"}';
+
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0001-0000-0000-0000-000000000001','aaaa0002-0000-0000-0000-000000000002','open_ended','bob draft','draft');
+select is(
+  (select status from public.ideas where id = 'bbbb0001-0000-0000-0000-000000000001'),
+  'draft',
+  '1: non-expert INSERT draft → stays draft'
+);
+
+-- 2: non-expert INSERT with status != draft → coerced to archived
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0002-0000-0000-0000-000000000002','aaaa0002-0000-0000-0000-000000000002','open_ended','bob open','open');
+select is(
+  (select status from public.ideas where id = 'bbbb0002-0000-0000-0000-000000000002'),
+  'archived',
+  '2: non-expert INSERT non-draft → coerced to archived'
+);
+
+-- 3: approved-expert INSERT with status != draft → stays open
+set local "request.jwt.claims" = '{"sub":"aaaa0001-0000-0000-0000-000000000001","role":"authenticated"}';
+
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0003-0000-0000-0000-000000000003','aaaa0001-0000-0000-0000-000000000001','open_ended','alice open','open');
+select is(
+  (select status from public.ideas where id = 'bbbb0003-0000-0000-0000-000000000003'),
+  'open',
+  '3: approved-expert INSERT non-draft → stays open'
+);
+
+-- ============ UPDATE (publish) gate tests ============
+
+-- 4: non-expert UPDATE draft→open → coerced to archived
+set local "request.jwt.claims" = '{"sub":"aaaa0002-0000-0000-0000-000000000002","role":"authenticated"}';
+
+update public.ideas set status = 'open' where id = 'bbbb0001-0000-0000-0000-000000000001';
+select is(
+  (select status from public.ideas where id = 'bbbb0001-0000-0000-0000-000000000001'),
+  'archived',
+  '4: non-expert UPDATE draft→open → coerced to archived'
+);
+
+-- 5: approved-expert UPDATE draft→open → stays open
+set local "request.jwt.claims" = '{"sub":"aaaa0001-0000-0000-0000-000000000001","role":"authenticated"}';
+
+-- create an expert draft first
+insert into public.ideas (id, author_id, type, title, status)
+  values ('bbbb0004-0000-0000-0000-000000000004','aaaa0001-0000-0000-0000-000000000001','open_ended','alice draft','draft');
+
+update public.ideas set status = 'open' where id = 'bbbb0004-0000-0000-0000-000000000004';
+select is(
+  (select status from public.ideas where id = 'bbbb0004-0000-0000-0000-000000000004'),
+  'open',
+  '5: approved-expert UPDATE draft→open → stays open'
+);
+
+-- ============ can_use_lab_ai() truth table ============
+
+-- 6: approved expert → true
+set local "request.jwt.claims" = '{"sub":"aaaa0001-0000-0000-0000-000000000001","role":"authenticated"}';
+select ok(public.can_use_lab_ai(), '6: approved expert can use lab AI');
+
+-- 7: plain user (no expert, no supporter) → false
+set local "request.jwt.claims" = '{"sub":"aaaa0002-0000-0000-0000-000000000002","role":"authenticated"}';
+select ok(not public.can_use_lab_ai(), '7: non-expert non-supporter cannot use lab AI');
+
+-- 8: active supporter → true
+set local "request.jwt.claims" = '{"sub":"aaaa0003-0000-0000-0000-000000000003","role":"authenticated"}';
+select ok(public.can_use_lab_ai(), '8: active supporter can use lab AI');
+
+-- 9: expired supporter (supporter_until in the past) → false
+reset role;
+update public.profiles set supporter_until = now() - interval '1 day'
+  where id = 'aaaa0003-0000-0000-0000-000000000003';
+set local role authenticated;
+set local "request.jwt.claims" = '{"sub":"aaaa0003-0000-0000-0000-000000000003","role":"authenticated"}';
+select ok(not public.can_use_lab_ai(), '9: expired supporter cannot use lab AI');
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/ideas_test.sql
+++ b/supabase/tests/database/ideas_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(8);
+select plan(9);
 
 -- two users: alice (approved expert), bob (regular)
 insert into auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at)
@@ -25,10 +25,17 @@ select throws_ok(
 -- act as bob (NOT an expert)
 set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}';
 
--- 3) non-expert cannot insert an idea (even authoring themselves)
-select throws_ok(
-  $$ insert into public.ideas (author_id, title) values ('22222222-2222-2222-2222-222222222222','bob idea') $$,
-  '42501', null, 'non-expert cannot insert idea');
+-- 3a) non-expert CAN insert their own idea (RLS allows authenticated insert own ideas)
+select lives_ok(
+  $$ insert into public.ideas (id, author_id, type, title, status)
+       values ('bbbbbbbb-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','hypothesis','bob idea','open') $$,
+  'non-expert can insert own idea');
+
+-- 3b) but the enforce_idea_submission trigger forces it to status=''archived''
+select is(
+  (select status from public.ideas where id = 'bbbbbbbb-0000-0000-0000-000000000001'),
+  'archived',
+  'non-expert own insert is coerced to archived by trigger');
 
 -- 4) bob (authed) can read alice's OPEN idea
 select ok((select count(*) from public.ideas where status='open') = 1, 'open idea readable by other users');
@@ -47,14 +54,16 @@ select throws_ok(
 set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
 update public.ideas set status='draft' where id='aaaaaaaa-0000-0000-0000-000000000001';
 
--- 7) anon cannot see a draft idea
+-- 7) anon cannot see a draft idea (filter by draft status; archived ideas remain readable)
 set local role anon;
-select ok((select count(*) from public.ideas) = 0, 'anon cannot see draft ideas');
+select ok((select count(*) from public.ideas where status = 'draft') = 0, 'anon cannot see draft ideas');
 
--- 8) the author CAN still see their own draft
+-- 8) the author CAN still see their own draft (check by ID)
 set local role authenticated;
 set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}';
-select ok((select count(*) from public.ideas) = 1, 'author sees own draft');
+select ok(
+  exists(select 1 from public.ideas where id = 'aaaaaaaa-0000-0000-0000-000000000001' and status = 'draft'),
+  'author sees own draft');
 
 select * from finish();
 rollback;


### PR DESCRIPTION
See branch; full description: personal Ideas Lab in the dashboard — optimistic draft capture (drafts = ideas in 'draft' status, private, real slug), submission gating (experts/admins publish open, others auto-archived for admin promotion; enforced at INSERT+UPDATE triggers), an extensible per-draft expansion registry, an AI critique↔refine loop + ExecPlan/readable-plan generation via Vercel AI Gateway + Claude (gated to experts/admins/monthly supporters, rate-limited, server-only key), publish + /admin/ideas moderation, and expert-profile authored ideas + Verified badge.

Tests: pgTAP ideas_lab 14/14, vitest 116/116 (AI mocked — no live calls), e2e capture→publish green, check 0/0, build clean. No service-role anywhere; gating is trigger-enforced.

OWNER PREREQS before AI works live (rest runs without): (1) apply migrations 20260608081014_open_idea_submissions.sql + 20260608095408_add_ideas_lab.sql to cloud; (2) set AI_GATEWAY_API_KEY + budget in Vercel (server env); (3) grant yourself admin: update public.profiles set is_admin=true where id=(select id from auth.users order by last_sign_in_at desc nulls last limit 1).

Deferred follow-ups: delete-undo window; render plan markdown as sanitized HTML; PATCH autosave rate-limit; de-dupe publish error message.

🤖 Generated with Claude Code