### PR TITLE
fix(nav): header wordmark back to 'AI Safety Ideas'

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
     <div class="site-header__inner">
       <a href="/" class="site-brand" aria-label="AI Safety Ideas — home">
         <Logo size={26} />
-        <span class="site-brand__name">AISI</span>
+        <span class="site-brand__name">AI&nbsp;Safety&nbsp;Ideas</span>
       </a>
       <nav class="site-nav">
         <a href="/ideas" class="site-nav__link">Ideas</a>


### PR DESCRIPTION
Reverts the header wordmark from 'AISI' to the full 'AI Safety Ideas' (non-breaking spaces to avoid wrap; footer already uses the full name). One-line change. 🤖 Generated with Claude Code